### PR TITLE
0.3.2018112002 bugfix release

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -28,14 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SAVED_TERM=$TERM
-
 . /usr/local/share/bastille/colors.pre.sh
 . /usr/local/etc/bastille/bastille.conf
 
 ## version
-BASTILLE_VERSION="0.3.20181114"
-
+BASTILLE_VERSION="0.3.20181120"
 
 usage() {
     cat << EOF
@@ -102,7 +99,6 @@ bootstrap|update|upgrade)
 	usage
 	;;
 esac
-
 
 SCRIPTPATH="${bastille_sharedir}/${CMD}.sh"
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -126,8 +126,10 @@ create_jail() {
     if [ "${RELEASE}" == "11.2-RELEASE" ]; then cp -a "${bastille_releasesdir}/${RELEASE}/usr/tests" "${bastille_jail_path}"; fi
 
     ## rc.conf.local & resolv.conf
+    ## cron_flags="-J 60" ## cedwards 20181118
     if [ ! -f "${bastille_jail_rc_conf}" ]; then
         echo -e "syslogd_flags=\"-ss\"\nsendmail_enable=\"NONE\"" > ${bastille_jail_rc_conf}
+	echo -e "cron_flags=\"-J 60\"" >> ${bastille_jail_rc_conf}
     fi
 
     if [ ! -f "${bastille_jail_resolv_conf}" ]; then

--- a/usr/local/share/bastille/freebsd_dist_fetch.sh
+++ b/usr/local/share/bastille/freebsd_dist_fetch.sh
@@ -2,8 +2,6 @@
 # https://pastebin.com/T6eThbKu
 
 DEVICE_SELF_SCAN_ALL=NO
-DIALOG_BACKTITLE="BastilleBSD"
-DIALOG_TITLE="bootstrap"
 [ "$_SCRIPT_SUBR" ] || . /usr/share/bsdconfig/script.subr
 usage(){ echo "Usage: ${0##*/} [-r releaseName] [dists ...]" >&2; exit 1; }
 while getopts hr: flag; do
@@ -24,13 +22,13 @@ REL_DIST=/usr/local/bastille/cache/$releaseName
 download() # $src to $dest
 {
 	size=$( f_device_get device_media "$1" $PROBE_SIZE )
-	f_device_get device_media "$1" | dpv -kb "$DIALOG_BACKTITLE" \
-		-t "$DIALOG_TITLE" -p "Downloading $releaseName" \
+	f_device_get device_media "$1" | dpv -kb "BastilleBSD" \
+		-t "bootstrap" -p "Downloading $releaseName" \
 		-o "$3" "$size:$1"
 }
 sign() # $file
 {
-	dpv -kb "$DIALOG_BACKTITLE" -t "$DIALOG_TITLE" \
+	dpv -kb "BastilleBSD" -t "bootstrap" \
 		-p "Signing $releaseName" -mx "sha256 >&2" \
 		"$size:${1##*/}" "$1" 2>&1 >&$TERMINAL_STDOUT_PASSTHRU
 }

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -63,8 +63,7 @@ for _jail in ${JAILS}; do
     ## pre
     if [ -s "${bastille_template}/PRE" ]; then
         echo -e "${COLOR_GREEN}Executing PRE-command(s).${COLOR_RESET}"
-        bastille_templatepre=$(cat "${bastille_template}/PRE")
-        jexec -l "${_jail}" /bin/sh "${bastille_templatepre}"
+        jexec -l ${_jail} /bin/sh < "${bastille_template}/PRE"
     fi
 
     ## config
@@ -80,12 +79,14 @@ for _jail in ${JAILS}; do
     if [ -s "${bastille_template}/FSTAB" ]; then
         bastille_templatefstab=$(cat "${bastille_template}/FSTAB")
         echo -e "${COLOR_GREEN}Updating fstab.${COLOR_RESET}"
+        echo -e "${COLOR_GREEN}NOT YET IMPLEMENTED.${COLOR_RESET}"
     fi
 
     ## pf
     if [ -s "${bastille_template}/PF" ]; then
         bastille_templatepf=$(cat "${bastille_template}/PF")
         echo -e "${COLOR_GREEN}Generating PF profile.${COLOR_RESET}"
+        echo -e "${COLOR_GREEN}NOT YET IMPLEMENTED.${COLOR_RESET}"
     fi
 
     ## pkg (bootstrap + pkg)
@@ -94,23 +95,23 @@ for _jail in ${JAILS}; do
         echo -e "${COLOR_GREEN}Installing packages.${COLOR_RESET}"
         jexec -l ${_jail} env ASSUME_ALWAYS_YES="YES" /usr/sbin/pkg bootstrap
         jexec -l ${_jail} env ASSUME_ALWAYS_YES="YES" /usr/sbin/pkg audit -F
-        jexec -l ${_jail} env ASSUME_ALWAYS_YES="YES" /usr/sbin/pkg install -y ${bastille_templatepkg}
+        jexec -l ${_jail} env ASSUME_ALWAYS_YES="YES" /usr/sbin/pkg install ${bastille_templatepkg}
     fi
 
     ## sysrc
     if [ -s "${bastille_template}/SYSRC" ]; then
-        bastille_templatesys=$(cat "${bastille_template}/SYSRC")
         echo -e "${COLOR_GREEN}Updating services.${COLOR_RESET}"
-        jexec -l ${_jail} /usr/sbin/sysrc ${bastille_templatesys}
+        IFS=''
+        while read _sysrc; do
+            jexec -l ${_jail} /usr/sbin/sysrc "${_sysrc}"
+        done < "${bastille_template}/SYSRC"
     fi
 
     ## cmd
     if [ -s "${bastille_template}/CMD" ]; then
-        bastille_templatecmd=$(cat "${bastille_template}/CMD")
         echo -e "${COLOR_GREEN}Executing final command(s).${COLOR_RESET}"
-        jexec -l ${_jail} ${bastille_templatecmd}
+        jexec -l ${_jail} /bin/sh < "${bastille_template}/CMD"
     fi
     echo -e "${COLOR_GREEN}Template Complete.${COLOR_RESET}"
-    echo
     echo
 done

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -49,7 +49,7 @@ fi
 
 RELEASE=$1
 
-echo -e "${COLOR_RED}Targeting specified release.${COLOR_RESET}"
+echo -e "${COLOR_GREEN}Targeting specified release.${COLOR_RESET}"
 echo -e "${RELEASE}"
 echo
 if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then


### PR DESCRIPTION
bugfix release.
addresses: #12, #14 plus a few other things I found.

`PRE`, and `CMD` template hooks should work more reliably now.
`SYSRC` template hook *requires* either NO quotes (even on strings with spaces) or escaped quotes!

Added a default `cron_flags="-J 60"` to the create sub-command. Defaults now include:
`syslogd_flags="-ss"`, `sendmail_enable="NONE"` and `cron_flags="-J 60"`.

Fixed the color output in the `update` sub-command from RED (error) to GREEN.