### PR TITLE
0.3.20181124 patch

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 ## version
-BASTILLE_VERSION="0.3.20181120"
+BASTILLE_VERSION="0.3.20181124"
 
 usage() {
     cat << EOF

--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -2,8 +2,6 @@
 
 # $FreeBSD: $
 #
-# Bastille startup script
-#
 # PROVIDE: bastille
 # REQUIRE: LOGIN
 # KEYWORD: shutdown
@@ -19,47 +17,29 @@
 . /etc/rc.subr
 
 name=bastille
-rcvar=bastille_enable
+rcvar=${name}_enable
 
-load_rc_config ${name}
+command="/usr/local/bin/${name}"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
 
 : ${bastille_enable:=NO}
-: ${bastille_list:=""}
-
-start_cmd=bastille_start
-stop_cmd=bastille_stop
-
-start_command="%%PREFIX%%/bin/bastille start"
-stop_command="%%PREFIX%%/bin/bastille stop"
+: ${bastille_list:="ALL"}
 
 bastille_start()
 {
-    if [ ! -n "${bastille_list}" ]; then
-        echo "${bastille_list} is undefined"
-        return 1
-    fi
-
-    local _jail
-
     for _jail in ${bastille_list}; do
-        echo "Starting Bastille Jail: ${_jail}"
-        ${start_command} ${_jail}
+        ${command} start ${_jail}
     done
 }
 
 bastille_stop()
 {
-    if [ ! -n "${bastille_list}" ]; then
-        echo "${bastille_list} is undefined"
-        return 1
-    fi
-
-    local _jail
-
     for _jail in ${bastille_list}; do
-        echo "Stopping Bastille Jail: ${_jail}"
-        ${stop_command} ${_jail}
+        ${command} stop ${_jail}
     done
 }
 
-run_rc_command "$1"
+load_rc_config ${name}
+run_rc_command "$@"

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -46,36 +46,42 @@ esac
 RELEASE=$1
 
 bootstrap() {
-    ### create $bastille_base/release/$release directory
-    ### fetch $release/base.txz -o $bastille_base/cache/$release/base.txz
-    ### extract $release/base.txz to $bastille_base/release/$release
+    ## ensure required directories are in place
     if [ ! -d ${bastille_jailsdir} ]; then
         mkdir -p ${bastille_jailsdir}
     fi
     if [ ! -d ${bastille_logsdir} ]; then
         mkdir -p ${bastille_logsdir}
     fi
-    if [ ! -d ${bastille_cachedir}/${RELEASE} ]; then
-        mkdir -p ${bastille_cachedir}/${RELEASE}
+    if [ ! -d ${bastille_templatesdir} ]; then
+        mkdir -p ${bastille_templatesdir}
+    fi
+    if [ ! -d "${bastille_cachedir}/${RELEASE}" ]; then
+        mkdir -p "${bastille_cachedir}/${RELEASE}"
     fi
 
-    if [ ! -d ${bastille_releasesdir}/${RELEASE} ]; then
-        mkdir -p ${bastille_releasesdir}/${RELEASE}
+    ### create $bastille_base/release/$release directory
+    ### fetch $release/base.txz -o $bastille_base/cache/$release/base.txz
+    ### fetch $release/lib32.txz -o $bastille_base/cache/$release/lib32.txz
+    ### extract $release/base.txz to $bastille_base/release/$release
+    ### extract $release/lib32.txz to $bastille_base/release/$release
+    if [ ! -d "${bastille_releasesdir}/${RELEASE}" ]; then
+        mkdir -p "${bastille_releasesdir}/${RELEASE}"
         sh ${bastille_sharedir}/freebsd_dist_fetch.sh -r ${RELEASE} base lib32
 
         echo
         echo -e "${COLOR_GREEN}Extracting FreeBSD ${RELEASE} base.txz.${COLOR_RESET}"
-        /usr/bin/tar -C ${bastille_releasesdir}/${RELEASE} -xf ${bastille_cachedir}/${RELEASE}/base.txz
+        /usr/bin/tar -C "${bastille_releasesdir}/${RELEASE}" -xf "${bastille_cachedir}/${RELEASE}/base.txz"
 
         echo -e "${COLOR_GREEN}Extracting FreeBSD ${RELEASE} lib32.txz.${COLOR_RESET}"
-        /usr/bin/tar -C ${bastille_releasesdir}/${RELEASE} -xf ${bastille_cachedir}/${RELEASE}/lib32.txz
+        /usr/bin/tar -C "${bastille_releasesdir}/${RELEASE}" -xf "${bastille_cachedir}/${RELEASE}/lib32.txz"
 
-	    echo -e "${COLOR_GREEN}Bootstrap successful.${COLOR_RESET}"
-	    echo -e "${COLOR_GREEN}See 'bastille --help' for available commands.${COLOR_RESET}"
-	    echo
+        echo -e "${COLOR_GREEN}Bootstrap successful.${COLOR_RESET}"
+        echo -e "${COLOR_GREEN}See 'bastille --help' for available commands.${COLOR_RESET}"
+        echo
     else
         echo -e "${COLOR_RED}Bootstrap appears complete.${COLOR_RESET}"
-	exit 1
+        exit 1
     fi
 }
 
@@ -83,29 +89,32 @@ bootstrap() {
 case "${RELEASE}" in
 10.1-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 10.1-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 10.2-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 10.2-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 10.3-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 10.3-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 10.4-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 10.4-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 11.0-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 11.0-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 11.1-RELEASE)
     bootstrap
-    echo -e "${COLOR_RED}This release is End of Life. No security updates.${COLOR_RESET}"
+    echo -e "${COLOR_RED}WARNING: FreeBSD 11.1-RELEASE HAS PASSED ITS END-OF-LIFE DATE.${COLOR_RESET}"
 	;;
 11.2-RELEASE)
+    bootstrap
+	;;
+12.0-RELEASE)
     bootstrap
 	;;
 12.0-BETA1)
@@ -124,8 +133,19 @@ case "${RELEASE}" in
     bootstrap
     echo -e "${COLOR_RED}BETA releases are completely untested.${COLOR_RESET}"
 	;;
+12.0-RC1)
+    bootstrap
+    echo -e "${COLOR_RED}RC releases are completely untested.${COLOR_RESET}"
+	;;
+12.0-RC2)
+    bootstrap
+    echo -e "${COLOR_RED}RC releases are completely untested.${COLOR_RESET}"
+	;;
+12.0-RC3)
+    bootstrap
+    echo -e "${COLOR_RED}RC releases are completely untested.${COLOR_RESET}"
+	;;
 *)
-    echo -e "${COLOR_RED}BETA releases are completely untested.${COLOR_RESET}"
     usage
     ;;
 esac

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -47,10 +47,10 @@ if [ $# -gt 2 ] || [ $# -lt 2 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -42,15 +42,14 @@ help|-h|--help)
     ;;
 esac
 
-
 if [ $# -gt 1 ] || [ $# -lt 1 ]; then
     usage
 fi
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -47,15 +47,15 @@ if [ $# -gt 3 ] || [ $# -lt 3 ]; then
     usage
 fi
 
-if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
-fi
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
+fi
+if [ "$1" != 'ALL' ]; then
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do
-    bastille_jail_path="${bastille_jailsdir}/${_jail}/root"
+    bastille_jail_path="$(jls -j "${_jail}" path)"
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
     cp -a "$2" "${bastille_jail_path}/$3"
     echo

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -37,7 +37,7 @@ usage() {
 }
 
 running_jail() {
-    jls -N name | grep ${NAME}
+    jls name | grep -E "(^|\b)${NAME}($|\b)"
 }
 
 validate_ip() {
@@ -94,7 +94,6 @@ create_jail() {
 
     ## using relative paths here
     ## MAKE SURE WE'RE IN THE RIGHT PLACE
-    ## ro
     cd "${bastille_jail_path}"
     echo
     echo -e "${COLOR_GREEN}NAME: ${NAME}.${COLOR_RESET}"
@@ -125,8 +124,11 @@ create_jail() {
     cp -a "${bastille_releasesdir}/${RELEASE}/usr/obj" "${bastille_jail_path}"
     if [ "${RELEASE}" == "11.2-RELEASE" ]; then cp -a "${bastille_releasesdir}/${RELEASE}/usr/tests" "${bastille_jail_path}"; fi
 
-    ## rc.conf.local & resolv.conf
-    ## cron_flags="-J 60" ## cedwards 20181118
+    ## rc.conf.local
+    ##  + syslogd_flags="-ss"
+    ##  + sendmail_none="NONE"
+    ##  + cron_flags="-J 60" ## cedwards 20181118
+    ## resolv.conf
     if [ ! -f "${bastille_jail_rc_conf}" ]; then
         echo -e "syslogd_flags=\"-ss\"\nsendmail_enable=\"NONE\"" > ${bastille_jail_rc_conf}
 	echo -e "cron_flags=\"-J 60\"" >> ${bastille_jail_rc_conf}
@@ -157,11 +159,50 @@ IP="$3"
 
 ## verify release
 case "${RELEASE}" in
+10.1-RELEASE)
+    RELEASE="10.1-RELEASE"
+	;;
+10.2-RELEASE)
+    RELEASE="10.2-RELEASE"
+	;;
+10.3-RELEASE)
+    RELEASE="10.3-RELEASE"
+	;;
 10.4-RELEASE)
     RELEASE="10.4-RELEASE"
     ;;
+11.0-RELEASE)
+    RELEASE="11.0-RELEASE"
+    ;;
+11.1-RELEASE)
+    RELEASE="11.1-RELEASE"
+    ;;
 11.2-RELEASE)
     RELEASE="11.2-RELEASE"
+    ;;
+12.0-RELEASE)
+    RELEASE="12.0-RELEASE"
+    ;;
+12.0-BETA1)
+    RELEASE="12.0-BETA1"
+    ;;
+12.0-BETA2)
+    RELEASE="12.0-BETA2"
+    ;;
+12.0-BETA3)
+    RELEASE="12.0-BETA3"
+    ;;
+12.0-BETA4)
+    RELEASE="12.0-BETA4"
+    ;;
+12.0-RC1)
+    RELEASE="12.0-RC1"
+    ;;
+12.0-RC2)
+    RELEASE="12.0-RC2"
+    ;;
+12.0-RC3)
+    RELEASE="12.0-RC3"
     ;;
 *)
     echo -e "${COLOR_RED}Unknown Release.${COLOR_RESET}"
@@ -170,14 +211,15 @@ case "${RELEASE}" in
 esac
 
 ## check for name/root/.bastille
-if [ -d "/usr/local/bastille/jails/${NAME}/root/.bastille" ]; then
+if [ -d "${bastille_jailsdir}/${NAME}/root/.bastille" ]; then
     echo -e "${COLOR_RED}Jail: ${NAME} already created. ${NAME}/root/.bastille exists.${COLOR_RESET}"
     exit 1
 fi
 
 ## check if a running jail matches name
 if running_jail ${NAME}; then
-    echo -e "${COLOR_RED}Running jail matches name.${COLOR_RESET}"
+    echo -e "${COLOR_RED}A running jail matches name.${COLOR_RESET}"
+    echo -e "${COLOR_RED}Jails must be stopped before they are destroyed.${COLOR_RESET}"
     exit 1
 fi
 

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -37,10 +37,10 @@ usage() {
 }
 
 destroy_jail() {
-    bastille_jail_base="${bastille_jailsdir}/${NAME}"  ## dir
+    bastille_jail_base="${bastille_jailsdir}/${NAME}"            ## dir
     bastille_jail_log="${bastille_logsdir}/${NAME}_console.log"  ## file
 
-    if [ $(jls -N name | grep ${NAME}) ]; then
+    if [ $(jls name | grep ${NAME}) ]; then
         echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
         echo -e "${COLOR_RED}See 'bastille stop ${NAME}'.${COLOR_RESET}"
         exit 1

--- a/usr/local/share/bastille/freebsd_dist_fetch.sh
+++ b/usr/local/share/bastille/freebsd_dist_fetch.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # https://pastebin.com/T6eThbKu
 
+. /usr/local/etc/bastille/bastille.conf
+
 DEVICE_SELF_SCAN_ALL=NO
 [ "$_SCRIPT_SUBR" ] || . /usr/share/bsdconfig/script.subr
 usage(){ echo "Usage: ${0##*/} [-r releaseName] [dists ...]" >&2; exit 1; }
@@ -18,7 +20,7 @@ mediaSetFTP
 mediaOpen
 set -e
 #debug=1
-REL_DIST=/usr/local/bastille/cache/$releaseName
+REL_DIST=${bastille_cachedir}/$releaseName
 download() # $src to $dest
 {
 	size=$( f_device_get device_media "$1" $PROBE_SIZE )

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -48,21 +48,19 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do
-    if [ ! -x "${bastille_jailsdir}/${_jail}/root/usr/local/bin/htop" ]; then
+    bastille_jail_path=$(jls -j "${_jail}" path)
+    if [ ! -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
         echo -e "${COLOR_RED}htop not found on ${_jail}.${COLOR_RESET}"
-    fi
-    if [ -x "${bastille_jailsdir}/${_jail}/root/usr/local/bin/htop" ]; then
+    elif [ -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jexec -l ${_jail} /usr/local/bin/htop
     fi
     echo -e "${COLOR_RESET}"
 done
-
-TERM=${SAVED_TERM}

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -47,16 +47,16 @@ if [ $# -gt 0 ]; then
         usage
         ;;
     release|releases)
-        ls "${bastille_releasesdir}"
+        ls "${bastille_releasesdir}" | sed "s/\n//g"
         ;;
     template|templates)
-        ls "${bastille_templatesdir}"
+	ls "${bastille_templatesdir}" | sed "s/\n//g"
         ;;
     jail|jails)
-        ls "${bastille_jailsdir}"
+	ls "${bastille_jailsdir}" | sed "s/\n//g"
         ;;
     log|logs)
-        ls "${bastille_logsdir}"
+        ls "${bastille_logsdir}" | sed "s/\n//g"
         ;;
     *)
         usage

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -47,10 +47,10 @@ if [ $# -gt 2 ] || [ $# -lt 2 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -47,11 +47,11 @@ if [ $# -gt 2 ] || [ $# -lt 2 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -48,22 +48,19 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(find ${bastille_jailsdir} -d 1 | awk -F / '{ print $6 }')
+    JAILS=$(/usr/local/bin/bastille list jails)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(find ${bastille_jailsdir} -d 1 | awk -F / '{ print $6 }' | grep $1)
-fi
-
-if [ $(jls -N name | ${NAME}) ]; then
-    echo -e "${COLOR_RED}${NAME} already running.${COLOR_RESET}"
-    exit 1
+    JAILS=$(/usr/local/bin/bastille list jails | grep "$1")
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
-    jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
+    if [ $(jls name | grep ${_jail}) ]; then
+        echo -e "${COLOR_RED}[${_jail}]: Already started.${COLOR_RESET}"
+    elif [ ! $(jls name | grep ${_jail}) ]; then
+        echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+        jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
+        pfctl -f /etc/pf.conf
+    fi
     echo
 done
-
-## HUP the firewall
-pfctl -f /etc/pf.conf

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -48,17 +48,15 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
     jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r ${_jail}
+    pfctl -f /etc/pf.conf
     echo
 done
-
-## HUP the firewall
-pfctl -f /etc/pf.conf

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -47,11 +47,11 @@ if [ $# -gt 2 ] || [ $# -lt 2 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -47,11 +47,11 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
 fi
 
 if [ "$1" = 'ALL' ]; then
-    JAILS=$(jls -N name)
+    JAILS=$(jls name)
 fi
 
 if [ "$1" != 'ALL' ]; then
-    JAILS=$(jls -N name | grep "$1")
+    JAILS=$(jls name | grep -E "(^|\b)${1}($|\b)")
 fi
 
 for _jail in ${JAILS}; do
@@ -59,5 +59,3 @@ for _jail in ${JAILS}; do
     jexec -l ${_jail} /usr/bin/top
     echo -e "${COLOR_RESET}"
 done
-
-TERM=${SAVED_TERM}

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -49,9 +49,6 @@ fi
 
 RELEASE=$1
 
-echo -e "${COLOR_GREEN}Targeting specified release.${COLOR_RESET}"
-echo -e "${RELEASE}"
-echo
 if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
     freebsd-update -b "${bastille_releasesdir}/${RELEASE}" fetch install --currently-running ${RELEASE}
 else

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -50,9 +50,6 @@ fi
 RELEASE=$1
 NEWRELEASE=$2
 
-echo -e "${COLOR_RED}Targeting specified release.${COLOR_RESET}"
-echo -e "${RELEASE} => ${NEWRELEASE}"
-echo
 if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
     freebsd-update -b "${bastille_releasesdir}/${RELEASE}" -r ${NEWRELEASE} upgrade
 else

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -49,9 +49,6 @@ fi
 
 RELEASE=$1
 
-echo -e "${COLOR_RED}Targeting specified release.${COLOR_RESET}"
-echo -e "${RELEASE}"
-echo
 if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
     freebsd-update -b "${bastille_releasesdir}/${RELEASE}" IDS
 else


### PR DESCRIPTION
There are a number of changes, fixes and cleanups in this patch.

- rev VERSION
- fix rc script; `bastille_list` now defaults to `ALL`
- cleanup bootstrap a little; support a couple more releases
- cmd, console, htop, pkg, service, stop, sysrc standardize on targeting
- removed target header in update, upgrade and verify
- start, stop now reload the firewall per-jail, not after for-loop
- template, cp now more flexible. should support non-bastille jails
- fixed template loop problem in last release (template target ALL would fail on pkg after first iteration)

Be aware: targeting by name is precise now. pending glob support, full jail names are required.