### PR TITLE
0.3.20181128 go go gadget git clone templates

### DIFF
--- a/docs/chapters/targeting.rst
+++ b/docs/chapters/targeting.rst
@@ -1,3 +1,69 @@
 =========
 Targeting
 =========
+
+Bastille uses a `command-target-args` syntax, meaning that each command
+requires a target. Targets are usually jails, but can also be releases.
+
+Targeting a jail is done by providing the exact jail name.
+
+Targeting a release is done by providing the release name. (Note: do note
+include the `-pX` point-release version.)
+
+Bastille includes a pre-defined keyword ALL to target all running jails.
+
+In the future I would like to support more options, including globbing, lists
+and regular-expressions.
+
+Examples: Jails
+===============
+
+.. code-block:: shell
+
+  ishmael ~ # bastille ...
+
+
++-----------+--------+------------------+-------------------------------------------------------------+
+| command   | target | args             | description                                                 |
++===========+========+==================+=============================================================+
+| cmd       | ALL    | 'sockstat -4'    | execute `sockstat -4` in ALL jails (listening ip4 sockets)  |
++-----------+--------+-----+------------+-------------------------------------------------------------+ 
+| console   | mariadb02    | ---        | console (shell) access to mariadb02                         |
++----+------+----+---------+------------+--------------+----------------------------------------------+ 
+| pkg       | web01  | 'install nginx'  | install nginx package in web01 jail                         |
++-----------+--------+------------------+-------------------------------------------------------------+
+| pkg       | ALL    | upgrade          | upgrade packages in ALL jails                               |
++-----------+--------+------------------+-------------------------------------------------------------+ 
+| pkg       | ALL    | audit            | (CVE) audit packages in ALL jails                           |
++-----------+--------+------------------+-------------------------------------------------------------+ 
+| sysrc     | web01  | nginx_enable=YES | execute `sysrc nginx_enable=YES` in web01 jail              |
++-----------+--------+------------------+-------------------------------------------------------------+ 
+| template  | ALL    | base             | apply `base` template to ALL jails                          |
++-----------+--------+------------------+-------------------------------------------------------------+ 
+| start     | web02  | ---              | start web02 jail                                            |
++-----------+--------+-----+------------+-------------------------------------------------------------+ 
+| cp | bastion03 | /tmp/resolv.conf-cf etc/resolv.conf | copy host-path to jail-path in bastion03     |
++----+------+----+---+------------------+--------------+----------------------------------------------+ 
+| create    | folsom | 12.0-RELEASE 10.10.10.10        | create v12.0 jail named `folsom` with IP     |
++-----------+--------+------------------+--------------+----------------------------------------------+
+
+
+Examples: Releases
+==================
+
+.. code-block:: shell
+
+  ishmael ~ # bastille ...
+
+
++-----------+--------------+--------------+-------------------------------------------------------------+
+| command   | target       | args         | description                                                 |
++===========+==============+==============+=============================================================+
+| bootstrap | 12.0-RELEASE | ---          | bootstrap 12.0-RELEASE release                              |
++-----------+--------------+--------------+-------------------------------------------------------------+ 
+| update    | 11.2-RELEASE | ---          | update 11.2-RELEASE release                                 |
++-----------+--------------+--------------+-------------------------------------------------------------+ 
+| upgrade   | 11.1-RELEASE | 11.2-RELEASE | update 11.2-RELEASE release                                 |
++-----------+--------------+--------------+-------------------------------------------------------------+ 
+| verify    | 11.2-RELEASE | ---          | update 11.2-RELEASE release                                 |
++-----------+--------------+--------------+-------------------------------------------------------------+ 

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 ## version
-BASTILLE_VERSION="0.3.20181124"
+BASTILLE_VERSION="0.3.20181128"
 
 usage() {
     cat << EOF

--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# $FreeBSD: $
+# Bastille jail startup script
 #
 # PROVIDE: bastille
 # REQUIRE: LOGIN
@@ -10,7 +10,7 @@
 #
 # bastille_enable (bool):          Set to NO by default.
 #               Set it to YES to enable bastille.
-# bastille_list (string):        Set to "" by default.
+# bastille_list (string):        Set to "ALL" by default.
 #               Space separated list of jails to start.
 #
 
@@ -19,27 +19,42 @@
 name=bastille
 rcvar=${name}_enable
 
-command="/usr/local/bin/${name}"
-
-start_cmd="${name}_start"
-stop_cmd="${name}_stop"
+load_rc_config ${name}
 
 : ${bastille_enable:=NO}
 : ${bastille_list:="ALL"}
 
+start_command="/usr/local/bin/bastille start"
+stop_command="/usr/local/bin/bastille stop"
+
 bastille_start()
 {
+    if [ ! -n "${bastille_list}" ]; then
+        echo "${bastille_list} is undefined"
+        return 1
+    fi
+
+    local _jail
+
     for _jail in ${bastille_list}; do
-        ${command} start ${_jail}
+        echo "Starting Bastille Jail: ${_jail}"
+        ${start_command} ${_jail}
     done
 }
 
 bastille_stop()
 {
+    if [ ! -n "${bastille_list}" ]; then
+        echo "${bastille_list} is undefined"
+        return 1
+    fi
+
+    local _jail
+
     for _jail in ${bastille_list}; do
-        ${command} stop ${_jail}
+        echo "Stopping Bastille Jail: ${_jail}"
+        ${stop_command} ${_jail}
     done
 }
 
-load_rc_config ${name}
-run_rc_command "$@"
+run_rc_command "$1"


### PR DESCRIPTION
This patch allows for using bootstrap to pull down Bastille templates from GitHub. Currently only supports GitHub (but will be easily extendable). Templates are also validated before they are ready to use. If validation fails the checkout is clobbered.