### PR TITLE
Update rule in pf.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ set block-policy drop
 scrub in on $ext_if all fragment reassemble
 
 set skip on lo
-nat on $ext_if from lo1:network to any -> ($ext_if)
+nat on $ext_if from !($ext_if) -> ($ext_if:0)
 
 ## rdr example
 ## rdr pass inet proto tcp from any to any port {80, 443} -> 10.17.89.45


### PR DESCRIPTION
I'm way out of my depth here, but I followed [these instructions](https://docs.bastillebsd.org/en/latest/chapters/networking.html) yesterday, and PF could be restarted; copy/pasting from Github today, showed this error:

```
Enabling pfno IP address found for lo1:network
/etc/pf.conf:7: could not parse host specification
pfctl: Syntax error in config file: pf rules not loaded
```

somebody please check this *very* carefully?