### PR TITLE
minor fixes discovered during 0.5.20191125 RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ First, create the loopback interface:
 ```shell
 ishmael ~ # sysrc cloned_interfaces+=lo1
 ishmael ~ # sysrc ifconfig_lo1_name="bastille0"
+ishmael ~ # sysrc ifconfig_bastille0_aliases="inet 10.17.89.1/32"
+ishmael ~ # ifconfig bastille0 inet 10.17.89.1/32
 ishmael ~ # service netif cloneup
-ishmael ~ # ifconfig bastille0 inet 10.17.89.10
 ```
 
 Second, enable the firewall:
@@ -357,9 +358,9 @@ ishmael ~ # bastille list
  folsom          10.17.89.10      folsom                        /usr/local/bastille/jails/folsom/root
 ```
 
-You can also list non-running containers with `bastille list jails`.  In the
-same manner you can list archived `logs`, downloaded `templates`, and
-`releases.
+You can also list non-running containers with `bastille list containers`.  In
+the same manner you can list archived `logs`, downloaded `templates`, and
+`releases`.
 
 
 bastille service

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -315,6 +315,10 @@ bootstrap_release() {
                         echo -e "${COLOR_RED}Failed validation for ${_archive}.txz, please retry bootstrap!${COLOR_RESET}"
                         rm ${bastille_cachedir}/${RELEASE}/${_archive}.txz
                         exit 1
+                    else
+                        echo -e "${COLOR_GREEN}Validated checksum for ${RELEASE}:${_archive}.txz.${COLOR_RESET}"
+                        echo -e "${COLOR_GREEN}MANIFEST:${SHA256_DIST}${COLOR_RESET}"
+                        echo -e "${COLOR_GREEN}DOWNLOAD:${SHA256_FILE}${COLOR_RESET}"
                     fi
                 fi
 
@@ -472,8 +476,8 @@ network)
     ;;
 esac
 
-if [ ! -z "${2}" ]; then
-    if [ "${2}" = 'update' ]; then
-        bastille update "${RELEASE}"
-    fi
-fi
+case "${2}" in
+update)
+    bastille update "${RELEASE}"
+    ;;
+esac

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -77,13 +77,13 @@ esac
 
 ## check ZFS enabled
 if [ ! "${bastille_zfs_enable}" = "YES" ]; then
-    echo -e "${COLOR_RED}ZFS not enabled.'${COLOR_RESET}"
+    echo -e "${COLOR_RED}ZFS not enabled.${COLOR_RESET}"
     exit 1
 fi
 
 ## check zpool defined
 if [ -z "${bastille_zfs_zpool}" ]; then
-    echo -e "${COLOR_RED}ZFS zpool not defined.'${COLOR_RESET}"
+    echo -e "${COLOR_RED}ZFS zpool not defined.${COLOR_RESET}"
     exit 1
 fi
 


### PR DESCRIPTION
Updates to the network bootstrap in the README
added sha256 output validation message in bootstrap
cleaned up some output in zfs