### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ First, create the loopback interface:
 ```shell
 ishmael ~ # sysrc cloned_interfaces+=lo1
 ishmael ~ # sysrc ifconfig_lo1_name="bastille0"
-ishmael ~ # sysrc ifconfig_bastille0_aliases="inet 10.17.89.1/32"
 ishmael ~ # service netif cloneup
-ishmael ~ # ifconfig bastille0 inet 10.17.89.1/32
 ```
 
 Second, enable the firewall:
@@ -116,7 +114,8 @@ set block-policy return
 scrub in on $ext_if all fragment reassemble
 
 set skip on lo
-nat on $ext_if from bastille0:network to any -> ($ext_if)
+table <jails> persist
+nat on $ext_if from <jails> to any -> ($ext_if)
 
 ## rdr example
 ## rdr pass inet proto tcp from any to any port {80, 443} -> 10.17.89.45

--- a/README.md
+++ b/README.md
@@ -97,12 +97,6 @@ ishmael ~ # sysrc ifconfig_lo1_name="bastille0"
 ishmael ~ # service netif cloneup
 ```
 
-Second, enable the firewall:
-
-```shell
-ishmael ~ # sysrc pf_enable="YES"
-```
-
 Create the firewall config, or merge as necessary.
 
 /etc/pf.conf
@@ -134,7 +128,8 @@ Note: if you have an existing firewall, the key lines for in/out traffic to
 containers are:
 
 ```
-nat on $ext_if from bastille0:network to any -> ($ext_if)
+table <jails> persist
+nat on $ext_if from <jails> to any -> ($ext_if)
 
 ## rdr example
 ## rdr pass inet proto tcp from any to any port {80, 443} -> 10.17.89.45
@@ -147,9 +142,10 @@ The `rdr pass ...` will redirect traffic from the host firewall on port X to
 the ip of container Y. The example shown redirects web traffic (80 & 443) to the
 container at `10.17.89.45`.
 
-Finally, start up the firewall:
+Finally, enable and (re)start the firewall:
 
 ```shell
+ishmael ~ # sysrc pf_enable="YES"
 ishmael ~ # service pf restart
 ```
 

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -28,6 +28,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
 ## root check first.
 bastille_root_check() {
     if [ $(id -u) -ne 0 ]; then

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -67,9 +67,9 @@ for _jail in ${JAILS}; do
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 
-        ## update ${bastille_jail_loopback}:network with added/removed addresses
+        ## update table:jails in firewall with container address
         if [ ! -z ${bastille_jail_loopback} ]; then
-            pfctl -f /etc/pf.conf
+            pfctl -t jails -T add $(jls -j ${_jail} ip4.addr)
         fi
     fi
     echo

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -67,7 +67,7 @@ for _jail in ${JAILS}; do
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 
-        ## update table:jails in firewall with container address
+        ## remove ip4.addr from firewall table:jails
         if [ ! -z ${bastille_jail_loopback} ]; then
             pfctl -t jails -T add $(jls -j ${_jail} ip4.addr)
         fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -67,7 +67,7 @@ for _jail in ${JAILS}; do
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 
-        ## remove ip4.addr from firewall table:jails
+        ## add ip4.addr to firewall table:jails
         if [ ! -z ${bastille_jail_loopback} ]; then
             pfctl -t jails -T add $(jls -j ${_jail} ip4.addr)
         fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -51,10 +51,10 @@ TARGET="${1}"
 shift
 
 if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(/usr/local/bin/bastille list jails)
+    JAILS=$(bastille list jails)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(/usr/local/bin/bastille list jails | grep -w "${TARGET}")
+    JAILS=$(bastille list jails | grep -w "${TARGET}")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -64,13 +64,14 @@ for _jail in ${JAILS}; do
 
     ## test if running
     elif [ $(jls name | grep -w "${_jail}") ]; then
+        ## remove ip4.addr from firewall table:jails
+        if [ ! -z ${bastille_jail_loopback} ]; then
+            pfctl -t jails -T delete $(jls -j ${_jail} ip4.addr)
+        fi
+
+        ## stop container
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r ${_jail}
-
-        ## update ${bastille_jail_loopback}:network with added/removed addresses
-        if [ ! -z ${bastille_jail_loopback} ]; then
-            pfctl -f /etc/pf.conf
-        fi
     fi
     echo
 done


### PR DESCRIPTION
This patch defines a PATH to be used throughout.

Also introduces an improvement in the way Bastille handles NAT through the firewall. Instead of reloading the firewall completely (was fine for testing, not going to fly in production), we create a table to hold the IP addresses of the containers. When a container is started the IP is added to this table. When it is stopped it is removed. This allows containers to have NAT and avoid the firewall reload taking a dump when there are no IPs assigned to the interface (as was the previous result).

This updates the README to reflect this new method.