### PR TITLE
quieting pfctl output in start/stop

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -69,7 +69,7 @@ for _jail in ${JAILS}; do
 
         ## add ip4.addr to firewall table:jails
         if [ ! -z ${bastille_jail_loopback} ]; then
-            pfctl -t jails -T add $(jls -j ${_jail} ip4.addr)
+            pfctl -q -t jails -T add $(jls -j ${_jail} ip4.addr)
         fi
     fi
     echo

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -66,7 +66,7 @@ for _jail in ${JAILS}; do
     elif [ $(jls name | grep -w "${_jail}") ]; then
         ## remove ip4.addr from firewall table:jails
         if [ ! -z ${bastille_jail_loopback} ]; then
-            pfctl -t jails -T delete $(jls -j ${_jail} ip4.addr)
+            pfctl -q -t jails -T delete $(jls -j ${_jail} ip4.addr)
         fi
 
         ## stop container


### PR DESCRIPTION
This adds the -q flag to the pfctl at start/stop to quiet output.