### PR TITLE
0.5.20191128 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: install
+install:
+	@echo "Installing Bastille"
+	@echo
+	@cp -av usr /
+	@echo
+	@echo "This method is for testing / development."
+
+.PHONY: uninstall
+uninstall:
+	@echo "Removing Bastille command"
+	@rm -vf /usr/local/bin/bastille
+	@echo
+	@echo "Removing Bastille sub-commands"
+	@rm -rvf /usr/local/share/bastille
+	@echo
+	@echo "removing configuration file"
+	@rm -rvf /usr/local/etc/bastille
+	@echo
+	@echo "removing startup script"
+	@rm -vf /usr/local/etc/rc.d/bastille

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ portsnap fetch auto
 make -C /usr/ports/sysutils/bastille install clean
 ```
 
+**Git**
+```shell
+git clone https://github.com/BastilleBSD/bastille.git
+cd bastille
+make install
+```
+
 **enable at boot**
 ```shell
 sysrc bastille_enable=YES
 ```
-
 
 Basic Usage
 -----------
@@ -64,11 +70,9 @@ Use "bastille command -h|--help" for more information about a command.
 
 ```
 
-
 ## 0.5-beta
 This document outlines the basic usage of the Bastille container management
 framework. This release is still considered beta.
-
 
 Network Requirements
 ====================
@@ -106,8 +110,8 @@ ext_if="vtnet0"
 
 set block-policy return
 scrub in on $ext_if all fragment reassemble
-
 set skip on lo
+
 table <jails> persist
 nat on $ext_if from <jails> to any -> ($ext_if)
 

--- a/docs/chapters/installation.rst
+++ b/docs/chapters/installation.rst
@@ -4,7 +4,7 @@ Bastille is available in the official FreeBSD ports tree at
 `sysutils/bastille`. Binary packages available in `quarterly` and `latest`
 repositories.
 
-Current version is `0.5.20191125`.
+Current version is `0.5.20191128`.
 
 To install from the FreeBSD package repository:
 
@@ -28,3 +28,17 @@ ports
 .. code-block:: shell
 
   make -C /usr/ports/sysutils/bastille install clean
+
+
+GIT
+---
+
+.. code-block:: shell
+
+  git clone https://github.com/BastilleBSD/bastille.git
+  cd bastille
+  make install
+
+This method will install the latest files from GitHub directly onto your
+system. It is verbose about the files it installs (for later removal), and also
+has a `make uninstall` target.

--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -81,7 +81,6 @@ First, create the loopback interface:
   ishmael ~ # sysrc cloned_interfaces+=lo1
   ishmael ~ # sysrc ifconfig_lo1_name="bastille0"
   ishmael ~ # service netif cloneup
-  ishmael ~ # ifconfig bastille0 inet 10.17.89.10
 
 Second, enable the firewall:
 
@@ -99,9 +98,10 @@ Create the firewall rules:
   
   set block-policy return
   scrub in on $ext_if all fragment reassemble
-  
   set skip on lo
-  nat on $ext_if from bastille0:network to any -> ($ext_if)
+
+  table <jails> persist
+  nat on $ext_if from <jails> to any -> ($ext_if)
   
   ## rdr example
   ## rdr pass inet proto tcp from any to any port {80, 443} -> 10.17.89.45
@@ -119,7 +119,7 @@ to containers are:
 
 .. code-block:: shell
 
-  nat on $ext_if from bastille0:network to any -> ($ext_if)
+  nat on $ext_if from <jails> to any -> ($ext_if)
   
   ## rdr example
   ## rdr pass inet proto tcp from any to any port {80, 443} -> 10.17.89.45

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ copyright = '2018-2019, Christer Edwards'
 author = 'Christer Edwards'
 
 # The short X.Y version
-version = '0.5.20191125'
+version = '0.5.20191128'
 # The full version, including alpha/beta/rc tags
-release = '0.5.20191125-beta'
+release = '0.5.20191128-beta'
 
 
 # -- General configuration ---------------------------------------------------

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -69,7 +69,7 @@ bastille_perms_check
 . /usr/local/etc/bastille/bastille.conf
 
 ## version
-BASTILLE_VERSION="0.5.20191125"
+BASTILLE_VERSION="0.5.20191128"
 
 usage() {
     cat << EOF


### PR DESCRIPTION
Adds a Makefile for simple test/dev installation & removal. (This can also be used in a pinch awaiting ports/pkg update)

Updates to documentation to reflect release.