### PR TITLE
Added support for HardenedBSD new link structure

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -441,7 +441,13 @@ case "${1}" in
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    if [ "$(ping -c1 ftp.freebsd.org 2>/dev/null)" ]; then
+        ## main http
+        UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    else
+        ## main ftp
+        UPSTREAM_URL="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    fi
     bootstrap_directories
     bootstrap_release
 else
@@ -467,7 +473,13 @@ NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
 NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    if [ "$(ping -c1 installer.hardenedbsd.org 2>/dev/null)" ]; then
+        ## main site
+        UPSTREAM_URL="http://installer.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    else
+        ## alternate mirror
+        UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    fi
     bootstrap_directories
     bootstrap_release
 else

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -441,11 +441,9 @@ case "${1}" in
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    if ping -c1 -t2 ftp.freebsd.org >/dev/null 2>&1; then
-        ## main http
-        UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
-    else
-        ## main ftp
+    UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
+        ## try an alternate url
         UPSTREAM_URL="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
     fi
     bootstrap_directories
@@ -465,7 +463,7 @@ if [ -n "${NAME_VERIFY}" ]; then
 else
     usage
 fi
-	;;
+    ;;
 *-stable-build-*|*-STABLE-BUILD-*)
 ## check for HardenedBSD(for current changes)
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
@@ -473,11 +471,9 @@ NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
 NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    if ping -c1 -t2 installer.hardenedbsd.org >/dev/null 2>&1; then
-        ## main site
-        UPSTREAM_URL="http://installer.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    else
-        ## alternate mirror
+    UPSTREAM_URL="http://installer.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
+        ## try an alternate url
         UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     fi
     bootstrap_directories

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -459,6 +459,20 @@ if [ -n "${NAME_VERIFY}" ]; then
 else
     usage
 fi
+	;;
+*-stable-build-*|*-STABLE-BUILD-*)
+## check for HardenedBSD(for current changes)
+NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
+NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
+NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
+if [ -n "${NAME_VERIFY}" ]; then
+    RELEASE="${NAME_VERIFY}"
+    UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    bootstrap_directories
+    bootstrap_release
+else
+    usage
+fi
     ;;
 http?://github.com/*/*|http?://gitlab.com/*/*)
     BASTILLE_TEMPLATE_URL=${1}

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -441,7 +441,7 @@ case "${1}" in
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    if [ "$(ping -c1 ftp.freebsd.org 2>/dev/null)" ]; then
+    if ping -c1 -t2 ftp.freebsd.org >/dev/null 2>&1; then
         ## main http
         UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
     else
@@ -473,7 +473,7 @@ NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
 NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    if [ "$(ping -c1 installer.hardenedbsd.org 2>/dev/null)" ]; then
+    if ping -c1 -t2 installer.hardenedbsd.org >/dev/null 2>&1; then
         ## main site
         UPSTREAM_URL="http://installer.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     else

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -339,6 +339,15 @@ else
     usage
 fi
     ;;
+*-stable-build-*|*-STABLE-BUILD-*)
+## check for HardenedBSD(for current changes)
+NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
+if [ -n "${NAME_VERIFY}" ]; then
+    RELEASE="${NAME_VERIFY}"
+else
+    usage
+fi
+    ;;
 *)
     echo -e "${COLOR_RED}Unknown Release.${COLOR_RESET}"
     usage

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -146,7 +146,6 @@ case "${NAME}" in
         usage
     fi
     ;;
-
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
     ## check for HardenedBSD releases name
     NAME_VERIFY=$(echo "${NAME}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
@@ -157,8 +156,17 @@ case "${NAME}" in
         usage
     fi
     ;;
+*-stable-build-*|*-STABLE-BUILD-*)
+## check for HardenedBSD(for current changes)
+NAME_VERIFY=$(echo "${NAME}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
+    if [ -n "${NAME_VERIFY}" ]; then
+        NAME="${NAME_VERIFY}"
+        destroy_rel
+    else
+        usage
+    fi
+    ;;
 *)
-
     ## just destroy a jail
     destroy_jail
     ;;


### PR DESCRIPTION
Hi, this add support for the current HardenedBSD new link structures.


Example for release bootstrap:
~~~
root@server: ~# bastille bootstrap 12-stable-build-39
/mnt/storage/bastille/cache/12-stable-build-39         258 MB  593 kBps 07m26s
Validated checksum for 12-stable-build-39:base.txz.
MANIFEST:7081c23b7fe114ffc9177d7e7057cd165bcffbab06c3bc5da2e87c1503f431b0
DOWNLOAD:7081c23b7fe114ffc9177d7e7057cd165bcffbab06c3bc5da2e87c1503f431b0
Extracting FreeBSD 12-stable-build-39 base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.

root@server: ~#
~~~

Example for HBSD container creation/test:
~~~
root@server: ~# bastille create myjail 12-stable-build-39 10.0.0.100
Valid: (10.0.0.100).

NAME: myjail.
IP: 10.0.0.100.
RELEASE: 12-stable-build-39.

syslogd_flags: -s -> -ss
sendmail_enable: NO -> NONE
cron_flags:  -> -J 60

root@server: ~# bastille start myjail 
[myjail]:
myjail: created

root@server: ~# bastille cmd myjail freebsd-version
[myjail]:
12.1--HBSD

root@server: ~#
~~~

Example for release destroy:
~~~
root@server: ~# bastille destroy 12-stable-build-39
Deleting base: 12-stable-build-39.

root@server: ~#
~~~

Regards