### PR TITLE
template validation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Bastille: Automated Container Security
-======================================
-Bastille is an open-source system for automating deployment and management of
-containerized applications on FreeBSD.
+Bastille: Automate Container Security
+=====================================
+[Bastille](https://bastillebsd.org/) is an open-source system for automating
+deployment and management of containerized applications on FreeBSD.
 
-Looking for [Bastille Templates](https://gitlab.com/BastilleBSD-Templates)?
+Looking for [Bastille Templates](https://gitlab.com/BastilleBSD-Templates/)?
 
 
 Installation
@@ -557,9 +557,9 @@ To leverage a template hook, create an UPPERCASE file in the root of the
 template directory named after the hook you want to execute. eg;
 
 ```shell
-echo "install zsh vim-console git-lite htop" > /usr/local/bastille/templates/base/PKG
-echo "/usr/bin/chsh -s /usr/local/bin/zsh" > /usr/local/bastille/templates/base/CMD
-echo "etc\nroot\nusr" > /usr/local/bastille/templates/base/OVERLAY
+echo "zsh vim-console git-lite htop" > /usr/local/bastille/templates/username/base/PKG
+echo "/usr/bin/chsh -s /usr/local/bin/zsh" > /usr/local/bastille/templates/username/base/CMD
+echo "usr" > /usr/local/bastille/templates/username/base/OVERLAY
 ```
 
 Template hooks are executed in specific order and require specific syntax to

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -31,32 +31,130 @@
 . /usr/local/share/bastille/colors.pre.sh
 . /usr/local/etc/bastille/bastille.conf
 
-usage() {
-    echo -e "${COLOR_RED}Usage: bastille verify release.${COLOR_RESET}"
+bastille_usage() {
+    echo -e "${COLOR_RED}Usage: bastille verify [release|template].${COLOR_RESET}"
     exit 1
+}
+
+verify_release() {
+    if [ ! -z "$(freebsd-version | grep -i HBSD)" ]; then
+        echo -e "${COLOR_RED}Not yet supported on HardenedBSD.${COLOR_RESET}"
+        exit 1
+    fi
+
+    if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
+        freebsd-update -b "${bastille_releasesdir}/${RELEASE}" --currently-running ${RELEASE} IDS
+    else
+        echo -e "${COLOR_RED}${RELEASE} not found. See bootstrap.${COLOR_RESET}"
+        exit 1
+    fi
+}
+
+verify_template() {
+    _template_path=${bastille_templatesdir}/${BASTILLE_TEMPLATE}
+    _hook_validate=0
+
+    for _hook in TARGET INCLUDE PRE OVERLAY FSTAB PF PKG SYSRC SERVICE CMD; do
+        _path=${_template_path}/${_hook}
+        if [ -s ${_path} ]; then
+            _hook_validate=$((_hook_validate+1))
+            echo -e "${COLOR_GREEN}Detected ${_hook} hook.${COLOR_RESET}"
+
+            ## line count must match newline count
+            if [ $(wc -l ${_path} | awk '{print $1}') -ne $(grep -c $'\n' ${_path}) ]; then
+                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                echo -e "${COLOR_RED}${BASTILLE_TEMPLATE}:${_hook} [failed].${COLOR_RESET}"
+                echo -e "${COLOR_RED}Line numbers don't match line breaks.${COLOR_RESET}"
+                echo
+                echo -e "${COLOR_RED}Template validation failed.${COLOR_RESET}"
+                exit 1
+
+            ## if INCLUDE; recursive verify
+            elif [ ${_hook} = 'INCLUDE' ]; then
+                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                cat "${_path}"
+                echo
+                while read _include; do
+                    echo -e "${COLOR_GREEN}[${_hook}]:[${_include}]:${COLOR_RESET}"
+
+                    case ${_include} in
+                        http?://github.com/*/*|http?://gitlab.com/*/*)
+                            bastille bootstrap ${_include}
+                        ;;
+                        */*)
+                            BASTILLE_TEMPLATE_USER=$(echo "${_include}" | awk -F / '{ print $1 }')
+                            BASTILLE_TEMPLATE_REPO=$(echo "${_include}" | awk -F / '{ print $2 }')
+                            bastille verify ${BASTILLE_TEMPLATE_USER}/${BASTILLE_TEMPLATE_REPO}
+                        ;;
+                        *)
+                            echo -e "${COLOR_RED}Template INCLUDE content not recognized.${COLOR_RESET}"
+	                    exit 1
+	                ;;
+                    esac
+                done < ${_path}
+
+            ## if tree; tree -a bastille_template/_dir
+            elif [ ${_hook} = 'OVERLAY' ]; then
+                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                cat "${_path}"
+                echo
+                while read _dir; do
+                if [ -x /usr/local/bin/tree ]; then
+                    echo -e "${COLOR_GREEN}[${_hook}]:[${_dir}]:${COLOR_RESET}"
+                    tree -a ${_template_path}/${_dir}
+                    echo
+                fi
+                done < ${_path}
+            else
+                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                cat "${_path}"
+                echo
+            fi
+        fi
+    done
+
+    ## remove bad templates
+    if [ ${_hook_validate} -lt 1 ]; then
+        echo -e "${COLOR_RED}No valid template hooks found.${COLOR_RESET}"
+        echo -e "${COLOR_RED}Template discarded.${COLOR_RESET}"
+        rm -rf ${bastille_template}
+        exit 1
+    fi
+
+    ## if validated; ready to use
+    if [ ${_hook_validate} -gt 0 ]; then
+        echo -e "${COLOR_GREEN}Template ready to use.${COLOR_RESET}"
+    fi
 }
 
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)
-    usage
+    bastille_usage
     ;;
 esac
 
 if [ $# -gt 1 ] || [ $# -lt 1 ]; then
-    usage
+    bastille_usage
 fi
 
-RELEASE=$1
-
-if [ ! -z "$(freebsd-version | grep -i HBSD)" ]; then
-    echo -e "${COLOR_RED}Not yet supported on HardenedBSD.${COLOR_RESET}"
-    exit 1
-fi
-
-if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
-    freebsd-update -b "${bastille_releasesdir}/${RELEASE}" IDS
-else
-    echo -e "${COLOR_RED}${RELEASE} not found. See bootstrap.${COLOR_RESET}"
-    exit 1
-fi
+case "$1" in
+*-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
+    RELEASE=$1
+    verify_release
+    ;;
+*-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
+    RELEASE=$1
+    verify_release
+    ;;
+http?*)
+    bastille_usage
+    ;;
+*/*)
+    BASTILLE_TEMPLATE=$1
+    verify_template
+    ;;
+*)
+    bastille_usage
+    ;;
+esac


### PR DESCRIPTION
This patch matures the bootstrap/verify/template system. It also now supports non-remote (local) templates. INCLUDE supports local and remote.

Templates can now be verified using `bastille verify template/path`.
Templates verified automatically at bootstrap.

Template order updated. OVERLAY moved directly post-PKG. This should be transparent to most installations. Lastly, `pkg audit -F` runs automatically after all PKG commands to warn of package based CVE.