### PR TITLE
Add more examples

### DIFF
--- a/docs/chapters/subcommands/service.rst
+++ b/docs/chapters/subcommands/service.rst
@@ -11,3 +11,6 @@ running inside the containers.
   ishmael ~ # bastille service web01 'nginx start'
   ishmael ~ # bastille service db01 'mysql-server restart'
   ishmael ~ # bastille service proxy 'nginx configtest'
+  ishmael ~ # bastille service proxy 'nginx enable'
+  ishmael ~ # bastille service proxy 'nginx disable'
+  ishmael ~ # bastille service proxy 'nginx delete'


### PR DESCRIPTION
Since FreeBSD 12.0 service(8) supports enable/disable/delete keywords. This also works with the 'bastille service' command.