### PR TITLE
Add "" around variables in test(1) cases to prevent errors when a var…

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -69,14 +69,14 @@ fi
 bootstrap_network_interfaces() {
 
     ## test for both options empty
-    if [ -z ${bastille_jail_loopback} ] && [ -z ${bastille_jail_external} ]; then
+    if [ -z "${bastille_jail_loopback}" ] && [ -z "${bastille_jail_external}" ]; then
         echo -e "${COLOR_RED}Please set preferred loopback or external interface.${COLOR_RESET}"
         echo -e "${COLOR_RED}See bastille.conf.${COLOR_RESET}"
         exit 1
     fi
 
     ## test for required variables -- external
-    if [ -z ${bastille_jail_loopback} ] && [ ! -z ${bastille_jail_external} ]; then
+    if [ -z "${bastille_jail_loopback}" ] && [ ! -z "${bastille_jail_external}" ]; then
 
        ## test for existing interface
        ifconfig ${bastille_jail_external} 2>&1 >/dev/null
@@ -101,8 +101,8 @@ bootstrap_network_interfaces() {
     fi
 
     ## test for required variables -- loopback
-    if [ -z ${bastille_jail_external} ] && [ ! -z ${bastille_jail_loopback} ] && \
-       [ ! -z ${bastille_jail_addr} ]; then
+    if [ -z "${bastille_jail_external}" ] && [ ! -z "${bastille_jail_loopback}" ] && \
+       [ ! -z "${bastille_jail_addr}" ]; then
 
        echo -e "${COLOR_GREEN}Detecting...${COLOR_RESET}"
        ## test for existing interface
@@ -360,11 +360,11 @@ bootstrap_template() {
     _template=${bastille_templatesdir}/${_user}/${_repo}
 
     ## support for non-git
-    if [ ! -x $(which git) ]; then
+    if [ ! -x "$(which git)" ]; then
         echo -e "${COLOR_RED}Git not found.${COLOR_RESET}"
         echo -e "${COLOR_RED}Not yet implemented.${COLOR_RESET}"
         exit 1
-    elif [ -x $(which git) ]; then
+    elif [ -x "$(which git)" ]; then
         if [ ! -d "${_template}/.git" ]; then
             $(which git) clone "${_url}" "${_template}" ||\
                 echo -e "${COLOR_RED}Clone unsuccessful.${COLOR_RESET}"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -140,10 +140,10 @@ create_jail() {
     fi
 
     if [ ! -f "${bastille_jail_conf}" ]; then
-        if [ -z ${bastille_jail_loopback} ] && [ ! -z ${bastille_jail_external} ]; then
+        if [ -z "${bastille_jail_loopback}" ] && [ ! -z "${bastille_jail_external}" ]; then
             local bastille_jail_conf_interface=${bastille_jail_external}
         fi
-        if [ ! -z ${bastille_jail_loopback} ] && [ -z ${bastille_jail_external} ]; then
+        if [ ! -z "${bastille_jail_loopback}" ] && [ -z "${bastille_jail_external}" ]; then
             local bastille_jail_conf_interface=${bastille_jail_interface}
         fi
         if [ ! -z  ${INTERFACE} ]; then
@@ -374,7 +374,7 @@ if running_jail ${NAME}; then
 fi
 
 ## check if ip address is valid
-if [ ! -z ${IP} ]; then
+if [ ! -z "${IP}" ]; then
     validate_ip
 else
     usage

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -68,7 +68,7 @@ for _jail in ${JAILS}; do
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 
         ## add ip4.addr to firewall table:jails
-        if [ ! -z ${bastille_jail_loopback} ]; then
+        if [ ! -z "${bastille_jail_loopback}" ]; then
             pfctl -q -t jails -T add $(jls -j ${_jail} ip4.addr)
         fi
     fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -65,7 +65,7 @@ for _jail in ${JAILS}; do
     ## test if running
     elif [ $(jls name | grep -w "${_jail}") ]; then
         ## remove ip4.addr from firewall table:jails
-        if [ ! -z ${bastille_jail_loopback} ]; then
+        if [ ! -z "${bastille_jail_loopback}" ]; then
             pfctl -q -t jails -T delete $(jls -j ${_jail} ip4.addr)
         fi
 

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -65,6 +65,11 @@ if [ ! -d "${bastille_templatesdir}/${TEMPLATE}" ]; then
     exit 1
 fi
 
+if [ -z "${JAILS}" ]; then
+    echo -e "${COLOR_RED}Container ${TARGET} is not running.${COLOR_RESET}"
+    exit 1
+fi
+
 ## global variables
 bastille_template=${bastille_templatesdir}/${TEMPLATE}
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -56,7 +56,7 @@ verify_template() {
 
     for _hook in TARGET INCLUDE PRE OVERLAY FSTAB PF PKG SYSRC SERVICE CMD; do
         _path=${_template_path}/${_hook}
-        if [ -s ${_path} ]; then
+        if [ -s "${_path}" ]; then
             _hook_validate=$((_hook_validate+1))
             echo -e "${COLOR_GREEN}Detected ${_hook} hook.${COLOR_RESET}"
 


### PR DESCRIPTION
…iable is unset

I didn't have tree(1) installed and when I fetched and created a Bastille template I saw an error message that tree could not be found. Looking into bootstrap.sh there's 
```
if [ -x $(which tree) ]; then 
tree ....
 ; fi
```
[ -x ] returns 0, so the if clause is true. When "" are added around the $() it works as expected.

The upper construct is no longer in bootstrap.sh in master, but the same is there for finding the git binary.
Also there are some cases in the *.sh files that use -z $var which also doesn't work as expected when $var is unset, so add some quotes around there, too.