### PR TITLE
Add JSON output for list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ ishmael ~ # bastille list
 
 You can also list non-running containers with `bastille list containers`.  In
 the same manner you can list archived `logs`, downloaded `templates`, and
-`releases`.
+`releases`.  Providing the `-j` flag to list alone will result in JSON output.
 
 
 bastille service

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -37,7 +37,11 @@ usage() {
 }
 
 if [ $# -eq 0 ]; then
-    jls -N
+   jls -N
+fi
+
+if [ "$1" == "-j" ]; then
+    jls -N --libxo json
 fi
 
 if [ $# -gt 0 ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille list [release|template|(jail|container)|log].${COLOR_RESET}"
+    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log].${COLOR_RESET}"
     exit 1
 }
 
@@ -42,6 +42,7 @@ fi
 
 if [ "$1" == "-j" ]; then
     jls -N --libxo json
+    exit 0
 fi
 
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
This PR adds the ability for the `bastille list` command to be printed to STDOUT in JSON format. E.g. usage `bastille list -j`.