### PR TITLE
Fix to match exact container name, add missing quotes

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -54,16 +54,16 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(bastille list jails)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(bastille list jails | grep -w "${TARGET}")
+    JAILS=$(bastille list jails | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do
     ## test if running
-    if [ $(jls name | grep -w ${_jail}) ]; then
+    if [ "$(jls name | awk "/^${_jail}$/")" ]; then
         echo -e "${COLOR_RED}[${_jail}]: Already started.${COLOR_RESET}"
 
     ## test if not running
-    elif [ ! $(jls name | grep -w ${_jail}) ]; then
+    elif [ ! "$(jls name | awk "/^${_jail}$/")" ]; then
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -54,16 +54,16 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do
     ## test if not running
-    if [ ! $(jls name | grep -w "${_jail}") ]; then
+    if [ ! "$(jls name | awk "/^${_jail}$/")" ]; then
         echo -e "${COLOR_RED}[${_jail}]: Not started.${COLOR_RESET}"
 
     ## test if running
-    elif [ $(jls name | grep -w "${_jail}") ]; then
+    elif [ "$(jls name | awk "/^${_jail}$/")" ]; then
         ## remove ip4.addr from firewall table:jails
         if [ ! -z "${bastille_jail_loopback}" ]; then
             pfctl -q -t jails -T delete $(jls -j ${_jail} ip4.addr)


### PR DESCRIPTION
This fix for matching exact container name and deals with names containing multiples dash/hyphen, also added missing quotes to avoid "unexpected operator" errors.
