### PR TITLE
build: fix manual install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	@echo "Installing Bastille"
 	@echo
 	@cp -av usr /
+	@test -d /usr/local/bastille || mkdir /usr/local/bastille
 	@chmod 0750 /usr/local/bastille
 	@echo
 	@echo "This method is for testing / development."


### PR DESCRIPTION
I'm assuming that's what you expected here, could equally have been something in `/usr/local/share`.