### PR TITLE
Initial support for LIMITS in template automation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,29 +2,34 @@
 
 ## Lead
 
-Christer Edwards [christer.edwards@gmail.com]
+Christer Edwards [christer.edwards@gmail.com]  
 
-## Contributors
+## Contributors (code)
 
-Barry McCormick
-Jose Rivera
-Giacomo Olgeni
-Jan-Piet Mens
+Barry McCormick  
+Brian Downs  
+Dave Cottlehuber  
+Giacomo Olgeni  
+JP Mens  
+Jose Rivera  
+Lars E.  
+Sven R.  
 
 ### Special thanks
 Software doesn't happen in a vacuum. Thank you to the following people who may
-not be found in the commit history.
+not be found in the commit history but have influenced Bastille's development
+in some way.
 
-Barry McCormick
-Carlos Meza
-Casandra Woodcox
-Clint Savage
-G. Clifford Williams
-Jack Thomasson
-Jun C Park
-Justin Desilets
-Larry Raab
-Nate Taylor
-Ryan Simpkins
-Tim Gelter
-Trevor Sharpe
+Carlos Meza  
+Casandra Woodcox  
+Clint Savage  
+G. Clifford Williams  
+Jack Thomasson  
+Jun C Park  
+Justin Desilets  
+Larry Raab  
+Nate Taylor  
+Peter Czanik  
+Ryan Simpkins  
+Tim Gelter  
+Trevor Sharpe  

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at conduct@bastillebsd.org. All
+reported by contacting the project team lead at christer.edwards@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # Ressource limits added by Sven R github.com/hackacad
 # 

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/restart.sh
+++ b/usr/local/share/bastille/restart.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -99,11 +99,13 @@ verify_template() {
                 cat "${_path}"
                 echo
                 while read _dir; do
-                if [ -x /usr/local/bin/tree ]; then
                     echo -e "${COLOR_GREEN}[${_hook}]:[${_dir}]:${COLOR_RESET}"
-                    tree -a ${_template_path}/${_dir}
+                        if [ -x /usr/local/bin/tree ]; then
+                            /usr/local/bin/tree -a ${_template_path}/${_dir}
+                        else
+                           find "${_template_path}/${_dir}" -print | sed -e 's;[^/]*/;|___;g;s;___|; |;g'
+                        fi
                     echo
-                fi
                 done < ${_path}
             else
                 echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # 
-# Copyright (c) 2018-2019, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This patch adds support for LIMITS in the template automation. 

Defining rctl values (eg; `memoryuse 1G`) will be parsed and added to the system. These limits are also made persistent via a new per-jail `rctl.conf` created using this automation.

Adding and removing these rctl rules at start/stop is pending in a second patch.