### PR TITLE
add/remove rctl limits on container start/stop

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -67,6 +67,13 @@ for _jail in ${JAILS}; do
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c ${_jail}
 
+        ## add rctl limits
+        if [ -s "${bastille_jailsdir}/${_jail}/rctl.conf" ]; then
+            while read _limits; do
+                rctl -a "${_limits}"
+            done < "${bastille_jailsdir}/${_jail}/rctl.conf"
+        fi
+
         ## add ip4.addr to firewall table:jails
         if [ ! -z "${bastille_jail_loopback}" ]; then
             pfctl -q -t jails -T add $(jls -j ${_jail} ip4.addr)

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -69,6 +69,13 @@ for _jail in ${JAILS}; do
             pfctl -q -t jails -T delete $(jls -j ${_jail} ip4.addr)
         fi
 
+        ## remove rctl limits
+        if [ -s "${bastille_jailsdir}/${_jail}/rctl.conf" ]; then
+            while read _limits; do
+                rctl -r "${_limits}"
+            done < "${bastille_jailsdir}/${_jail}/rctl.conf"
+        fi
+
         ## stop container
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r ${_jail}


### PR DESCRIPTION
This patch adds support for (optionally) adding and removing `rctl.conf` values to containers at start and stop.