### PR TITLE
support listing current defined container resource limits

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log].${COLOR_RESET}"
+    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log|limit].${COLOR_RESET}"
     exit 1
 }
 
@@ -76,6 +76,9 @@ if [ $# -gt 0 ]; then
         ;;
     log|logs)
         find "${bastille_logsdir}" -type f -maxdepth 1
+        ;;
+    limit|limits)
+        rctl -h jail:
         ;;
     *)
         usage


### PR DESCRIPTION
This patch allows listing currently enabled resource controls (filter by `jail:`).

`bastille list limits` will return any enabled rctl rules.