### PR TITLE
Initial support for container export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Available Commands:
   cp          cp(1) files from host to targeted container(s).
   create      Create a new thin container or a thick container if -T|--thick option specified.
   destroy     Destroy a stopped container or a FreeBSD release.
+  export      Exports a specified container.
   help        Help about any command
   htop        Interactive process viewer (requires htop).
+  import      Import a specified container.
   list        List containers (running and stopped).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   restart     Restart a running container.
@@ -220,14 +222,14 @@ ishmael ~ # bastille bootstrap 12.0-RELEASE
 ishmael ~ # bastille bootstrap 12.1-RELEASE
 ```
 
-**HardenedBSD 11-STABLE-LAST**
+**HardenedBSD 11-STABLE-BUILD-XX**
 ```shell
-ishmael ~ # bastille bootstrap 11-STABLE-LAST
+ishmael ~ # bastille bootstrap 11-STABLE-BUILD-XX
 ```
 
-**HardenedBSD 12-STABLE-LAST**
+**HardenedBSD 12-STABLE-BUILD-XX**
 ```shell
-ishmael ~ # bastille bootstrap 12-STABLE-LAST
+ishmael ~ # bastille bootstrap 12-STABLE-BUILD-XX
 ```
 
 > `bastille bootstrap RELEASE update` to apply updates automatically at bootstrap.
@@ -792,6 +794,45 @@ ishmael ~ # bastille zfs ALL df
 ishmael ~ # bastille zfs folsom df
 ```
 
+bastille export
+----------------
+Containers can be exported for archiving purposes easily.
+Note: On UFS systems containers must be stopped before export.
+
+```shell
+ishmael ~ # bastille export folsom
+Exporting 'folsom' to a compressed .xz archive.
+Sending zfs data stream...
+  100 %     1057.2 KiB / 9231.5 KiB = 0.115                   0:01             
+Exported '/usr/local/bastille/jails/backups/folsom_2020-01-26-19:23:04.xz' successfully.
+
+```
+
+bastille import
+----------------
+Containers can be imported from supported archives easily.
+
+```shell
+ishmael ~ # bastille import folsom_2020-01-26-19:22:23.xz
+Validating file: folsom_2020-01-26-19:22:23.xz...
+File validation successful!
+Importing 'folsom' from compressed .xz archive.
+Receiving zfs data stream...
+/usr/local/bastille/jails/backups/folsom_2020-01-26-19:22:23.xz (1/1)
+  100 %      626.4 KiB / 9231.5 KiB = 0.068                   0:02             
+Container 'folsom' imported successfully.
+```
+
+bastille import list
+--------------------
+Exported containers can be listed easily before import.
+```shell
+ishmael ~ # bastille import list
+folsom_2020-01-26-19:23:04.xz
+thickjail_2020-01-25-04:00:19.xz
+thinjail_2020-01-25-02:10:16.txz
+root@nas-mserver: ~#
+```
 
 Example (create, start, console)
 ================================

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -87,8 +87,10 @@ Available Commands:
   cp          cp(1) files from host to targeted container(s).
   create      Create a new thin container or a thick container if -T|--thick option specified.
   destroy     Destroy a stopped container or a FreeBSD release.
-  help        Help about any command
+  export      Exports a specified container.
+  help        Help about any command.
   htop        Interactive process viewer (requires htop).
+  import      Import a specified container.
   list        List containers (running and stopped).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   restart     Restart a running container.
@@ -128,7 +130,7 @@ esac
 
 # Filter out all non-commands
 case "${CMD}" in
-cmd|convert|cp|create|destroy|list|pkg|restart|start|stop|sysrc|template|verify)
+cmd|convert|cp|create|destroy|export|import|list|pkg|restart|start|stop|sysrc|template|verify)
     ;;
 update|upgrade)
     ;;

--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -3,40 +3,43 @@
 #####################
 
 ## default paths
-bastille_prefix=/usr/local/bastille                     ## default: "/usr/local/bastille"
-bastille_backupsdir=${bastille_prefix}/backups          ## default: ${bastille_prefix}/backups
-bastille_cachedir=${bastille_prefix}/cache              ## default: ${bastille_prefix}/cache
-bastille_jailsdir=${bastille_prefix}/jails              ## default: ${bastille_prefix}/jails
-bastille_logsdir=${bastille_prefix}/logs                ## default: ${bastille_prefix}/logs
-bastille_releasesdir=${bastille_prefix}/releases        ## default: ${bastille_prefix}/releases
-bastille_templatesdir=${bastille_prefix}/templates      ## default: ${bastille_prefix}/templates
+bastille_prefix=/usr/local/bastille                                   ## default: "/usr/local/bastille"
+bastille_backupsdir=${bastille_prefix}/backups                        ## default: ${bastille_prefix}/backups
+bastille_cachedir=${bastille_prefix}/cache                            ## default: ${bastille_prefix}/cache
+bastille_jailsdir=${bastille_prefix}/jails                            ## default: ${bastille_prefix}/jails
+bastille_logsdir=${bastille_prefix}/logs                              ## default: ${bastille_prefix}/logs
+bastille_releasesdir=${bastille_prefix}/releases                      ## default: ${bastille_prefix}/releases
+bastille_templatesdir=${bastille_prefix}/templates                    ## default: ${bastille_prefix}/templates
 
 ## bastille scripts directory (assumed by bastille pkg)
-bastille_sharedir=/usr/local/share/bastille             ## default: "/usr/local/share/bastille"
+bastille_sharedir=/usr/local/share/bastille                           ## default: "/usr/local/share/bastille"
 
 ## bootstrap archives (base, lib32, ports, src, test)
-bastille_bootstrap_archives="base"                      ## default: "base"
+bastille_bootstrap_archives="base"                                    ## default: "base"
 
 ## default timezone
-bastille_tzdata="etc/UTC"                               ## default: "etc/UTC"
+bastille_tzdata="etc/UTC"                                             ## default: "etc/UTC"
 
 ## default jail resolv.conf
-bastille_resolv_conf="/etc/resolv.conf"                 ## default: "/etc/resolv.conf"
+bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"
+
+## bootstrap urls
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"   ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
 
 ## ZFS options
-bastille_zfs_enable=""                                  ## default: ""
-bastille_zfs_zpool=""                                   ## default: ""
-bastille_zfs_prefix="bastille"                          ## default: "${bastille_zfs_zpool}/bastille"
-bastille_zfs_mountpoint=${bastille_prefix}              ## default: "${bastille_prefix}"
-bastille_zfs_options="-o compress=lz4 -o atime=off"     ## default: "-o compress=lz4 -o atime=off"
+bastille_zfs_enable=""                                                ## default: ""
+bastille_zfs_zpool=""                                                 ## default: ""
+bastille_zfs_prefix="bastille"                                        ## default: "${bastille_zfs_zpool}/bastille"
+bastille_zfs_options="-o compress=lz4 -o atime=off"                   ## default: "-o compress=lz4 -o atime=off"
 
 ## Export/Import options
-bastille_compress_xz_options="-0 -v"                    ## default "-0 -v"
-bastille_decompress_xz_options="-c -d -v"               ## default "-c -d -v"
+bastille_compress_xz_options="-0 -v"                                  ## default "-0 -v"
+bastille_decompress_xz_options="-c -d -v"                             ## default "-c -d -v"
 
 ## Networking
-bastille_jail_loopback="lo1"                            ## default: "lo1"
-bastille_jail_interface="bastille0"                     ## default: "bastille0"
-bastille_jail_external=""                               ## default: ""
-bastille_jail_addr="10.17.89.10"                        ## default: "10.17.89.10"
-bastille_jail_gateway=""                                ## default: ""
+bastille_jail_loopback="lo1"                                          ## default: "lo1"
+bastille_jail_interface="bastille0"                                   ## default: "bastille0"
+bastille_jail_external=""                                             ## default: ""
+bastille_jail_addr="10.17.89.10"                                      ## default: "10.17.89.10"
+bastille_jail_gateway=""                                              ## default: ""

--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -4,6 +4,7 @@
 
 ## default paths
 bastille_prefix=/usr/local/bastille                     ## default: "/usr/local/bastille"
+bastille_backupsdir=${bastille_prefix}/backups          ## default: ${bastille_prefix}/backups
 bastille_cachedir=${bastille_prefix}/cache              ## default: ${bastille_prefix}/cache
 bastille_jailsdir=${bastille_prefix}/jails              ## default: ${bastille_prefix}/jails
 bastille_logsdir=${bastille_prefix}/logs                ## default: ${bastille_prefix}/logs
@@ -28,6 +29,10 @@ bastille_zfs_zpool=""                                   ## default: ""
 bastille_zfs_prefix="bastille"                          ## default: "${bastille_zfs_zpool}/bastille"
 bastille_zfs_mountpoint=${bastille_prefix}              ## default: "${bastille_prefix}"
 bastille_zfs_options="-o compress=lz4 -o atime=off"     ## default: "-o compress=lz4 -o atime=off"
+
+## Export/Import options
+bastille_compress_xz_options="-0 -v"                    ## default "-0 -v"
+bastille_decompress_xz_options="-c -d -v"               ## default "-c -d -v"
 
 ## Networking
 bastille_jail_loopback="lo1"                            ## default: "lo1"

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -173,6 +173,18 @@ bootstrap_directories() {
         fi
     fi
 
+    ## ${bastille_backupsdir}
+    if [ ! -d "${bastille_backupsdir}" ]; then
+        if [ "${bastille_zfs_enable}" = "YES" ];then
+            if [ ! -z "${bastille_zfs_zpool}" ]; then
+                zfs create ${bastille_zfs_options} -o mountpoint=${bastille_backupsdir} ${bastille_zfs_zpool}/${bastille_zfs_prefix}/backups
+            fi
+        else
+            mkdir -p "${bastille_backupsdir}"
+            chmod 0750 "${bastille_backupsdir}"
+        fi
+    fi
+
     ## ${bastille_cachedir}
     if [ ! -d "${bastille_cachedir}" ]; then
         if [ "${bastille_zfs_enable}" = "YES" ]; then

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# 
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    echo -e "${COLOR_RED}Usage: bastille export TARGET.${COLOR_RESET}"
+    exit 1
+}
+
+# Handle special-case commands first
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+    usage
+fi
+
+TARGET="${1}"
+shift
+
+error_notify()
+{
+    # Notify message on error and exit
+    echo -e "$*" >&2
+    exit 1
+}
+
+jail_export()
+{
+    # Attempt to export the container
+    DATE=$(date +%F-%H:%M:%S)
+    if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
+        if [ "${bastille_zfs_enable}" = "YES" ]; then
+            if [ ! -z "${bastille_zfs_zpool}" ]; then
+                FILE_EXT="xz"
+                echo -e "${COLOR_GREEN}Exporting '${TARGET}' to a compressed .${FILE_EXT} archive.${COLOR_RESET}"
+                echo -e "${COLOR_GREEN}Sending zfs data stream...${COLOR_RESET}"
+                # Take a recursive temporary snapshot
+                SNAP_NAME="bastille_export-${DATE}"
+                zfs snapshot -r ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@${SNAP_NAME}
+
+                # Export the container recursively and cleanup temporary snapshots
+                zfs send -R ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@${SNAP_NAME} | \
+                xz ${bastille_compress_xz_options} > ${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}
+                zfs destroy -r ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@${SNAP_NAME}
+            fi
+        else
+            # Create standard backup archive
+            FILE_EXT="txz"
+            echo -e "${COLOR_GREEN}Exporting '${TARGET}' to a compressed .${FILE_EXT} archive...${COLOR_RESET}"
+            cd ${bastille_jailsdir} && tar -cf - ${TARGET} | xz ${bastille_compress_xz_options} > ${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}
+        fi
+
+        if [ $? -ne 0 ]; then
+            error_notify "${COLOR_RED}Failed to export '${TARGET}' container.${COLOR_RESET}"
+        else
+            # Generate container checksum file
+            cd ${bastille_backupsdir}
+            sha256 -q ${TARGET}_${DATE}.${FILE_EXT} > ${TARGET}_${DATE}.sha256
+            echo -e "${COLOR_GREEN}Exported '${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}' successfully.${COLOR_RESET}"
+            exit 0
+        fi
+    else
+        error_notify "${COLOR_RED}Container '${TARGET}' does not exist.${COLOR_RESET}"
+    fi
+}
+
+# Check if backups directory/dataset exist
+if [ ! -d "${bastille_backupsdir}" ]; then
+    error_notify "${COLOR_RED}Backups directory/dataset does not exist, See 'bastille bootstrap'.${COLOR_RESET}"
+fi
+
+# Check if is a ZFS system
+if [ "${bastille_zfs_enable}" != "YES" ]; then
+    # Check if container is running and ask for stop in UFS systems
+    if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
+        error_notify "${COLOR_RED}${TARGET} is running, See 'bastille stop'.${COLOR_RESET}"
+    fi
+fi
+
+jail_export

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+# 
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    echo -e "${COLOR_RED}Usage: bastille import [TARGET|list].${COLOR_RESET}"
+    exit 1
+}
+
+# Handle special-case commands first
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+    usage
+fi
+
+TARGET="${1}"
+shift
+
+error_notify() {
+    # Notify message on error and exit
+    echo -e "$*" >&2
+    exit 1
+}
+
+validate_archive() {
+    # Compare checksums on the target archive
+    if [ -f "${bastille_backupsdir}/${TARGET}" ]; then
+        echo -e "${COLOR_GREEN}Validating file: ${TARGET}...${COLOR_RESET}"
+        SHA256_DIST=$(cat ${bastille_backupsdir}/${FILE_TRIM}.sha256)
+        SHA256_FILE=$(sha256 -q ${bastille_backupsdir}/${TARGET})
+        if [ "${SHA256_FILE}" != "${SHA256_DIST}" ]; then
+            error_notify "${COLOR_RED}Failed validation for ${TARGET}.${COLOR_RESET}"
+        else
+            echo -e "${COLOR_GREEN}File validation successful!${COLOR_RESET}"
+        fi
+    fi
+}
+
+update_zfsmount() {
+    # Update the mountpoint property on the received zfs data stream
+    OLD_ZFS_MOUNTPOINT=$(zfs get -H mountpoint ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root | awk '{print $3}')
+    NEW_ZFS_MOUNTPOINT="${bastille_jailsdir}/${TARGET_TRIM}/root"
+    if [ "${NEW_ZFS_MOUNTPOINT}" != "${OLD_ZFS_MOUNTPOINT}" ]; then
+        echo -e "${COLOR_GREEN}Updating zfs mountpoint...${COLOR_RESET}"
+        zfs set mountpoint=${bastille_jailsdir}/${TARGET_TRIM}/root ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
+    fi
+}
+
+update_jailconf() {
+    # Update jail.conf paths
+    JAIL_CONFIG="${bastille_jailsdir}/${TARGET_TRIM}/jail.conf"
+    if [ -f "${JAIL_CONFIG}" ]; then
+        if ! grep -qw "path = ${bastille_jailsdir}/${TARGET_TRIM}/root;" ${JAIL_CONFIG}; then
+            echo -e "${COLOR_GREEN}Updating jail.conf...${COLOR_RESET}"
+            sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${TARGET_TRIM}_console.log;|" ${JAIL_CONFIG}
+            sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${TARGET_TRIM}/root;|" ${JAIL_CONFIG}
+            sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${TARGET_TRIM}/fstab;|" ${JAIL_CONFIG}
+        fi
+    fi
+}
+
+update_fstab() {
+    # Update fstab .bastille mountpoint on thin containers only
+    # Check if is a thin container
+    if [ ! -d "${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille" ]; then
+        break
+    elif ! grep -qw ".bastille" "${bastille_jailsdir}/${TARGET_TRIM}/fstab"; then
+        break
+    fi
+
+    # Set some variables
+    FSTAB_CONFIG="${bastille_jailsdir}/${TARGET_TRIM}/fstab"
+    FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2]|-stable-build-[0-9]{1,3})' ${FSTAB_CONFIG})
+    FSTAB_CURRENT=$(cat ${FSTAB_CONFIG} | grep -w ".*/releases/.*/jails/${TARGET_TRIM}/root/.bastille")
+    FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille nullfs ro 0 0"
+    if ! grep -qw "${bastille_releasesdir}/${FSTAB_RELEASE}.*${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille" ${FSTAB_CONFIG}; then
+        echo -e "${COLOR_GREEN}Updating fstab...${COLOR_RESET}"
+        sed -i '' "s|${FSTAB_CURRENT}|${FSTAB_NEWCONF}|" ${FSTAB_CONFIG}
+    fi
+}
+
+jail_import() {
+    # Attempt to import container from file
+    FILE_TRIM=$(echo ${TARGET} | sed 's/.[txz]\{2,3\}//')
+    FILE_EXT=$(echo ${TARGET} | cut -d '.' -f2)
+    validate_archive
+    if [ -d "${bastille_jailsdir}" ]; then
+        if [ "${bastille_zfs_enable}" = "YES" ]; then
+            if [ ! -z "${bastille_zfs_zpool}" ]; then
+                if [ "${FILE_EXT}" = "xz" ]; then
+                    # Import from compressed xz on ZFS systems
+                    echo -e "${COLOR_GREEN}Importing '${TARGET_TRIM}' from compressed .${FILE_EXT} archive.${COLOR_RESET}"
+                    echo -e "${COLOR_GREEN}Receiving zfs data stream...${COLOR_RESET}"
+                    xz ${bastille_decompress_xz_options} ${bastille_backupsdir}/${TARGET} | \
+                    zfs receive -u ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
+
+                    # Update ZFS mountpoint property if required
+                    # This is required on foreign imports only
+                    update_zfsmount
+
+                    # Mount new container ZFS datasets
+                    zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
+                    zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
+                elif [ "${FILE_EXT}" = "txz" ]; then
+                    # Prepare the ZFS environment and restore from existing tar.xz file
+                    echo -e "${COLOR_GREEN}Importing '${TARGET_TRIM}' form .${FILE_EXT} archive.${COLOR_RESET}"
+                    echo -e "${COLOR_GREEN}Preparing zfs environment...${COLOR_RESET}"
+                    zfs create ${bastille_zfs_options} ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
+                    zfs create ${bastille_zfs_options} -o mountpoint=${bastille_jailsdir}/${TARGET_TRIM}/root \
+                    ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
+
+                    # Extract required files to the new datasets
+                    echo -e "${COLOR_GREEN}Extracting files from '${TARGET}' archive...${COLOR_RESET}"
+                    tar --exclude='root' -Jxf ${bastille_backupsdir}/${TARGET} --strip-components 1 -C ${bastille_jailsdir}/${TARGET_TRIM} 
+                    tar -Jxf ${bastille_backupsdir}/${TARGET} --strip-components 2 -C ${bastille_jailsdir}/${TARGET_TRIM}/root ${TARGET_TRIM}/root
+                    if [ $? -ne 0 ]; then
+                        zfs destroy -r ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
+                        error_notify "${COLOR_RED}Failed to extract files from '${TARGET}' archive.${COLOR_RESET}"
+                    fi
+                else
+                    error_notify "${COLOR_RED}Unknown archive format.${COLOR_RESET}"
+                fi
+            fi
+        else
+            # Import from standard tar.xz archive on UFS systems
+            echo -e "${COLOR_GREEN}Extracting files from '${TARGET}' archive...${COLOR_RESET}"
+            tar -Jxf  ${bastille_backupsdir}/${TARGET} -C ${bastille_jailsdir}
+        fi
+
+        if [ $? -ne 0 ]; then
+            error_notify "${COLOR_RED}Failed to import from '${TARGET}' archive.${COLOR_RESET}"
+        else
+            # Update the jail.conf and fstab if required
+            # This is required on foreign imports only
+            update_jailconf
+            update_fstab
+            echo -e "${COLOR_GREEN}Container '${TARGET_TRIM}' imported successfully.${COLOR_RESET}"
+            exit 0
+        fi
+    else
+        error_notify "${COLOR_RED}Jails directory/dataset does not exist, See 'bastille bootstrap'.${COLOR_RESET}"
+    fi
+}
+
+# Check if backups directory/dataset exist
+if [ ! -d "${bastille_backupsdir}" ]; then
+    error_notify "${COLOR_RED}Backups directory/dataset does not exist, See 'bastille bootstrap'.${COLOR_RESET}"
+fi
+
+# Handle additional options
+case "${TARGET}" in
+list)
+    ls "${bastille_backupsdir}" | grep -Ev "*.sha256"
+    exit 0
+    ;;
+*)
+    # Check if archive exist then trim archive name
+    if [ "$(ls "${bastille_backupsdir}" | awk "/^${TARGET}$/")" ]; then
+        TARGET_TRIM=$(echo ${TARGET} | sed "s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*:[0-9]*:[0-9]*.[txz]\{2,3\}//")
+    else
+        error_notify "${COLOR_RED}Archive '${TARGET}' not found.${COLOR_RESET}"
+    fi
+    ;;
+esac
+
+# Check if a running jail matches name or already exist
+if [ -n "$(jls name | awk "/^${TARGET_TRIM}$/")" ]; then
+    error_notify "${COLOR_RED}A running jail matches name.${COLOR_RESET}"
+elif [ -d "${bastille_jailsdir}/${TARGET_TRIM}" ]; then
+    error_notify "${COLOR_RED}Container: ${TARGET_TRIM} already exist.${COLOR_RESET}"
+fi
+
+jail_import

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -181,21 +181,12 @@ if [ ! -d "${bastille_backupsdir}" ]; then
     error_notify "${COLOR_RED}Backups directory/dataset does not exist, See 'bastille bootstrap'.${COLOR_RESET}"
 fi
 
-# Handle additional options
-case "${TARGET}" in
-list)
-    ls "${bastille_backupsdir}" | grep -Ev "*.sha256"
-    exit 0
-    ;;
-*)
-    # Check if archive exist then trim archive name
-    if [ "$(ls "${bastille_backupsdir}" | awk "/^${TARGET}$/")" ]; then
-        TARGET_TRIM=$(echo ${TARGET} | sed "s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*:[0-9]*:[0-9]*.[txz]\{2,3\}//")
-    else
-        error_notify "${COLOR_RED}Archive '${TARGET}' not found.${COLOR_RESET}"
-    fi
-    ;;
-esac
+# Check if archive exist then trim archive name
+if [ "$(ls "${bastille_backupsdir}" | awk "/^${TARGET}$/")" ]; then
+    TARGET_TRIM=$(echo ${TARGET} | sed "s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*:[0-9]*:[0-9]*.[txz]\{2,3\}//")
+else
+    error_notify "${COLOR_RED}Archive '${TARGET}' not found.${COLOR_RESET}"
+fi
 
 # Check if a running jail matches name or already exist
 if [ -n "$(jls name | awk "/^${TARGET_TRIM}$/")" ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -80,6 +80,10 @@ if [ $# -gt 0 ]; then
     limit|limits)
         rctl -h jail:
         ;;
+    import|imports|export|exports|backup|backups)
+        ls "${bastille_backupsdir}" | grep -Ev "*.sha256"
+    exit 0
+    ;;
     *)
         usage
         ;;


### PR DESCRIPTION
This adds initial support for container export and import.

## Bastille Export
`usage: bastille export TARGET`

Bastille export is basically for archiving containers to a compressed files, both thin and thick containers are fully supported by the export command.

**Export behavior:**
In ZFS systems, the export command will use `zfs send` and `xz` by default to send a compressed full stream of the selected container as shown below:
`name_YYYY-MM-DD-HH:MM:SS.xz`

In UFS system, the export command will use `tar` and `xz` by default to send a compressed backup of the selected container as shown below:
`name_YYYY-MM-DD-HH:MM:SS.txz`

The exported archives will be followed by an checksum file which is used for archive integrity check during imports, this file should always remain there to avoid import failure, the file is named as follow:
`name_YYYY-MM-DD-HH:MM:SS.sha256`

**Relevant bastille.conf user variable for export:**
`bastille_compress_xz_options="-0 -v"`
This variable configures the "xz" compress options.

The compression time and ratio will depend on the `bastille_compress_xz_options` and the container type, this also varies depending on the system specs and resources, for example setting the below options:
`bastille_compress_xz_options="-9e -v --threads=0"`

 will yield a very small exported archive if the system has the horsepower, at the expense of time, high memory usage and all CPU cores available during the archive creation.

Note that in ZFS systems the export can be done regardless if the container is running or not thanks to ZFS snapshots, while in UFS systems the container must be stopped before export.


## Sample output
**Thin container export in a ZFS system:**
```
root@server: ~# bastille export myjail 
Exporting 'myjail' to a compressed .xz archive.
Sending zfs data stream...
  100 %     1057.0 KiB / 9230.0 KiB = 0.115                                    
Exported '/mnt/storage/bastille/backups/myjail_2020-01-26-04:16:17.xz' successfully.
root@server: ~#
```

**Thin container export in a UFS system:**
```
root@server: ~# bastille export folsom
Exporting 'folsom' to a compressed .txz archive...
  100 %      840.1 KiB / 7400.0 KiB = 0.114                                    
Exported '/mnt/storage/bastille/backups/folsom_2020-01-26-04:25:07.txz' successfully.
root@server: ~#
```


## Bastille Import
`usage: bastille import [TARGET|list]`

Bastille import is basically for restoring containers from supported compressed files, both thin and thick containers are fully supported by the import command.

**Import behavior:**
In ZFS systems, the import command will decompress and use `zfs receive`  to receive a full stream from the selected archive to the containers default location, the archive is named as follow:
`name_YYYY-MM-DD-HH:MM:SS.xz`

If an `name_YYYY-MM-DD-HH:MM:SS.txz` archive is selected instead(note the **.txz** file extension), the import command  will take care of creating the required ZFS environment used by Bastille before decompress the archive, effectively migrating the container to ZFS.

In UFS systems, the import command will decompress the selected archive and restore the files to the containers default location, the archive is named as follow:
`name_YYYY-MM-DD-HH:MM:SS.txz`

Archive integrity check will be performed before the import in either system configurations, also the import command will take care of updating relevant container configuration files when importing archives from foreign systems, this configuration/files may be the `fstab`, `jail.conf` and `zfs mountpoint` also only fields needed by Bastille will be updated only if required, the user is responsible for updating custom fstab mountpoint if necessary.

**Relevant bastille.conf user variable for import:**
`bastille_decompress_xz_options="-c -d -v"`
This variable configures the "xz" decompress options.

The archive extraction time will depend on the the container type, this also varies depending on the system specs and resources available.

**Listing importable archives:**
`usage: bastille import list`

You can list existing archives by executing the above command to check the most recent archives before import for convenience.

## Sample output

**Thin container import on a ZFS system:**
```
root@server: ~# bastille import myjail_2020-01-26-04:16:17.xz
Validating file: myjail_2020-01-26-04:16:17.xz...
File validation successful!
Importing 'myjail' from compressed .xz archive.
Receiving zfs data stream...
/mnt/storage/bastille/backups/myjail_2020-01-26-04:16:17.xz (1/1)
  100 %     1057.0 KiB / 9230.0 KiB = 0.115                   0:01             
Container 'myjail' imported successfully.
root@server: ~#
```
**Thin container import on a UFS system:**
```
root@server: ~# bastille import folsom_2020-01-26-04:25:07.txz
Validating file: folsom_2020-01-26-04:25:07.txz...
File validation successful!
Extracting files from 'folsom_2020-01-26-04:25:07.txz' archive...
Container 'folsom' imported successfully.
root@server: ~#
```

**Thin container imported and migrated from UFS to ZFS:**
```
root@server: ~# bastille import folsom_2020-01-26-04:25:07.txz
Validating file: folsom_2020-01-26-04:25:07.txz...
File validation successful!
Importing 'folsom' form .txz archive.
Preparing zfs environment...
Extracting files from 'folsom_2020-01-26-04:25:07.txz' archive...
Container 'folsom' imported successfully.
root@server: ~#
```

**Thin container imported and migrated from UFS to new ZFS host:**
```
root@server: ~# bastille import thin_2020-01-25-02:10:16.txz
Validating file: thin_2020-01-25-02:10:16.txz...
File validation successful!
Importing 'thin' form .txz archive.
Preparing zfs environment...
Extracting files from 'thin_2020-01-25-02:10:16.txz' archive...
Updating jail.conf...
Updating fstab...
Container 'thin' imported successfully.
root@server: ~#
```

**Thick container imported from old to new ZFS host:**
```
root@server: ~# bastille import thick_zfs_2020-01-25-04:00:19.xz
Validating file: thick_zfs_2020-01-25-04:00:19.xz...
File validation successful!
Importing 'thick_zfs' from compressed .xz archive.
Receiving zfs data stream...
/mnt/storage/bastille/backups/thick_zfs_2020-01-25-04:00:19.xz (1/1)
  100 %       191.0 MiB / 862.4 MiB = 0.222    38 MiB/s       0:22             
Updating zfs mountpoint...
Updating jail.conf...
Updating fstab...
Container 'thick_zfs' imported successfully.
root@server: ~#
```

Sorry for the very basic usage/explanation.
Regards
