### PR TITLE
bootstrap_urls in bastille.conf

### DIFF
--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -3,39 +3,38 @@
 #####################
 
 ## default paths
-bastille_prefix=/usr/local/bastille                     		## default: "/usr/local/bastille"
-bastille_cachedir=${bastille_prefix}/cache              		## default: ${bastille_prefix}/cache
-bastille_jailsdir=${bastille_prefix}/jails              		## default: ${bastille_prefix}/jails
-bastille_logsdir=${bastille_prefix}/logs                		## default: ${bastille_prefix}/logs
-bastille_releasesdir=${bastille_prefix}/releases        		## default: ${bastille_prefix}/releases
-bastille_templatesdir=${bastille_prefix}/templates      		## default: ${bastille_prefix}/templates
+bastille_prefix=/usr/local/bastille                                   ## default: "/usr/local/bastille"
+bastille_cachedir=${bastille_prefix}/cache                            ## default: ${bastille_prefix}/cache
+bastille_jailsdir=${bastille_prefix}/jails                            ## default: ${bastille_prefix}/jails
+bastille_logsdir=${bastille_prefix}/logs                              ## default: ${bastille_prefix}/logs
+bastille_releasesdir=${bastille_prefix}/releases                      ## default: ${bastille_prefix}/releases
+bastille_templatesdir=${bastille_prefix}/templates                    ## default: ${bastille_prefix}/templates
 
 ## bastille scripts directory (assumed by bastille pkg)
-bastille_sharedir=/usr/local/share/bastille             		## default: "/usr/local/share/bastille"
+bastille_sharedir=/usr/local/share/bastille                           ## default: "/usr/local/share/bastille"
 
 ## bootstrap archives (base, lib32, ports, src, test)
-bastille_bootstrap_archives="base"                      		## default: "base"
+bastille_bootstrap_archives="base"                                    ## default: "base"
 
 ## default timezone
-bastille_tzdata="etc/UTC"                               		## default: "etc/UTC"
+bastille_tzdata="etc/UTC"                                             ## default: "etc/UTC"
 
 ## default jail resolv.conf
-bastille_resolv_conf="/etc/resolv.conf"                 		## default: "/etc/resolv.conf"
+bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"
 
 ## bootstrap urls
-bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"	## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
-bastille_url_hardenedbsd="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"	## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"   ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
 
 ## ZFS options
-bastille_zfs_enable=""                                  		## default: ""
-bastille_zfs_zpool=""                                   		## default: ""
-bastille_zfs_prefix="bastille"                          		## default: "${bastille_zfs_zpool}/bastille"
-bastille_zfs_mountpoint=${bastille_prefix}              		## default: "${bastille_prefix}"
-bastille_zfs_options="-o compress=lz4 -o atime=off"    			## default: "-o compress=lz4 -o atime=off"
+bastille_zfs_enable=""                                                ## default: ""
+bastille_zfs_zpool=""                                                 ## default: ""
+bastille_zfs_prefix="bastille"                                        ## default: "${bastille_zfs_zpool}/bastille"
+bastille_zfs_options="-o compress=lz4 -o atime=off"                   ## default: "-o compress=lz4 -o atime=off"
 
 ## Networking
-bastille_jail_loopback="lo1"                            		## default: "lo1"
-bastille_jail_interface="bastille0"                     		## default: "bastille0"
-bastille_jail_external=""                               		## default: ""
-bastille_jail_addr="10.17.89.10"                        		## default: "10.17.89.10"
-bastille_jail_gateway=""                                		## default: ""
+bastille_jail_loopback="lo1"                                          ## default: "lo1"
+bastille_jail_interface="bastille0"                                   ## default: "bastille0"
+bastille_jail_external=""                                             ## default: ""
+bastille_jail_addr="10.17.89.10"                                      ## default: "10.17.89.10"
+bastille_jail_gateway=""                                              ## default: ""

--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -3,35 +3,39 @@
 #####################
 
 ## default paths
-bastille_prefix=/usr/local/bastille                     ## default: "/usr/local/bastille"
-bastille_cachedir=${bastille_prefix}/cache              ## default: ${bastille_prefix}/cache
-bastille_jailsdir=${bastille_prefix}/jails              ## default: ${bastille_prefix}/jails
-bastille_logsdir=${bastille_prefix}/logs                ## default: ${bastille_prefix}/logs
-bastille_releasesdir=${bastille_prefix}/releases        ## default: ${bastille_prefix}/releases
-bastille_templatesdir=${bastille_prefix}/templates      ## default: ${bastille_prefix}/templates
+bastille_prefix=/usr/local/bastille                     		## default: "/usr/local/bastille"
+bastille_cachedir=${bastille_prefix}/cache              		## default: ${bastille_prefix}/cache
+bastille_jailsdir=${bastille_prefix}/jails              		## default: ${bastille_prefix}/jails
+bastille_logsdir=${bastille_prefix}/logs                		## default: ${bastille_prefix}/logs
+bastille_releasesdir=${bastille_prefix}/releases        		## default: ${bastille_prefix}/releases
+bastille_templatesdir=${bastille_prefix}/templates      		## default: ${bastille_prefix}/templates
 
 ## bastille scripts directory (assumed by bastille pkg)
-bastille_sharedir=/usr/local/share/bastille             ## default: "/usr/local/share/bastille"
+bastille_sharedir=/usr/local/share/bastille             		## default: "/usr/local/share/bastille"
 
 ## bootstrap archives (base, lib32, ports, src, test)
-bastille_bootstrap_archives="base"                      ## default: "base"
+bastille_bootstrap_archives="base"                      		## default: "base"
 
 ## default timezone
-bastille_tzdata="etc/UTC"                               ## default: "etc/UTC"
+bastille_tzdata="etc/UTC"                               		## default: "etc/UTC"
 
 ## default jail resolv.conf
-bastille_resolv_conf="/etc/resolv.conf"                 ## default: "/etc/resolv.conf"
+bastille_resolv_conf="/etc/resolv.conf"                 		## default: "/etc/resolv.conf"
+
+## bootstrap urls
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"	## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"	## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
 
 ## ZFS options
-bastille_zfs_enable=""                                  ## default: ""
-bastille_zfs_zpool=""                                   ## default: ""
-bastille_zfs_prefix="bastille"                          ## default: "${bastille_zfs_zpool}/bastille"
-bastille_zfs_mountpoint=${bastille_prefix}              ## default: "${bastille_prefix}"
-bastille_zfs_options="-o compress=lz4 -o atime=off"     ## default: "-o compress=lz4 -o atime=off"
+bastille_zfs_enable=""                                  		## default: ""
+bastille_zfs_zpool=""                                   		## default: ""
+bastille_zfs_prefix="bastille"                          		## default: "${bastille_zfs_zpool}/bastille"
+bastille_zfs_mountpoint=${bastille_prefix}              		## default: "${bastille_prefix}"
+bastille_zfs_options="-o compress=lz4 -o atime=off"    			## default: "-o compress=lz4 -o atime=off"
 
 ## Networking
-bastille_jail_loopback="lo1"                            ## default: "lo1"
-bastille_jail_interface="bastille0"                     ## default: "bastille0"
-bastille_jail_external=""                               ## default: ""
-bastille_jail_addr="10.17.89.10"                        ## default: "10.17.89.10"
-bastille_jail_gateway=""                                ## default: ""
+bastille_jail_loopback="lo1"                            		## default: "lo1"
+bastille_jail_interface="bastille0"                     		## default: "bastille0"
+bastille_jail_external=""                               		## default: ""
+bastille_jail_addr="10.17.89.10"                        		## default: "10.17.89.10"
+bastille_jail_gateway=""                                		## default: ""

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -388,7 +388,7 @@ case "${1}" in
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    UPSTREAM_URL="http://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    UPSTREAM_URL="${bastille_url_freebsd}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
     if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
         ## try an alternate url
         UPSTREAM_URL="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
@@ -404,7 +404,7 @@ fi
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    UPSTREAM_URL="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${RELEASE}"
+    UPSTREAM_URL="i${bastille_url_hardenedbsd}/${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${RELEASE}"
     bootstrap_directories
     bootstrap_release
 else

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -404,7 +404,7 @@ fi
 NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
 if [ -n "${NAME_VERIFY}" ]; then
     RELEASE="${NAME_VERIFY}"
-    UPSTREAM_URL="i${bastille_url_hardenedbsd}/${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${RELEASE}"
+    UPSTREAM_URL="${bastille_url_hardenedbsd}/${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${RELEASE}"
     bootstrap_directories
     bootstrap_release
 else


### PR DESCRIPTION
configure bootstrap url for FreeBSD and Hardened in bastille.conf
will fallback to official FreeBSD URL on failure