### PR TITLE
Minor fixes to create and import

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -67,11 +67,10 @@ validate_ip() {
 
 validate_netif() {
     local LIST_INTERFACES=$(ifconfig -l)
-    interface=${INTERFACE}
-    if echo "${LIST_INTERFACES}" | grep -qwo "${INTERFACE}"; then
-        echo -e "${COLOR_GREEN}Valid: ($interface).${COLOR_RESET}"
+    if echo "${LIST_INTERFACES} VNET" | grep -qwo "${INTERFACE}"; then
+        echo -e "${COLOR_GREEN}Valid: (${INTERFACE}).${COLOR_RESET}"
     else
-        echo -e "${COLOR_RED}Invalid: ($interface).${COLOR_RESET}"
+        echo -e "${COLOR_RED}Invalid: (${INTERFACE}).${COLOR_RESET}"
         exit 1
     fi
 }

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille import [TARGET|list].${COLOR_RESET}"
+    echo -e "${COLOR_RED}Usage: bastille import backup_file.${COLOR_RESET}"
     exit 1
 }
 


### PR DESCRIPTION
This patch simplifies variable usage in the create network validation and updates the usage in the new import sub-command.