### PR TITLE
reverting Makefile; resolves #115

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ install:
 	@echo "Installing Bastille"
 	@echo
 	@cp -av usr /
-	@test -d /usr/local/bastille || mkdir /usr/local/bastille
-	@chmod 0750 /usr/local/bastille
 	@echo
 	@echo "This method is for testing / development."
 


### PR DESCRIPTION
This patch removes the addition we made to the Makefile to create `/usr/local/bastille` as this caused issues in bootstrap. Fixes #115 .