### PR TITLE
Add HardenedBSD CURRENT and LATEST download options, and code improve…

### DIFF
--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -24,8 +24,10 @@ bastille_tzdata="etc/UTC"                                             ## default
 bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"
 
 ## bootstrap urls
-bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"          ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
-bastille_url_hardenedbsd="http://installer.hardenedbsd.org/pub/hardenedbsd/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"              ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_freebsd_alt="ftp://ftp.freebsd.org/pub/FreeBSD/releases/"           ## default: "ftp://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="http://installer.hardenedbsd.org/pub/hardenedbsd/"     ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
+bastille_url_hardenedbsd_alt="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/" ## default: "http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/"
 
 ## ZFS options
 bastille_zfs_enable=""                                                ## default: ""

--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -24,10 +24,8 @@ bastille_tzdata="etc/UTC"                                             ## default
 bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"
 
 ## bootstrap urls
-bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"              ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
-bastille_url_freebsd_alt="ftp://ftp.freebsd.org/pub/FreeBSD/releases/"           ## default: "ftp://ftp.freebsd.org/pub/FreeBSD/releases/"
-bastille_url_hardenedbsd="http://installer.hardenedbsd.org/pub/hardenedbsd/"     ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
-bastille_url_hardenedbsd_alt="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/" ## default: "http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/"
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"          ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="http://installer.hardenedbsd.org/pub/hardenedbsd/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
 
 ## ZFS options
 bastille_zfs_enable=""                                                ## default: ""

--- a/usr/local/etc/bastille/bastille.conf
+++ b/usr/local/etc/bastille/bastille.conf
@@ -24,8 +24,8 @@ bastille_tzdata="etc/UTC"                                             ## default
 bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"
 
 ## bootstrap urls
-bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"   ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
-bastille_url_hardenedbsd="https://installer.hardenedbsd.org/pub/HardenedBSD/releases/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
+bastille_url_freebsd="http://ftp.freebsd.org/pub/FreeBSD/releases/"          ## default: "http://ftp.freebsd.org/pub/FreeBSD/releases/"
+bastille_url_hardenedbsd="http://installer.hardenedbsd.org/pub/hardenedbsd/" ## default: "https://installer.hardenedbsd.org/pub/HardenedBSD/releases/"
 
 ## ZFS options
 bastille_zfs_enable=""                                                ## default: ""

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -69,6 +69,7 @@ fi
 validate_release_url() {
     ## check upstream url, else switch to alternate url
     if [ -n "${NAME_VERIFY}" ]; then
+        RELEASE="${NAME_VERIFY}"
         if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
             ## try an alternate url
             UPSTREAM_URL="${UPSTREAM_ALT}"

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -454,20 +454,20 @@ case "${1}" in
     UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
-*-current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
+current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
     ## check for HardenedBSD(specific current build releases)
-    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build|-CURRENT-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
-    NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-current-.*/current/g')
-    NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-current-//g')
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '(current-build|-CURRENT-BUILD)-([0-9]{1,3})' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
+    NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
+    NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     UPSTREAM_ALT="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
-*-current-build-latest|*-CURRENT-BUILD-LATEST)
+current-build-latest|*-CURRENT-BUILD-LATEST)
     ## check for HardenedBSD(latest current build release)
-    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
-    NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-current-.*/current/g')
-    NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-current-//g')
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '(current-build-latest|-CURRENT-BUILD-LATEST)' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
+    NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     UPSTREAM_ALT="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -426,14 +426,14 @@ case "${1}" in
     ## check for FreeBSD releases name
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
     UPSTREAM_URL="${bastille_url_freebsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
-    UPSTREAM_ALT="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
+    UPSTREAM_ALT="${bastille_url_freebsd_alt}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
     validate_release_url
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
     ## check for HardenedBSD releases name(previous infrastructure, keep for reference)
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${NAME_VERIFY}"
-    UPSTREAM_ALT="http://ftp.freebsd.org/pub/FreeBSD/releases/"
+    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}"
     validate_release_url
     ;;
 *-stable-build-[0-9]*|*-STABLE-BUILD-[0-9]*)
@@ -442,7 +442,7 @@ case "${1}" in
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 *-stable-build-latest|*-STABLE-BUILD-LATEST)
@@ -451,7 +451,7 @@ case "${1}" in
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-BUILD-LATEST//g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_URL="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    UPSTREAM_URL="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
@@ -460,7 +460,7 @@ current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 current-build-latest|*-CURRENT-BUILD-LATEST)
@@ -469,7 +469,7 @@ current-build-latest|*-CURRENT-BUILD-LATEST)
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="http://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 http?://github.com/*/*|http?://gitlab.com/*/*)

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -451,7 +451,7 @@ case "${1}" in
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-BUILD-LATEST//g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_URL="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
+    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -67,12 +67,12 @@ if [ "${bastille_zfs_enable}" = "YES" ]; then
 fi
 
 validate_release_url() {
-    ## check upstream url, else switch to alternate url
+    ## check upstream url, else warn user
     if [ -n "${NAME_VERIFY}" ]; then
         RELEASE="${NAME_VERIFY}"
         if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
-            ## try an alternate url
-            UPSTREAM_URL="${UPSTREAM_ALT}"
+            echo -e "${COLOR_RED}Unable to fetch MANIFEST, See 'bootstrap urls'.${COLOR_RESET}"
+            exit 1
         fi
         bootstrap_directories
         bootstrap_release
@@ -426,14 +426,12 @@ case "${1}" in
     ## check for FreeBSD releases name
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
     UPSTREAM_URL="${bastille_url_freebsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
-    UPSTREAM_ALT="${bastille_url_freebsd_alt}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
     validate_release_url
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
     ## check for HardenedBSD releases name(previous infrastructure, keep for reference)
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${NAME_VERIFY}"
-    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}"
     validate_release_url
     ;;
 *-stable-build-[0-9]*|*-STABLE-BUILD-[0-9]*)
@@ -442,7 +440,6 @@ case "${1}" in
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-build-[0-9]\{1,2\}//g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 *-stable-build-latest|*-STABLE-BUILD-LATEST)
@@ -451,7 +448,6 @@ case "${1}" in
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/-BUILD-LATEST//g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/[0-9]\{1,2\}-stable-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
@@ -460,7 +456,6 @@ current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 current-build-latest|*-CURRENT-BUILD-LATEST)
@@ -469,7 +464,6 @@ current-build-latest|*-CURRENT-BUILD-LATEST)
     NAME_RELEASE=$(echo ${NAME_VERIFY} | sed 's/current-.*/current/g')
     NAME_BUILD=$(echo ${NAME_VERIFY} | sed 's/current-//g')
     UPSTREAM_URL="${bastille_url_hardenedbsd}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
-    UPSTREAM_ALT="${bastille_url_hardenedbsd_alt}${NAME_RELEASE}/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_BUILD}"
     validate_release_url
     ;;
 http?://github.com/*/*|http?://gitlab.com/*/*)

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -69,7 +69,6 @@ fi
 validate_release_url() {
     ## check upstream url, else switch to alternate url
     if [ -n "${NAME_VERIFY}" ]; then
-        RELEASE="${NAME_VERIFY}"
         if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
             ## try an alternate url
             UPSTREAM_URL="${UPSTREAM_ALT}"
@@ -425,14 +424,14 @@ case "${1}" in
 *-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
     ## check for FreeBSD releases name
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
-    UPSTREAM_URL="${bastille_url_freebsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
-    UPSTREAM_ALT="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${RELEASE}"
+    UPSTREAM_URL="${bastille_url_freebsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
+    UPSTREAM_ALT="ftp://ftp.freebsd.org/pub/FreeBSD/releases/${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
     validate_release_url
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
     ## check for HardenedBSD releases name(previous infrastructure, keep for reference)
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
-    UPSTREAM_URL="${bastille_url_hardenedbsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${RELEASE}"
+    UPSTREAM_URL="${bastille_url_hardenedbsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/hardenedbsd-${NAME_VERIFY}"
     UPSTREAM_ALT="http://ftp.freebsd.org/pub/FreeBSD/releases/"
     validate_release_url
     ;;

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -355,14 +355,14 @@ case "${RELEASE}" in
     NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build-latest|-STABLE-BUILD-LATEST)$' | sed 's/STABLE/stable/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
     validate_release
     ;;
-*-current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
+current-build-[0-9]*|CURRENT-BUILD-[0-9]*)
     ## check for HardenedBSD(specific current build releases)
-    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build|-CURRENT-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '(current-build|-CURRENT-BUILD)-([0-9]{1,3})' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
     validate_release
     ;;
-*-current-build-latest|*-CURRENT-BUILD-LATEST)
+current-build-latest|CURRENT-BUILD-LATEST)
     ## check for HardenedBSD(latest current build release)
-    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '(current-build-latest|-CURRENT-BUILD-LATEST)' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
     validate_release
     ;;
 *)

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -96,6 +96,15 @@ validate_netconf() {
     fi
 }
 
+validate_release() {
+    ## check release name match, else show usage
+    if [ -n "${NAME_VERIFY}" ]; then
+        RELEASE="${NAME_VERIFY}"
+    else
+        usage
+    fi
+}
+
 create_jail() {
     bastille_jail_base="${bastille_jailsdir}/${NAME}/root/.bastille"  ## dir
     bastille_jail_template="${bastille_jailsdir}/${NAME}/root/.template"  ## dir
@@ -327,31 +336,34 @@ fi
 ## verify release
 case "${RELEASE}" in
 *-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
-## check for FreeBSD releases name
-NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
-if [ -n "${NAME_VERIFY}" ]; then
-    RELEASE="${NAME_VERIFY}"
-else
-    usage
-fi
+    ## check for FreeBSD releases name
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
+    validate_release
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
-## check for HardenedBSD releases name
-NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
-if [ -n "${NAME_VERIFY}" ]; then
-    RELEASE="${NAME_VERIFY}"
-else
-    usage
-fi
+    ## check for HardenedBSD releases name(previous infrastructure)
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
+    validate_release
     ;;
-*-stable-build-*|*-STABLE-BUILD-*)
-## check for HardenedBSD(for current changes)
-NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
-if [ -n "${NAME_VERIFY}" ]; then
-    RELEASE="${NAME_VERIFY}"
-else
-    usage
-fi
+*-stable-build-[0-9]*|*-STABLE-BUILD-[0-9]*)
+    ## check for HardenedBSD(specific stable build releases)
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
+    validate_release
+    ;;
+*-stable-build-latest|*-STABLE-BUILD-LATEST)
+    ## check for HardenedBSD(latest stable build release)
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-stable-build-latest|-STABLE-BUILD-LATEST)$' | sed 's/STABLE/stable/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    validate_release
+    ;;
+*-current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
+    ## check for HardenedBSD(specific current build releases)
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build|-CURRENT-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
+    validate_release
+    ;;
+*-current-build-latest|*-CURRENT-BUILD-LATEST)
+    ## check for HardenedBSD(latest current build release)
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '([0-9]{1,2})(-current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    validate_release
     ;;
 *)
     echo -e "${COLOR_RED}Unknown Release.${COLOR_RESET}"

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille destroy [container|release]${COLOR_RESET}"
+    echo -e "${COLOR_RED}Usage: bastille destroy [option] | [container|release]${COLOR_RESET}"
     exit 1
 }
 
@@ -41,9 +41,13 @@ destroy_jail() {
     bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
 
     if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
-        echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
-        echo -e "${COLOR_RED}See 'bastille stop ${TARGET}'.${COLOR_RESET}"
-        exit 1
+        if [ "${FORCE_STOP}" = "1" ]; then
+            bastille stop ${TARGET}
+        else
+            echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
+            echo -e "${COLOR_RED}See 'bastille stop ${TARGET}'.${COLOR_RESET}"
+            exit 1
+        fi
     fi
 
     if [ ! -d "${bastille_jail_base}" ]; then
@@ -136,11 +140,28 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
-    usage
-fi
+OPTION="${1}"
+TARGET="${2}"
 
-TARGET="$1"
+## handle additional options
+case "${OPTION}" in
+-f|--forcestop)
+    if [ $# -gt 2 ] || [ $# -lt 2 ]; then
+        usage
+    fi
+    FORCE_STOP="1"
+    ;;
+-*)
+    echo -e "${COLOR_RED}Unknown Option.${COLOR_RESET}"
+    usage
+    ;;
+*)
+    if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+        usage
+    fi
+    TARGET="${1}"
+    ;;
+esac
 
 ## check what should we clean
 case "${TARGET}" in

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -41,7 +41,7 @@ destroy_jail() {
     bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
 
     if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
-        if [ "${FORCE_STOP}" = "1" ]; then
+        if [ "${FORCE}" = "1" ]; then
             bastille stop ${TARGET}
         else
             echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
@@ -116,6 +116,11 @@ destroy_rel() {
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 if [ ! -z "${bastille_zfs_zpool}" ]; then
                     zfs destroy ${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${TARGET}
+                    if [ "${FORCE}" = "1" ]; then
+                        if [ -d "${bastille_cachedir}/${TARGET}" ]; then
+                            zfs destroy ${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${TARGET}
+                        fi
+                    fi
                 fi
             fi
 
@@ -125,6 +130,13 @@ destroy_rel() {
 
                 ## remove jail base
                 rm -rf ${bastille_rel_base}
+            fi
+
+            if [ "${FORCE}" = "1" ]; then
+                ## remove cache on force
+                if [ -d "${bastille_cachedir}/${TARGET}" ]; then
+                    rm -rf "${bastille_cachedir}/${TARGET}"
+                fi
             fi
             echo
         else
@@ -145,11 +157,11 @@ TARGET="${2}"
 
 ## handle additional options
 case "${OPTION}" in
--f|--forcestop)
+-f|--force)
     if [ $# -gt 2 ] || [ $# -lt 2 ]; then
         usage
     fi
-    FORCE_STOP="1"
+    FORCE="1"
     ;;
 -*)
     echo -e "${COLOR_RED}Unknown Option.${COLOR_RESET}"

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -37,12 +37,12 @@ usage() {
 }
 
 destroy_jail() {
-    bastille_jail_base="${bastille_jailsdir}/${NAME}"            ## dir
-    bastille_jail_log="${bastille_logsdir}/${NAME}_console.log"  ## file
+    bastille_jail_base="${bastille_jailsdir}/${TARGET}"            ## dir
+    bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
 
-    if [ "$(jls name | awk "/^${NAME}$/")" ]; then
+    if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
         echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
-        echo -e "${COLOR_RED}See 'bastille stop ${NAME}'.${COLOR_RESET}"
+        echo -e "${COLOR_RED}See 'bastille stop ${TARGET}'.${COLOR_RESET}"
         exit 1
     fi
 
@@ -52,12 +52,12 @@ destroy_jail() {
     fi
 
     if [ -d "${bastille_jail_base}" ]; then
-        echo -e "${COLOR_GREEN}Deleting Jail: ${NAME}.${COLOR_RESET}"
+        echo -e "${COLOR_GREEN}Deleting Jail: ${TARGET}.${COLOR_RESET}"
         if [ "${bastille_zfs_enable}" = "YES" ]; then
             if [ ! -z "${bastille_zfs_zpool}" ]; then
-                if [ ! -z "${NAME}" ]; then
+                if [ ! -z "${TARGET}" ]; then
                     ## remove jail zfs dataset recursively
-                    zfs destroy -r ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NAME}
+                    zfs destroy -r ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}
                 fi
             fi
         fi
@@ -81,15 +81,23 @@ destroy_jail() {
 }
 
 destroy_rel() {
-    bastille_rel_base="${bastille_releasesdir}/${NAME}"  ## dir
+    ## check release name match before destroy
+    if [ -n "${NAME_VERIFY}" ]; then
+        TARGET="${NAME_VERIFY}"
+        break
+    else
+        usage
+    fi
+
+    bastille_rel_base="${bastille_releasesdir}/${TARGET}"  ## dir
 
     ## check if this release have containers child
     BASE_HASCHILD="0"
     if [ -d "${bastille_jailsdir}" ]; then
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _jail in ${JAIL_LIST}; do
-            if grep -qwo "${NAME}" ${bastille_jailsdir}/${_jail}/fstab 2>/dev/null; then
-                echo -e "${COLOR_RED}Notice: (${_jail}) depends on ${NAME} base.${COLOR_RESET}"
+            if grep -qwo "${TARGET}" ${bastille_jailsdir}/${_jail}/fstab 2>/dev/null; then
+                echo -e "${COLOR_RED}Notice: (${_jail}) depends on ${TARGET} base.${COLOR_RESET}"
                 BASE_HASCHILD="1"
             fi
         done
@@ -100,10 +108,10 @@ destroy_rel() {
         exit 1
     else
         if [ "${BASE_HASCHILD}" -eq "0" ]; then
-            echo -e "${COLOR_GREEN}Deleting base: ${NAME}.${COLOR_RESET}"
+            echo -e "${COLOR_GREEN}Deleting base: ${TARGET}.${COLOR_RESET}"
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 if [ ! -z "${bastille_zfs_zpool}" ]; then
-                    zfs destroy ${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${NAME}
+                    zfs destroy ${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${TARGET}
                 fi
             fi
 
@@ -132,39 +140,39 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
     usage
 fi
 
-NAME="$1"
+TARGET="$1"
 
 ## check what should we clean
-case "${NAME}" in
+case "${TARGET}" in
 *-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
     ## check for FreeBSD releases name
-    NAME_VERIFY=$(echo "${NAME}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
-    if [ -n "${NAME_VERIFY}" ]; then
-        NAME="${NAME_VERIFY}"
-        destroy_rel
-    else
-        usage
-    fi
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
+    destroy_rel
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
     ## check for HardenedBSD releases name
-    NAME_VERIFY=$(echo "${NAME}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
-    if [ -n "${NAME_VERIFY}" ]; then
-        NAME="${NAME_VERIFY}"
-        destroy_rel
-    else
-        usage
-    fi
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([1-9]{2,2})(-stable-LAST|-STABLE-last|-stable-last|-STABLE-LAST)$' | sed 's/STABLE/stable/g' | sed 's/last/LAST/g')
+    destroy_rel
     ;;
-*-stable-build-*|*-STABLE-BUILD-*)
-## check for HardenedBSD(for current changes)
-NAME_VERIFY=$(echo "${NAME}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,2})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
-    if [ -n "${NAME_VERIFY}" ]; then
-        NAME="${NAME_VERIFY}"
-        destroy_rel
-    else
-        usage
-    fi
+*-stable-build-[0-9]*|*-STABLE-BUILD-[0-9]*)
+    ## check for HardenedBSD(specific stable build releases)
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-stable-build|-STABLE-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/STABLE/stable/g')
+    destroy_rel
+    ;;
+*-stable-build-latest|*-STABLE-BUILD-LATEST)
+    ## check for HardenedBSD(latest stable build release)
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-stable-build-latest|-STABLE-BUILD-LATEST)$' | sed 's/STABLE/stable/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    destroy_rel
+    ;;
+*-current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
+    ## check for HardenedBSD(specific current build releases)
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-current-build|-CURRENT-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
+    destroy_rel
+    ;;
+*-current-build-latest|*-CURRENT-BUILD-LATEST)
+    ## check for HardenedBSD(latest current build release)
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    destroy_rel
     ;;
 *)
     ## just destroy a jail

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -164,14 +164,14 @@ case "${TARGET}" in
     NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-stable-build-latest|-STABLE-BUILD-LATEST)$' | sed 's/STABLE/stable/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
     destroy_rel
     ;;
-*-current-build-[0-9]*|*-CURRENT-BUILD-[0-9]*)
+current-build-[0-9]*|CURRENT-BUILD-[0-9]*)
     ## check for HardenedBSD(specific current build releases)
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-current-build|-CURRENT-BUILD)-([0-9]{1,3})$' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(current-build|-CURRENT-BUILD)-([0-9]{1,3})' | sed 's/BUILD/build/g' | sed 's/CURRENT/current/g')
     destroy_rel
     ;;
-*-current-build-latest|*-CURRENT-BUILD-LATEST)
+current-build-latest|CURRENT-BUILD-LATEST)
     ## check for HardenedBSD(latest current build release)
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '([0-9]{1,2})(-current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(current-build-latest|-CURRENT-BUILD-LATEST)$' | sed 's/CURRENT/current/g' | sed 's/build/BUILD/g' | sed 's/latest/LATEST/g')
     destroy_rel
     ;;
 *)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log|limit].${COLOR_RESET}"
+    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log|limit|(import|export|backup)].${COLOR_RESET}"
     exit 1
 }
 


### PR DESCRIPTION
Hello. this will add all HardenedBSD CURRENT and LATEST, as well as for specific BUILD download options, and some code improvements.

Some examples below:

**Download a standard FreeBSD release:**
```
root@server: ~# bastille bootstrap 12.0-RELEASE
/mnt/storage/bastille/cache/12.0-RELEASE/MANIFEST         1045  B   10 MBps    00s
/mnt/storage/bastille/cache/12.0-RELEASE/base.txz.        147 MB  506 kBps 04m57s
Validated checksum for 12.0-RELEASE:base.txz.
MANIFEST:360df303fac75225416ccc0c32358333b90ebcd58e54d8a935a4e13f158d3465
DOWNLOAD:360df303fac75225416ccc0c32358333b90ebcd58e54d8a935a4e13f158d3465
Extracting FreeBSD 12.0-RELEASE base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Download the latest HardenedBSD build release:**
```
root@server: ~# bastille bootstrap 12-stable-build-latest
...
....
Extracting FreeBSD 12-stable-BUILD-LATEST base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Download a specific HardenedBSD build release:**
```
root@server: ~# bastille bootstrap 12-stable-build-97
...
....
Extracting FreeBSD 12-stable-build-97 base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Download the latest HardenedBSD current release:**
```
root@server: ~# bastille bootstrap current-build-latest
...
...
Extracting FreeBSD current-BUILD-LATEST base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Download a specific HardenedBSD current release:**
```
root@server: ~# bastille bootstrap current-build-104
...
....
Extracting FreeBSD current-build-104 base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Creating a jail with a specific HardenedBSD build release, in this example build-104:**
```
root@server: ~# bastille create test current-build-104 10.0.0.10
Valid: (10.0.0.10).

NAME: test.
IP: 10.0.0.10.
RELEASE: current-build-104.

syslogd_flags: -s -> -ss
sendmail_enable: NO -> NONE
cron_flags:  -> -J 60
```

**Creating a jail with a the LATEST HardenedBSD release:**
```
root@nas-server: ~# bastille create test2 current-build-latest 10.0.0.11
Valid: (10.0.0.11).

NAME: test2.
IP: 10.0.0.11.
RELEASE: current-BUILD-LATEST.

syslogd_flags: -s -> -ss
sendmail_enable: NO -> NONE
cron_flags:  -> -J 60
```

* Why keeping the sufix "##-XYZ" in the name and not just "12-stable", "BUILD-LATES" or something shortened?
*This is to maintain a valid naming structure so the user can mix several releases, between said "11-stable", "12-stable" etc.*

Updated following PR [5aba0d3](https://github.com/BastilleBSD/bastille/pull/121/commits/5aba0d36f5ca040dafb62bf03e3f1f366f048027)

Regards