### PR TITLE
Compare/update fstab if both variables are set

### DIFF
--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -95,21 +95,17 @@ update_jailconf() {
 
 update_fstab() {
     # Update fstab .bastille mountpoint on thin containers only
-    # Check if is a thin container
-    if [ ! -d "${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille" ]; then
-        break
-    elif ! grep -qw ".bastille" "${bastille_jailsdir}/${TARGET_TRIM}/fstab"; then
-        break
-    fi
-
     # Set some variables
     FSTAB_CONFIG="${bastille_jailsdir}/${TARGET_TRIM}/fstab"
     FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2]|-stable-build-[0-9]{1,3})' ${FSTAB_CONFIG})
     FSTAB_CURRENT=$(cat ${FSTAB_CONFIG} | grep -w ".*/releases/.*/jails/${TARGET_TRIM}/root/.bastille")
     FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille nullfs ro 0 0"
-    if ! grep -qw "${bastille_releasesdir}/${FSTAB_RELEASE}.*${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille" ${FSTAB_CONFIG}; then
-        echo -e "${COLOR_GREEN}Updating fstab...${COLOR_RESET}"
-        sed -i '' "s|${FSTAB_CURRENT}|${FSTAB_NEWCONF}|" ${FSTAB_CONFIG}
+    if [ -n "${FSTAB_CURRENT}" ] && [ -n "${FSTAB_NEWCONF}" ]; then
+        # If both variables are set, compare and update as needed
+        if ! grep -qw "${bastille_releasesdir}/${FSTAB_RELEASE}.*${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille" ${FSTAB_CONFIG}; then
+            echo -e "${COLOR_GREEN}Updating fstab...${COLOR_RESET}"
+            sed -i '' "s|${FSTAB_CURRENT}|${FSTAB_NEWCONF}|" ${FSTAB_CONFIG}
+        fi
     fi
 }
 

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -98,7 +98,7 @@ update_fstab() {
     # Set some variables
     FSTAB_CONFIG="${bastille_jailsdir}/${TARGET_TRIM}/fstab"
     FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2]|-stable-build-[0-9]{1,3})' ${FSTAB_CONFIG})
-    FSTAB_CURRENT=$(cat ${FSTAB_CONFIG} | grep -w ".*/releases/.*/jails/${TARGET_TRIM}/root/.bastille")
+    FSTAB_CURRENT=$(grep -w ".*/releases/.*/jails/${TARGET_TRIM}/root/.bastille" ${FSTAB_CONFIG})
     FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille nullfs ro 0 0"
     if [ -n "${FSTAB_CURRENT}" ] && [ -n "${FSTAB_NEWCONF}" ]; then
         # If both variables are set, compare and update as needed


### PR DESCRIPTION
Hi this simplifies the fstab content comparison on thin containers.
This fix for the `sed: first RE may not be empty` error during remote container imports.

Regards