### PR TITLE
Code improvements, use awk for exact match

### DIFF
--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -53,7 +53,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 validate_user() {

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -55,7 +55,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -63,7 +63,7 @@ if [ "${TARGET}" = 'ALL' ]; then
 fi
 
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -53,7 +53,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
 fi
 
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
 fi
 
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(jls name)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 TEMPLATE="${1}"

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -54,7 +54,7 @@ if [ "${TARGET}" = 'ALL' ]; then
 fi
 
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -57,7 +57,7 @@ fi
 
 if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
     if ! grep -qw ".bastille" "${bastille_jailsdir}/${TARGET}/fstab"; then
-            if [ "$(jls name | grep -w "${TARGET}")" ]; then
+            if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
                 # Update a thick container.
                 CURRENT_VERSION=$(/usr/sbin/jexec -l ${TARGET} freebsd-version 2>/dev/null)
                 if [ -z "${CURRENT_VERSION}" ]; then

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -98,7 +98,7 @@ if [ "${TARGET}" = 'ALL' ]; then
 fi
 
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | grep -w "${TARGET}")
+    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 case "$2" in


### PR DESCRIPTION
Code maintenance routine to use `awk` for exact match instead.
While `grep "^${TARGET}$"` may work, `awk` is way more flexible.

**Example using regular grep:**
```
# echo "jail- jail-test jail--test" | tr " " "\n"
jail-
jail-test
jail--test
# echo "jail- jail-test jail--test" | tr " " "\n" | grep -w "jail-"
jail-
jail--test
```
**Example using awk:**
```
# echo "jail- jail-test jail--test" | tr " " "\n" | awk "/^jail-$/"
jail-
```

Regards