### PR TITLE
make deinstall: avoid removing bastille.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ uninstall:
 	@rm -rvf /usr/local/share/bastille
 	@echo
 	@echo "removing configuration file"
-	@rm -rvf /usr/local/etc/bastille
+	@rm -rvf /usr/local/etc/bastille/bastille.conf.sample
 	@echo
 	@echo "removing startup script"
 	@rm -vf /usr/local/etc/rc.d/bastille
+	@echo "You may need to manually remove /usr/local/etc/bastille/bastille.conf if it is no longer needed."


### PR DESCRIPTION
avoid deleting bastille.conf when running `make deinstall`
refers to: #135 