### PR TITLE
Ignore IPv4 check if there is no entry at all

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -122,10 +122,10 @@ create_jail() {
     if [ ! -d "${bastille_jailsdir}/${NAME}" ]; then
         if [ "${bastille_zfs_enable}" = "YES" ]; then
             if [ ! -z "${bastille_zfs_zpool}" ]; then
-                ## create required zfs datasets
+                ## create required zfs datasets, mountpoint inherited from system
                 zfs create ${bastille_zfs_options} ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NAME}
                 if [ -z "${THICK_JAIL}" ]; then
-                    zfs create ${bastille_zfs_options} -o mountpoint=${bastille_jailsdir}/${NAME}/root ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NAME}/root
+                    zfs create ${bastille_zfs_options} ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NAME}/root
                 fi
             fi
         else

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -78,6 +78,14 @@ update_zfsmount() {
         echo -e "${COLOR_GREEN}Updating zfs mountpoint...${COLOR_RESET}"
         zfs set mountpoint=${bastille_jailsdir}/${TARGET_TRIM}/root ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
     fi
+
+    # Mount new container ZFS datasets
+    if ! zfs mount | grep "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}"; then
+        zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
+    fi
+    if ! zfs mount | grep "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root"; then
+        zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
+    fi
 }
 
 update_jailconf() {
@@ -128,9 +136,6 @@ jail_import() {
                     # This is required on foreign imports only
                     update_zfsmount
 
-                    # Mount new container ZFS datasets
-                    zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}
-                    zfs mount ${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root
                 elif [ "${FILE_EXT}" = "txz" ]; then
                     # Prepare the ZFS environment and restore from existing tar.xz file
                     echo -e "${COLOR_GREEN}Importing '${TARGET_TRIM}' form .${FILE_EXT} archive.${COLOR_RESET}"

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -68,11 +68,13 @@ for _jail in ${JAILS}; do
 
     ## test if not running
     elif [ ! "$(jls name | awk "/^${_jail}$/")" ]; then
-    ## warn if matching configured (but not online) ip4.addr
+        ## warn if matching configured (but not online) ip4.addr, ignore if there's no ip4.addr entry
         ip=$(grep 'ip4.addr' "${bastille_jailsdir}/${_jail}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
-        if ifconfig | grep -w "${ip}" >/dev/null; then
-          echo -e "${COLOR_RED}Error: IP address (${ip}) already in use.${COLOR_RESET}"
-          exit 1
+        if [ -n "${ip}" ]; then
+            if ifconfig | grep -w "${ip}" >/dev/null; then
+                echo -e "${COLOR_RED}Error: IP address (${ip}) already in use.${COLOR_RESET}"
+                exit 1
+            fi
         fi
 
         ## start the container


### PR DESCRIPTION
This will Ignore IPv4 checking if there is no related `ip4.addr` entry at all, i.e. for IPv6 only containers.