### PR TITLE
fixes for new edit sub-command; supports stopped as it should

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -134,7 +134,7 @@ esac
 case "${CMD}" in
 bootstrap|cmd|console|convert|cp|create)
     ;;
-destroy|export|htop|import|limits|list)
+destroy|edit|export|htop|import|limits|list)
     ;;
 pkg|rdr|rename|restart|service|start|stop|sysrc)
     ;;

--- a/usr/local/share/bastille/edit.sh
+++ b/usr/local/share/bastille/edit.sh
@@ -57,10 +57,10 @@ if [ -z "${EDITOR}" ]; then
 fi
 
 if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
+    JAILS=$(bastille list jails)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
+    JAILS=$(bastille list jails | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do


### PR DESCRIPTION
This is a minor fix to support the new edit sub-command.

Now supports offline containers (as it should have), because editing the jail.conf while the container is running is probably not a good idea.