### PR TITLE
update README with ip6 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-Bastille: Automate Container Security
-=====================================
+Bastille
+========
 [Bastille](https://bastillebsd.org/) is an open-source system for automating
 deployment and management of containerized applications on FreeBSD.
 
 Looking for [Bastille Templates](https://gitlab.com/BastilleBSD-Templates/)?
-
 
 Installation
 ============
@@ -21,7 +20,7 @@ portsnap fetch auto
 make -C /usr/ports/sysutils/bastille install clean
 ```
 
-**Git**
+**Git** (bleeding edge / unstable -- primarily for developers)
 ```shell
 git clone https://github.com/BastilleBSD/bastille.git
 cd bastille
@@ -50,6 +49,7 @@ Available Commands:
   cp          cp(1) files from host to targeted container(s).
   create      Create a new thin or thick container.
   destroy     Destroy a stopped container or a bootstrapped release.
+  edit        Edit container configuration files (advanced).
   export      Exports a container archive or image.
   help        Help about any command
   htop        Interactive process viewer (requires htop).
@@ -298,25 +298,43 @@ IP at container creation.
 
 - name
 - release (bootstrapped)
-- ip
+- ip (ip4 or ip6)
 - interface (optional)
 
 
+**ip4**
 ```shell
-ishmael ~ # bastille create folsom 12.0-RELEASE 10.17.89.10
+ishmael ~ # bastille create folsom 12.1-RELEASE 10.17.89.10
 Valid: (10.17.89.10).
 
 NAME: folsom.
 IP: 10.17.89.10.
-RELEASE: 12.0-RELEASE.
+RELEASE: 12.1-RELEASE.
 
 syslogd_flags: -s -> -ss
 sendmail_enable: NO -> NONE
 cron_flags:  -> -J 60
 ```
 
-This command will create a 12.0-RELEASE container assigning the 10.17.89.10 ip
+This command will create a 12.1-RELEASE container assigning the 10.17.89.10 ip
 address to the new system.
+
+**ip6**
+```shell
+ishmael ~ # bastille create folsom 12.1-RELEASE fd35:f1fd:2cb6:6c5c::13
+Valid: (fd35:f1fd:2cb6:6c5c::13).
+
+NAME: folsom.
+IP: fd35:f1fd:2cb6:6c5c::13
+RELEASE: 12.1-RELEASE.
+
+syslogd_flags: -s -> -ss
+sendmail_enable: NO -> NONE
+cron_flags:  -> -J 60
+```
+
+This command will create a 12.1-RELEASE container assigning the
+fd35:f1fd:2cb6:6c5c::13  ip address to the new system.
 
 Optionally `bastille create [ -T | --thick ]` will create a container with a
 private base. This is sometimes referred to as a "thick" container (whereas the
@@ -613,7 +631,7 @@ work as expected. This table outlines that order and those requirements:
 
 | PLANNED | format           | example                                                        |
 |---------|------------------|----------------------------------------------------------------|
-| PF      | pf rdr entry     | rdr pass inet proto tcp from any to any port 80 -> 10.17.89.80 |
+| RDR     | pf rdr entry     | rdr pass inet proto tcp from any to any port 80 -> 10.17.89.80 |
 | LOG     | path             | /var/log/nginx/access.log                                      |
 
 Note: SYSRC requires NO quotes or that quotes (`"`) be escaped. ie; `\"`)
@@ -752,7 +770,7 @@ ishmael ~ # bastille cp ALL /tmp/resolv.conf-cf etc/resolv.conf
 /tmp/resolv.conf-cf -> /usr/local/bastille/jails/unbound0/root/etc/resolv.conf
 ```
 
-bastille-rdr
+bastille rdr
 ------------
 
 `bastille rdr` allows you to configure dynamic rdr rules for your containers
@@ -761,7 +779,7 @@ for a private network and have enabled `rdr-anchor 'rdr/*'` in /etc/pf.conf
 as described in the Networking section).
 
 ```shell
-    # bastille rdr --help
+    # bastille rdr help
     Usage: bastille rdr TARGET [clear] | [list] | [tcp <host_port> <jail_port>] | [udp <host_port> <jail_port>]
     # bastille rdr dev1 tcp 2001 22
     # bastille rdr dev1 list


### PR DESCRIPTION
This patch updates the README with a few fixes and adds an example of creating an ip6 container.