### PR TITLE
no dots allowed in rename.sh

### DIFF
--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -57,6 +57,11 @@ TARGET="${1}"
 NEWNAME="${2}"
 shift
 
+if echo "${NEWNAME}" | grep -q "[.]"; then
+    echo -e "${COLOR_RED}Container names may not contain a dot(.)!${COLOR_RESET}"
+    exit 1
+fi
+
 update_jailconf() {
     # Update jail.conf
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"


### PR DESCRIPTION
Disallow dots for jailname when using rename.sh