### PR TITLE
fix zfs snapshot recursive

### DIFF
--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -39,7 +39,7 @@ usage() {
 zfs_snapshot() {
 for _jail in ${JAILS}; do
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
-    zfs snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
+    zfs snapshot -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
     echo
 done
 }


### PR DESCRIPTION
Snapshots should be created recursively to add "data dataset" (jailname/root) as well