### PR TITLE
 network cleanup; default route addition for vnet

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -38,8 +38,6 @@ bastille_compress_xz_options="-0 -v"                                  ## default
 bastille_decompress_xz_options="-c -d -v"                             ## default "-c -d -v"
 
 ## Networking
-bastille_jail_loopback="lo1"                                          ## default: "lo1"
-bastille_jail_interface="bastille0"                                   ## default: "bastille0"
-bastille_jail_external=""                                             ## default: ""
-bastille_jail_addr="10.17.89.10"                                      ## default: "10.17.89.10"
-bastille_jail_gateway=""                                              ## default: ""
+bastille_network_loopback="bastille0"                                 ## default: "bastille0"
+bastille_network_shared=""                                            ## default: ""
+bastille_network_gateway=""                                           ## default: ""

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -274,10 +274,10 @@ workout_components() {
 
 config_netif() {
     # Get interface from bastille configuration
-    if [ -n "${bastille_jail_interface}" ]; then
-        NETIF_CONFIG="${bastille_jail_interface}"
-    elif [ -n "${bastille_jail_external}" ]; then
-        NETIF_CONFIG="${bastille_jail_external}"
+    if [ -n "${bastille_network_loopback}" ]; then
+        NETIF_CONFIG="${bastille_network_loopback}"
+    elif [ -n "${bastille_network_shared}" ]; then
+        NETIF_CONFIG="${bastille_network_shared}"
     else
         NETIF_CONFIG=
     fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -89,7 +89,7 @@ for _jail in ${JAILS}; do
         fi
 
         ## add ip4.addr to firewall table:jails
-        if [ ! -z "${bastille_jail_loopback}" ]; then
+        if [ ! -z "${bastille_network_loopback}" ]; then
             pfctl -q -t jails -T add "$(jls -j "${_jail}" ip4.addr)"
         fi
     fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -67,7 +67,7 @@ for _jail in ${JAILS}; do
     ## test if running
     if [ "$(jls name | awk "/^${_jail}$/")" ]; then
         ## remove ip4.addr from firewall table:jails
-        if [ -n "${bastille_jail_loopback}" ]; then
+        if [ -n "${bastille_network_loopback}" ]; then
             pfctl -q -t jails -T delete "$(jls -j "${_jail}" ip4.addr)"
         fi
 


### PR DESCRIPTION
This patch cleans up the networking section of the config and with that change allows for defining the default route in a VNET container.

The new network configuration should now be simpler as follows:

- bastille_network_loopback is the loopback based (bastille0) networking that requires pf NAT.
- bastille_network_shared is the shared-ip based networking on existing interface(s).
- bastille_network_gateway defines the default gateway in a VNET container.

Note: if bastille_network_gateway is undefined it will attempt to be populated from the host default gateway.

Also removed is the unused network bootstrap option that never reliably worked anyway.