### PR TITLE
fix route auto-detect and SERVICE template

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -331,7 +331,7 @@ create_jail() {
             ## if 0.0.0.0 set DHCP
             ## else set static address
             if [ "${IP}" == "0.0.0.0" ]; then
-                /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="DHCP"
+                /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
             else
                 /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
                 if [ -n "${bastille_network_gateway}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -337,7 +337,7 @@ create_jail() {
                 if [ -n "${bastille_network_gateway}" ]; then
                     /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" defaultrouter="${bastille_network_gateway}"
                 else
-                    /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" defaultrouter="$(route show default | awk '/gateway/ {print $2}')"
+                    /usr/sbin/sysrc -f "${bastille_jail_rc_conf}" defaultrouter="$(netstat -rn | awk '/default/ {print $2}')"
                 fi
             fi
 

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -266,7 +266,7 @@ for _jail in ${JAILS}; do
     if [ -s "${bastille_template}/SERVICE" ]; then
         echo -e "${COLOR_GREEN}[${_jail}]:SERVICE -- START${COLOR_RESET}"
         while read _service; do
-            jexec -l "${_jail}" /usr/sbin/service "${_service}" || exit 1
+            jexec -l "${_jail}" /usr/sbin/service ${_service} || exit 1
         done < "${bastille_template}/SERVICE"
         echo -e "${COLOR_GREEN}[${_jail}]:SERVICE -- END${COLOR_RESET}"
         echo


### PR DESCRIPTION
This improves the route auto-detect by using `netstat -rn` which will not do name resolution. The previous solution had the chance of resolving the address resulting in failed networking.

The SERVICE template is also fixed by removing too many quotes. This was from our `shellcheck` testing and not unexpected to find.