### PR TITLE
start/stop hotfix and version bump

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -69,7 +69,7 @@ bastille_perms_check
 . /usr/local/etc/bastille/bastille.conf
 
 ## version
-BASTILLE_VERSION="0.6.20200412"
+BASTILLE_VERSION="0.6.20200414"
 
 usage() {
     cat << EOF

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -89,7 +89,7 @@ for _jail in ${JAILS}; do
         fi
 
         ## add ip4.addr to firewall table:jails
-        if [ ! -z "${bastille_network_loopback}" ]; then
+        if grep "interface = ${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
             pfctl -q -t jails -T add "$(jls -j "${_jail}" ip4.addr)"
         fi
     fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -67,7 +67,7 @@ for _jail in ${JAILS}; do
     ## test if running
     if [ "$(jls name | awk "/^${_jail}$/")" ]; then
         ## remove ip4.addr from firewall table:jails
-        if [ -n "${bastille_network_loopback}" ]; then
+        if grep "interface = ${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
             pfctl -q -t jails -T delete "$(jls -j "${_jail}" ip4.addr)"
         fi
 


### PR DESCRIPTION
This patch bumps the version for the hotfix release and includes a fix to the PF table logic in start/stop.

If the container to be started/stopped includes the `bastille_network_loopback` value then update the PF table. Otherwise leave it alone. This should avoid the issue we had with pf trying to reload unnecessarily.