### PR TITLE
Fix for pfctl on start/stop commands, clean up excess double quotes

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -89,8 +89,10 @@ for _jail in ${JAILS}; do
         fi
 
         ## add ip4.addr to firewall table:jails
-        if grep "interface = ${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-            pfctl -q -t jails -T add "$(jls -j "${_jail}" ip4.addr)"
+        if [ -n "${bastille_network_loopback}" ]; then
+            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
+                pfctl -q -t jails -T add "$(jls -j ${_jail} ip4.addr)"
+            fi
         fi
     fi
     echo

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -67,8 +67,10 @@ for _jail in ${JAILS}; do
     ## test if running
     if [ "$(jls name | awk "/^${_jail}$/")" ]; then
         ## remove ip4.addr from firewall table:jails
-        if grep "interface = ${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-            pfctl -q -t jails -T delete "$(jls -j "${_jail}" ip4.addr)"
+        if [ -n "${bastille_network_loopback}" ]; then
+            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
+                pfctl -q -t jails -T delete "$(jls -j ${_jail} ip4.addr)"
+            fi
         fi
 
         ## remove rctl limits


### PR DESCRIPTION
Fix for the following error in the start stop commands:
```
root@server: ~# bastille start dvr
[dvr]:
dvr: created
  interface = em0;
pfctl: /dev/pf: No such file or directory

root@server: ~# bastille stop dvr
  interface = em0;
pfctl: /dev/pf: No such file or directory
[dvr]:
dvr: removed

```

Also `grep` will not be called at all if `${bastille_network_loopback}` is empty, common on shared IP based containers.

Additionally grep will exact match regardless of either *spaces and *tabs silently.

Regards