### PR TITLE
Feature add, create empty jail and minor maintenance

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -3,16 +3,16 @@
 #####################
 
 ## default paths
-bastille_prefix=/usr/local/bastille                                   ## default: "/usr/local/bastille"
-bastille_backupsdir=${bastille_prefix}/backups                        ## default: ${bastille_prefix}/backups
-bastille_cachedir=${bastille_prefix}/cache                            ## default: ${bastille_prefix}/cache
-bastille_jailsdir=${bastille_prefix}/jails                            ## default: ${bastille_prefix}/jails
-bastille_logsdir=${bastille_prefix}/logs                              ## default: ${bastille_prefix}/logs
-bastille_releasesdir=${bastille_prefix}/releases                      ## default: ${bastille_prefix}/releases
-bastille_templatesdir=${bastille_prefix}/templates                    ## default: ${bastille_prefix}/templates
+bastille_prefix="/usr/local/bastille"                                 ## default: "/usr/local/bastille"
+bastille_backupsdir="${bastille_prefix}/backups"                      ## default: ${bastille_prefix}/backups
+bastille_cachedir="${bastille_prefix}/cache"                          ## default: ${bastille_prefix}/cache
+bastille_jailsdir="${bastille_prefix}/jails"                          ## default: ${bastille_prefix}/jails
+bastille_logsdir="${bastille_prefix}/logs"                            ## default: ${bastille_prefix}/logs
+bastille_releasesdir="${bastille_prefix}/releases"                    ## default: ${bastille_prefix}/releases
+bastille_templatesdir="${bastille_prefix}/templates"                  ## default: ${bastille_prefix}/templates
 
 ## bastille scripts directory (assumed by bastille pkg)
-bastille_sharedir=/usr/local/share/bastille                           ## default: "/usr/local/share/bastille"
+bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"
 
 ## bootstrap archives (base, lib32, ports, src, test)
 bastille_bootstrap_archives="base"                                    ## default: "base"

--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -4,12 +4,12 @@
 
 ## default paths
 bastille_prefix="/usr/local/bastille"                                 ## default: "/usr/local/bastille"
-bastille_backupsdir="${bastille_prefix}/backups"                      ## default: ${bastille_prefix}/backups
-bastille_cachedir="${bastille_prefix}/cache"                          ## default: ${bastille_prefix}/cache
-bastille_jailsdir="${bastille_prefix}/jails"                          ## default: ${bastille_prefix}/jails
-bastille_logsdir="${bastille_prefix}/logs"                            ## default: ${bastille_prefix}/logs
-bastille_releasesdir="${bastille_prefix}/releases"                    ## default: ${bastille_prefix}/releases
-bastille_templatesdir="${bastille_prefix}/templates"                  ## default: ${bastille_prefix}/templates
+bastille_backupsdir="${bastille_prefix}/backups"                      ## default: "${bastille_prefix}/backups"
+bastille_cachedir="${bastille_prefix}/cache"                          ## default: "${bastille_prefix}/cache"
+bastille_jailsdir="${bastille_prefix}/jails"                          ## default: "${bastille_prefix}/jails"
+bastille_logsdir="${bastille_prefix}/logs"                            ## default: "${bastille_prefix}/logs"
+bastille_releasesdir="${bastille_prefix}/releases"                    ## default: "${bastille_prefix}/releases"
+bastille_templatesdir="${bastille_prefix}/templates"                  ## default: "${bastille_prefix}/templates"
 
 ## bastille scripts directory (assumed by bastille pkg)
 bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -325,14 +325,20 @@ create_jail() {
         fi
 
         ## rc.conf
-        ##  + syslogd_flags="-ss"
-        ##  + sendmail_none="NONE"
-        ##  + cron_flags="-J 60" ## cedwards 20181118
+        ## + syslogd_flags="-ss"
+        ## + sendmail_enable="NO"
+        ## + sendmail_submit_enable="NO"
+        ## + sendmail_outbound_enable="NO"
+        ## + sendmail_msp_queue_enable="NO"
+        ## + cron_flags="-J 60" ## cedwards 20181118
         if [ ! -f "${bastille_jail_rc_conf}" ]; then
             touch "${bastille_jail_rc_conf}"
-            sysrc -f "${bastille_jail_rc_conf}" syslogd_flags=-ss
-            sysrc -f "${bastille_jail_rc_conf}" sendmail_enable=NONE
-            sysrc -f "${bastille_jail_rc_conf}" cron_flags='-J 60'
+            sysrc -f "${bastille_jail_rc_conf}" syslogd_flags="-ss"
+            sysrc -f "${bastille_jail_rc_conf}" sendmail_enable="NO"
+            sysrc -f "${bastille_jail_rc_conf}" sendmail_submit_enable="NO"
+            sysrc -f "${bastille_jail_rc_conf}" sendmail_outbound_enable="NO"
+            sysrc -f "${bastille_jail_rc_conf}" sendmail_msp_queue_enable="NO"
+            sysrc -f "${bastille_jail_rc_conf}" cron_flags="-J 60"
 
             ## VNET specific
             if [ -n "${VNET_JAIL}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -207,10 +207,6 @@ create_jail() {
             mkdir -p "${bastille_jail_base}"
         fi
 
-        if [ ! -d "${bastille_jail_path}/usr/home" ]; then
-            mkdir -p "${bastille_jail_path}/usr/home"
-        fi
-
         if [ ! -d "${bastille_jail_path}/usr/local" ]; then
             mkdir -p "${bastille_jail_path}/usr/local"
         fi
@@ -259,13 +255,11 @@ create_jail() {
         echo
 
         if [ -z "${THICK_JAIL}" ]; then
-            for _link in bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/sbin usr/share usr/src; do
+            LINK_LIST="bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/sbin usr/share usr/src"
+            for _link in ${LINK_LIST}; do
                 ln -sf /.bastille/${_link} ${_link}
             done
         fi
-
-        ## link home properly
-        ln -s usr/home home
 
         if [ -z "${THICK_JAIL}" ]; then
             ## rw
@@ -322,6 +316,15 @@ create_jail() {
                     exit 1
                 fi
             fi
+        fi
+
+        ## create home directory if missing
+        if [ ! -d "${bastille_jail_path}/usr/home" ]; then
+            mkdir -p "${bastille_jail_path}/usr/home"
+        fi
+        ## link home properly
+        if [ ! -L "home" ]; then
+            ln -s usr/home home
         fi
 
         ## rc.conf

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -445,8 +445,8 @@ else
 fi
 
 ## don't allow for dots(.) in container names
-if echo "${NAME}" | grep -q "[.]"; then
-    echo -e "${COLOR_RED}Container names may not contain a dot(.)!${COLOR_RESET}"
+if echo "${NAME}" | grep -Eq '[.]|\ '; then
+    echo -e "${COLOR_RED}Container names may not contain a dot(.) nor spaces!${COLOR_RESET}"
     exit 1
 fi
 

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -109,9 +109,9 @@ update_jailconf() {
     if [ -f "${JAIL_CONFIG}" ]; then
         if ! grep -qw "path = ${bastille_jailsdir}/${TARGET_TRIM}/root;" "${JAIL_CONFIG}"; then
             echo -e "${COLOR_GREEN}Updating jail.conf...${COLOR_RESET}"
-            sed -i '' "s|exec.consolelog.*= .*;|exec.consolelog = ${bastille_logsdir}/${TARGET_TRIM}_console.log;|" "${JAIL_CONFIG}"
-            sed -i '' "s|path.*= .*;|path = ${bastille_jailsdir}/${TARGET_TRIM}/root;|" "${JAIL_CONFIG}"
-            sed -i '' "s|mount.fstab.*= .*;|mount.fstab = ${bastille_jailsdir}/${TARGET_TRIM}/fstab;|" "${JAIL_CONFIG}"
+            sed -i '' "s|exec.consolelog.*=.*;|exec.consolelog = ${bastille_logsdir}/${TARGET_TRIM}_console.log;|" "${JAIL_CONFIG}"
+            sed -i '' "s|path.*=.*;|path = ${bastille_jailsdir}/${TARGET_TRIM}/root;|" "${JAIL_CONFIG}"
+            sed -i '' "s|mount.fstab.*=.*;|mount.fstab = ${bastille_jailsdir}/${TARGET_TRIM}/fstab;|" "${JAIL_CONFIG}"
         fi
     fi
 }

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -43,7 +43,7 @@ error_notify() {
 }
 
 validate_name() {
-    local NAME_VERIFY=${NAME}
+    local NAME_VERIFY=${NEWNAME}
     local NAME_SANITY=$(echo "${NAME_VERIFY}" | tr -c -d 'a-zA-Z0-9-_')
     if [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
         error_notify "${COLOR_RED}Container names may not contain special characters!${COLOR_RESET}"
@@ -64,11 +64,6 @@ fi
 TARGET="${1}"
 NEWNAME="${2}"
 shift
-
-if echo "${NEWNAME}" | grep -Eq '[.]|\ '; then
-    echo -e "${COLOR_RED}Container names may not contain a dot(.) nor spaces!${COLOR_RESET}"
-    exit 1
-fi
 
 update_jailconf() {
     # Update jail.conf
@@ -141,7 +136,7 @@ elif [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
 fi
 
 ## validate jail name
-if [ -n "${NAME}" ]; then
+if [ -n "${NEWNAME}" ]; then
     validate_name
 fi
 

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -42,6 +42,14 @@ error_notify() {
     exit 1
 }
 
+validate_name() {
+    local NAME_VERIFY=${NAME}
+    local NAME_SANITY=$(echo "${NAME_VERIFY}" | tr -c -d 'a-zA-Z0-9-_')
+    if [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
+        error_notify "${COLOR_RED}Container names may not contain special characters!${COLOR_RESET}"
+    fi
+}
+
 # Handle special-case commands first
 case "$1" in
 help|-h|--help)
@@ -130,6 +138,11 @@ if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
     error_notify "${COLOR_RED}Warning: ${TARGET} is running or the name does match.${COLOR_RESET}"
 elif [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
     error_notify "${COLOR_RED}Jail: ${NEWNAME} already exist.${COLOR_RESET}"
+fi
+
+## validate jail name
+if [ -n "${NAME}" ]; then
+    validate_name
 fi
 
 change_name

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -57,8 +57,8 @@ TARGET="${1}"
 NEWNAME="${2}"
 shift
 
-if echo "${NEWNAME}" | grep -q "[.]"; then
-    echo -e "${COLOR_RED}Container names may not contain a dot(.)!${COLOR_RESET}"
+if echo "${NEWNAME}" | grep -Eq '[.]|\ '; then
+    echo -e "${COLOR_RED}Container names may not contain a dot(.) nor spaces!${COLOR_RESET}"
     exit 1
 fi
 
@@ -125,9 +125,11 @@ change_name() {
     fi
 }
 
-# Check if container is running
-if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
-    error_notify "${COLOR_RED}${TARGET} is running, See 'bastille stop'.${COLOR_RESET}"
+## check if a running jail matches name or already exist
+if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
+    error_notify "${COLOR_RED}Warning: ${TARGET} is running or the name does match.${COLOR_RESET}"
+elif [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
+    error_notify "${COLOR_RED}Jail: ${NEWNAME} already exist.${COLOR_RESET}"
 fi
 
 change_name

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -102,9 +102,16 @@ change_name() {
         if [ "${bastille_zfs_enable}" = "YES" ]; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 # Rename ZFS dataset and mount points accordingly
-                zfs rename "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NEWNAME}"
-                if [ "$?" -ne 0 ]; then
-                    error_notify "${COLOR_RED}Error: Can't rename zfs dataset.${COLOR_RESET}"
+                if zfs list | grep -qw "${bastille_zfs_prefix}/jails/${TARGET}$"; then
+                    zfs rename "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NEWNAME}"
+                    if [ "$?" -ne 0 ]; then
+                        error_notify "${COLOR_RED}Error: Can't rename zfs dataset.${COLOR_RESET}"
+                    fi
+                else
+                    # Just rename the jail directory
+                    if ! zfs list | grep -qw "jails/${TARGET}$"; then
+                        mv "${bastille_jailsdir}/${TARGET}" "${bastille_jailsdir}/${NEWNAME}"
+                    fi
                 fi
             fi
         else


### PR DESCRIPTION
This feature adds ability to create empty jails.

This are ideal for custom homegrown builds, experimenting with unsupported release types, or experimenting with Linux jails.

**Usage:**
`bastille create -E folsom`

Alternative options: [--empty|empty]

Regards