### PR TITLE
Add mount and umount commands to manage volumes inside containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Available Commands:
   import      Import a container archive or image.
   limits      Apply resources limits to targeted container(s). See rctl(8).
   list        List containers, releases, templates, logs, limits or backups.
+  mount       Mount a volume inside the targeted container(s).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   rdr         Redirect host port to container port.
   restart     Restart a running container.
@@ -67,6 +68,7 @@ Available Commands:
   sysrc       Safely edit rc files within targeted container(s).
   template    Apply automation templates to targeted container(s).
   top         Display and update information about the top(1) cpu processes.
+  umount      Unmount a volume from within the targeted container(s).
   update      Update container base -pX release.
   upgrade     Upgrade container release to X.Y-RELEASE.
   verify      Verify bootstrapped release or automation template.
@@ -933,10 +935,36 @@ bastille clone
 Please be aware that no host specific keys or hashes will be regenerated.
 E. g. remove OpenSSH host keys to avoid duplicate host keys `rm /etc/ssh/ssh_host_*`
 
-Usage: `bastille clone [TARGET] [NEWJAIL] [NEW_IPADRRESS]
+Usage: `bastille clone [TARGET] [NEWJAIL] [NEW_IPADRRESS]`
 
 ```shell
 ishmael ~ # bastille clone sourcejail targetjail 10.17.89.11
+```
+
+bastille mount
+---------------
+`bastille mount` will nullfs mount a path from the host inside the container.
+Uses the same format as an fstab entry.
+Filesystem type, options, dump, and pass number are optional and default to: nullfs ro 0 0
+
+Usage: `bastille mount [TARGET] [HOST_PATH] [CONTAINER_PATH] [FILESYSTEM_TYPE] [OPTIONS] [DUMP] [PASS_NUMBER]`
+
+```shell
+ishmael ~ # bastille mount targetjail /host/path container/path
+[targetjail]:
+Added: /host/path container/path nullfs ro 0 0
+```
+
+bastille umount
+---------------
+`bastille umount` will unmount a volume from inside the container.
+
+Usage: `bastille umount [TARGET] [CONTAINER_PATH]`
+
+```shell
+ishmael ~ # bastille umount targetjail container/path
+[targetjail]:
+Unmounted: container/path
 ```
 
 Example (create, start, console)

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -100,6 +100,7 @@ Available Commands:
   htop        Interactive process viewer (requires htop).
   import      Import a specified container.
   list        List containers (running and stopped).
+  mount       Mount a volume inside the targeted container(s).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   rdr         Redirect host port to container port.
   rename      Rename a container.
@@ -110,6 +111,7 @@ Available Commands:
   sysrc       Safely edit rc files within targeted container(s).
   template    Apply file templates to targeted container(s).
   top         Display and update information about the top(1) cpu processes.
+  umount      Unmount a volume from within the targeted container(s).
   update      Update container base -pX release.
   upgrade     Upgrade container release to X.Y-RELEASE.
   verify      Compare release against a "known good" index.
@@ -142,9 +144,9 @@ esac
 case "${CMD}" in
 bootstrap|clone|cmd|console|convert|cp|create)
     ;;
-destroy|edit|export|htop|import|limits|list)
+destroy|edit|export|htop|import|limits|list|mount)
     ;;
-pkg|rdr|rename|restart|service|start|stop|sysrc)
+pkg|rdr|rename|restart|service|start|stop|sysrc|umount)
     ;;
 template|top|update|upgrade|verify|zfs)
     ;;

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    echo -e "${COLOR_RED}Usage: bastille mount TARGET host_path container_path [filesystem_type options dump pass_number]${COLOR_RESET}"
+    exit 1
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+TARGET=$1
+shift
+
+if [ "${TARGET}" = 'ALL' ]; then
+    JAILS=$(jls name)
+else
+    JAILS=$(jls name | awk "/^${TARGET}$/")
+fi
+
+if [ $# -eq 2 ]; then
+    _fstab="$@ nullfs ro 0 0"
+else
+    _fstab="$@"
+fi
+
+## assign needed variables
+_hostpath=$(echo "${_fstab}" | awk '{print $1}')
+_jailpath=$(echo "${_fstab}" | awk '{print $2}')
+_type=$(echo "${_fstab}" | awk '{print $3}')
+_perms=$(echo "${_fstab}" | awk '{print $4}')
+_checks=$(echo "${_fstab}" | awk '{print $5" "$6}')
+
+## if any variables are empty, bail out
+if [ -z "${_hostpath}" ] || [ -z "${_jailpath}" ] || [ -z "${_type}" ] || [ -z "${_perms}" ] || [ -z "${_checks}" ]; then
+    echo -e "${COLOR_RED}FSTAB format not recognized.${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    exit 1
+fi
+
+## if host path doesn't exist or type is not "nullfs"
+if [ ! -d "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
+    echo -e "${COLOR_RED}Detected invalid host path or incorrect mount type in FSTAB.${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    exit 1
+fi
+
+## if mount permissions are not "ro" or "rw"
+if [ "${_perms}" != "ro" ] && [ "${_perms}" != "rw" ]; then
+    echo -e "${COLOR_RED}Detected invalid mount permissions in FSTAB.${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    exit 1
+fi
+
+## if check & pass are not "0 0 - 1 1"; bail out
+if [ "${_checks}" != "0 0" ] && [ "${_checks}" != "1 0" ] && [ "${_checks}" != "0 1" ] && [ "${_checks}" != "1 1" ]; then
+    echo -e "${COLOR_RED}Detected invalid fstab options in FSTAB.${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
+    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    exit 1
+fi
+
+for _jail in ${JAILS}; do
+    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+
+    ## aggregate variables into FSTAB entry
+    _fstab_entry="${_hostpath} ${bastille_jailsdir}/${_jail}/root/${_jailpath} ${_type} ${_perms} ${_checks}"
+
+    ## Create mount point if it does not exist. -- cwells
+    if [ ! -d "${bastille_jailsdir}/${_jail}/root/${_jailpath}" ]; then
+        if ! mkdir -p "${bastille_jailsdir}/${_jail}/root/${_jailpath}"; then
+            echo -e "${COLOR_RED}Failed to create mount point inside jail.${COLOR_RESET}"
+            exit 1
+        fi
+    fi
+
+    ## if entry doesn't exist, add; else show existing entry
+    if ! grep -q "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
+        if ! echo "${_fstab_entry}" >> "${bastille_jailsdir}/${_jail}/fstab"; then
+            echo -e "${COLOR_RED}Failed to create fstab entry: ${_fstab_entry}${COLOR_RESET}"
+            exit 1
+        fi
+        echo "Added: ${_fstab_entry}"
+    else
+        grep "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab"
+    fi
+    mount -F "${bastille_jailsdir}/${_jail}/fstab" -a
+    echo
+done

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    echo -e "${COLOR_RED}Usage: bastille umount TARGET container_path${COLOR_RESET}"
+    exit 1
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -ne 2 ]; then
+    usage
+fi
+
+TARGET=$1
+shift
+
+MOUNT_PATH=$1
+shift
+
+if [ "${TARGET}" = 'ALL' ]; then
+    JAILS=$(jls name)
+else
+    JAILS=$(jls name | awk "/^${TARGET}$/")
+fi
+
+for _jail in ${JAILS}; do
+    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+
+    _jailpath="${bastille_jailsdir}/${_jail}/root/${MOUNT_PATH}"
+
+    if [ ! -d "${_jailpath}" ]; then
+        echo -e "${COLOR_RED}The specified mount point does not exist inside the jail.${COLOR_RESET}"
+        exit 1
+    fi
+
+    # Unmount the volume. -- cwells
+    if ! umount "${_jailpath}"; then
+        echo -e "${COLOR_RED}Failed to unmount volume: ${MOUNT_PATH}${COLOR_RESET}"
+        exit 1
+    fi
+
+    # Remove the entry from fstab so it is not automounted in the future. -- cwells
+    if ! sed -E -i '' "\, +${_jailpath} +,d" "${bastille_jailsdir}/${_jail}/fstab"; then
+        echo -e "${COLOR_RED}Failed to delete fstab entry: ${_fstab_entry}${COLOR_RESET}"
+        exit 1
+    fi
+
+    echo "Unmounted: ${MOUNT_PATH}"
+    echo
+done


### PR DESCRIPTION
The `mount` code is basically copy/paste from the FSTAB code inside the `template` command. I created `umount` as well because it just made sense to have it.  This functionality was needed in order for my next pull request to have feature parity with existing code.

I also fixed a small typo in the README (missing backtick). I hope it's ok for that to go into the same commit.