### PR TITLE
Deduplicate template fstab entries using their full paths.

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -105,7 +105,8 @@ for _jail in ${JAILS}; do
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
 
     ## aggregate variables into FSTAB entry
-    _fstab_entry="${_hostpath} ${bastille_jailsdir}/${_jail}/root/${_jailpath} ${_type} ${_perms} ${_checks}"
+    _jailpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"
+    _fstab_entry="${_hostpath} ${_jailpath} ${_type} ${_perms} ${_checks}"
 
     ## Create mount point if it does not exist. -- cwells
     if [ ! -d "${bastille_jailsdir}/${_jail}/root/${_jailpath}" ]; then
@@ -116,14 +117,14 @@ for _jail in ${JAILS}; do
     fi
 
     ## if entry doesn't exist, add; else show existing entry
-    if ! grep -q "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
+    if ! egrep -q "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
         if ! echo "${_fstab_entry}" >> "${bastille_jailsdir}/${_jail}/fstab"; then
             echo -e "${COLOR_RED}Failed to create fstab entry: ${_fstab_entry}${COLOR_RESET}"
             exit 1
         fi
         echo "Added: ${_fstab_entry}"
     else
-        grep "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab"
+        egrep "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
     fi
     mount -F "${bastille_jailsdir}/${_jail}/fstab" -a
     echo

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -243,14 +243,15 @@ for _jail in ${JAILS}; do
             fi
 
             ## aggregate variables into FSTAB entry
-            _fstab_entry="${_hostpath} ${bastille_jailsdir}/${_jail}/root/${_jailpath} ${_type} ${_perms} ${_checks}"
+            _jailpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"
+            _fstab_entry="${_hostpath} ${_jailpath} ${_type} ${_perms} ${_checks}"
 
             ## if entry doesn't exist, add; else show existing entry
-            if ! grep -q "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab"; then
+            if ! egrep -q "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"; then
                 echo "${_fstab_entry}" >> "${bastille_jailsdir}/${_jail}/fstab"
                 echo "Added: ${_fstab_entry}"
             else
-                grep "${_jailpath}" "${bastille_jailsdir}/${_jail}/fstab"
+                egrep "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
             fi
         done < "${bastille_template}/FSTAB"
         mount -F "${bastille_jailsdir}/${_jail}/fstab" -a


### PR DESCRIPTION
This allows a fstab entry that happens to be a substring of the
jail path (or that of an existing entry) to be added correctly.