### PR TITLE
Force unmount any filesystems before jail rename, error handling

### DIFF
--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -96,6 +96,8 @@ destroy_jail() {
 }
 
 destroy_rel() {
+    local OPTIONS
+
     ## check release name match before destroy
     if [ -n "${NAME_VERIFY}" ]; then
         TARGET="${NAME_VERIFY}"
@@ -125,10 +127,16 @@ destroy_rel() {
             echo -e "${COLOR_GREEN}Deleting base: ${TARGET}.${COLOR_RESET}"
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
-                    zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${TARGET}"
-                    if [ "${FORCE}" = "1" ]; then
-                        if [ -d "${bastille_cachedir}/${TARGET}" ]; then
-                            zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${TARGET}"
+                    if [ -n "${TARGET}" ]; then
+                        OPTIONS="-r"
+                        if [ "${FORCE}" = "1" ]; then
+                            OPTIONS="-rf"
+                        fi
+                        zfs destroy "${OPTIONS}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${TARGET}"
+                        if [ "${FORCE}" = "1" ]; then
+                            if [ -d "${bastille_cachedir}/${TARGET}" ]; then
+                                zfs destroy "${OPTIONS}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${TARGET}"
+                            fi
                         fi
                     fi
                 fi

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -104,7 +104,9 @@ change_name() {
                 # Check and rename container ZFS dataset accordingly
                 # Perform additional checks in case of non-zfs existing containers
                 if zfs list | grep -qw "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}"; then
-                    zfs rename "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NEWNAME}"
+                    if ! zfs rename -f "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NEWNAME}"; then
+                        error_notify "${COLOR_RED}Can't rename '${TARGET}' dataset.${COLOR_RESET}"
+                    fi
                 else
                     # Check and rename container directory instead
                     if ! zfs list | grep -qw "jails/${TARGET}$"; then
@@ -119,7 +121,9 @@ change_name() {
                 ZFS_DATASET_ORIGIN=$(zfs list | grep -w "jails/${TARGET}$" | awk '{print $1}')
                 ZFS_DATASET_TARGET=$(echo "${ZFS_DATASET_ORIGIN}" | sed "s|\/${TARGET}||")
                 if [ -n "${ZFS_DATASET_ORIGIN}" ] && [ -n "${ZFS_DATASET_TARGET}" ]; then
-                    zfs rename "${ZFS_DATASET_ORIGIN}" "${ZFS_DATASET_TARGET}/${NEWNAME}"
+                    if ! zfs rename -f "${ZFS_DATASET_ORIGIN}" "${ZFS_DATASET_TARGET}/${NEWNAME}"; then
+                        error_notify "${COLOR_RED}Can't rename '${TARGET}' dataset.${COLOR_RESET}"
+                    fi
                 else
                     error_notify "${COLOR_RED}Can't determine the zfs origin path of '${TARGET}'.${COLOR_RESET}"
                 fi


### PR DESCRIPTION
Let ZFS try to force unmount for any filesystems before jail rename attempt, more error handling.
Regards