### PR TITLE
update bastille log path

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -7,9 +7,9 @@ bastille_prefix="/usr/local/bastille"                                 ## default
 bastille_backupsdir="${bastille_prefix}/backups"                      ## default: "${bastille_prefix}/backups"
 bastille_cachedir="${bastille_prefix}/cache"                          ## default: "${bastille_prefix}/cache"
 bastille_jailsdir="${bastille_prefix}/jails"                          ## default: "${bastille_prefix}/jails"
-bastille_logsdir="${bastille_prefix}/logs"                            ## default: "${bastille_prefix}/logs"
 bastille_releasesdir="${bastille_prefix}/releases"                    ## default: "${bastille_prefix}/releases"
 bastille_templatesdir="${bastille_prefix}/templates"                  ## default: "${bastille_prefix}/templates"
+bastille_logsdir="/var/log/bastille"                                  ## default: "/var/log/bastille"
 
 ## bastille scripts directory (assumed by bastille pkg)
 bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"


### PR DESCRIPTION
Updates `bastille_logsdir` to `/var/log/bastille`