### PR TITLE
Initial alternate architecture fetch/create support

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -172,4 +172,5 @@ if [ -f "${SCRIPTPATH}" ]; then
 else
     bastille_colors_pre
     echo -e "${COLOR_RED}${SCRIPTPATH} not found.${COLOR_RESET}" 1>&2
+    exit 1
 fi

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -140,7 +140,7 @@ update_fstab() {
     # Update fstab to use the new name
     FSTAB_CONFIG="${bastille_jailsdir}/${NEWNAME}/fstab"
     if [ -f "${FSTAB_CONFIG}" ]; then
-        FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${FSTAB_CONFIG}")
+        FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${FSTAB_CONFIG}")
         FSTAB_CURRENT=$(grep -w ".*/releases/.*/jails/${TARGET}/root/.bastille" "${FSTAB_CONFIG}")
         FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${NEWNAME}/root/.bastille nullfs ro 0 0"
         if [ -n "${FSTAB_CURRENT}" ] && [ -n "${FSTAB_NEWCONF}" ]; then

--- a/usr/local/share/bastille/convert.sh
+++ b/usr/local/share/bastille/convert.sh
@@ -115,7 +115,7 @@ start_convert() {
         echo -e "${COLOR_GREEN}Converting '${TARGET}' into a thickjail, this may take a while...${COLOR_RESET}"
 
         # Set some variables
-        RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${bastille_jailsdir}/${TARGET}/fstab")
+        RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${bastille_jailsdir}/${TARGET}/fstab")
         FSTABMOD=$(grep -w "${bastille_releasesdir}/${RELEASE} ${bastille_jailsdir}/${TARGET}/root/.bastille" "${bastille_jailsdir}/${TARGET}/fstab")
         SYMLINKS="bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/ports usr/sbin usr/share usr/src"
 

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -61,11 +61,13 @@ fi
 for _jail in ${JAILS}; do
     bastille_jail_path="$(jls -j "${_jail}" path)"
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
-    # Add line break and return status
-    if cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"; then
-        echo
+    cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"
+    RETURN="$?"
+    if [ "${TARGET}" = "ALL" ]; then
+        # Display the return status for reference
+        echo -e "Returned: ${RETURN}\n"
     else
         echo
-        false
+        return "${RETURN}"
     fi
 done

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -61,6 +61,11 @@ fi
 for _jail in ${JAILS}; do
     bastille_jail_path="$(jls -j "${_jail}" path)"
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
-    cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"
-    echo
+    # Add line break and return status
+    if cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"; then
+        echo
+    else
+        echo
+        false
+    fi
 done

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -458,9 +458,9 @@ fi
 if [ -z "${EMPTY_JAIL}" ]; then
     ## verify release
     case "${RELEASE}" in
-    *-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
+    *-RELEASE|*-RELEASE-I386|*-RELEASE-i386|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
         ## check for FreeBSD releases name
-        NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
+        NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])$' | tr '[:lower:]' '[:upper:]' | sed 's/I/i/g')
         validate_release
         ;;
     *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -388,6 +388,14 @@ create_jail() {
         ## Generate minimal configuration for empty jail
         generate_minimal_conf
     fi
+
+    # Post-creation jail misc configuration
+    # Creates a dummy fstab file
+    # Disables adjkerntz, avoids spurious error messages
+    # Set strict permissions on the jail by default
+    touch "etc/fstab"
+    sed -i '' 's|[0-9],[0-9]\{2\}.*[0-9]-[0-9].*root.*kerntz -a|#& # Disabled by bastille|' "etc/crontab"
+    chmod 0700 "${bastille_jailsdir}/${NAME}"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -193,9 +193,9 @@ fi
 
 ## check what should we clean
 case "${TARGET}" in
-*-RELEASE|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
+*-RELEASE|*-RELEASE-I386|*-RELEASE-i386|*-release|*-RC1|*-rc1|*-RC2|*-rc2)
     ## check for FreeBSD releases name
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])$' | tr '[:lower:]' '[:upper:]')
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])$' | tr '[:lower:]' '[:upper:]' | sed 's/I/i/g')
     destroy_rel
     ;;
 *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -120,7 +120,7 @@ update_fstab() {
     # Update fstab .bastille mountpoint on thin containers only
     # Set some variables
     FSTAB_CONFIG="${bastille_jailsdir}/${TARGET_TRIM}/fstab"
-    FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${FSTAB_CONFIG}")
+    FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${FSTAB_CONFIG}")
     FSTAB_CURRENT=$(grep -w ".*/releases/.*/jails/${TARGET_TRIM}/root/.bastille" "${FSTAB_CONFIG}")
     FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${TARGET_TRIM}/root/.bastille nullfs ro 0 0"
     if [ -n "${FSTAB_CURRENT}" ] && [ -n "${FSTAB_NEWCONF}" ]; then


### PR DESCRIPTION
This PR adds Initial architecture fetch/create support as an **experimental** new feature, only 32-Bit(i386) is supported.

**Usage examples:**

**Bootstrap an alternate release/arch(--i386|--32bit):**
```
root@nas-mserver: ~# bastille bootstrap 12.1-RELEASE --i386
Bootstrapping FreeBSD distfiles...
/mnt/storage/bastille/cache/12.1-RELEASE-i386/MANIFEST         782  B 5920 kBps    00s
/mnt/storage/bastille/cache/12.1-RELEASE-i386/base.txz         142 MB  476 kBps 05m06s
Validated checksum for 12.1-RELEASE-i386:base.txz.
MANIFEST:4c978fb0d9c4f65e0089718f0e905fd5a8c2651582de050df6b7f49a8481a169
DOWNLOAD:4c978fb0d9c4f65e0089718f0e905fd5a8c2651582de050df6b7f49a8481a169
Extracting FreeBSD 12.1-RELEASE-i386 base.txz.

Bootstrap successful.
See 'bastille --help' for available commands.
```

**Create a jail from an alternate release/arch:**
```
root@nas-mserver: ~# bastille create folsom 12.1-RELEASE-i386 10.0.0.10 em0
Valid: (10.0.0.10).
Valid: (em0).

NAME: folsom.
IP: 10.0.0.10.
INTERFACE: em0.
RELEASE: 12.1-RELEASE-i386.

syslogd_flags: -s -> -ss
sendmail_enable: NO -> NO
sendmail_submit_enable: YES -> NO
sendmail_outbound_enable: YES -> NO
sendmail_msp_queue_enable: YES -> NO
cron_flags:  -> -J 60
```

**Destroy an alternate release/arch:**
```
root@nas-mserver: ~# bastille destroy 12.1-RELEASE-i386
Deleting base: 12.1-RELEASE-i386.
```

Regards
