### PR TITLE
Fixed the overlay command in Bastillefile

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -132,7 +132,8 @@ for _jail in ${JAILS}; do
                     # Allow redirection within the jail. -- cwells
                     _args="sh -c '${_args}'"
                     ;;
-                cp)
+                overlay)
+                    _cmd='cp'
                     # Convert relative "from" path into absolute path inside the template directory. -- cwells
                     if [ "${_args%${_args#?}}" != '/' ]; then
                         _args="${bastille_template}/${_args}"

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -134,6 +134,9 @@ for _jail in ${JAILS}; do
                     ;;
                 overlay)
                     _cmd='cp'
+                    _args="${bastille_template}/${_args} /"
+                    ;;
+                cp|copy)
                     # Convert relative "from" path into absolute path inside the template directory. -- cwells
                     if [ "${_args%${_args#?}}" != '/' ]; then
                         _args="${bastille_template}/${_args}"


### PR DESCRIPTION
The documentation did mention that `OVERLAY` should be used, but only `cp` was implemented.
Also the destination part where to copy the files to has been missing. 

The previous hooks seem to implement it in a similar way: https://github.com/BastilleBSD/bastille/blob/master/usr/local/share/bastille/template.sh#L175