### PR TITLE
Added fstab alias to mount command in Bastillefiles.

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -138,6 +138,8 @@ for _jail in ${JAILS}; do
                         _args="${bastille_template}/${_args}"
                     fi
                     ;;
+                fstab|mount)
+                    _cmd='mount' ;;
                 include)
                     _cmd='template' ;;
                 pkg)


### PR DESCRIPTION
The documentation states that `fstab` should be used inside `Bastillefile`s. I updated the code to reflect this wording.