### PR TITLE
Map COPY alias in Bastillefile to use cp subcommand

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -137,6 +137,7 @@ for _jail in ${JAILS}; do
                     _args="${bastille_template}/${_args} /"
                     ;;
                 cp|copy)
+                    _cmd='cp'
                     # Convert relative "from" path into absolute path inside the template directory. -- cwells
                     if [ "${_args%${_args#?}}" != '/' ]; then
                         _args="${bastille_template}/${_args}"


### PR DESCRIPTION
This updates the subcommand to be `cp` when the `COPY` alias is used in a Bastillefile. Otherwise, it will try to run `bastille copy`, which does not exist.