### PR TITLE
Require target to be running for specific commands

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -133,20 +133,48 @@ version|-v|--version)
 help|-h|--help)
     usage
     ;;
-esac
+bootstrap|create|destroy|import|list|rdr|restart|start|update|upgrade|verify)
+    # Nothing "extra" to do for these commands. -- cwells
+    ;;
+clone|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)
+    # Parse the target and ensure it exists. -- cwells
+    if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
+        PARAMS='help'
+    elif [ "${1}" != 'help' ] && [ "${1}" != '-h' ] && [ "${1}" != '--help' ]; then
+        TARGET="${1}"
+        shift
 
-# Filter out all non-commands
-case "${CMD}" in
-bootstrap|clone|cmd|console|convert|cp|create)
+        if [ "${TARGET}" = 'ALL' ]; then
+            JAILS=$(jls name)
+        else
+            JAILS=$(jls name | awk "/^${TARGET}$/")
+
+            # Ensure the target exists. -- cwells
+            if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+                error_exit "[${TARGET}]: Not found."
+            fi
+
+            case "${CMD}" in
+            cmd|console|htop|pkg|service|stop|sysrc|template|top)
+                # Require the target to be running. -- cwells
+                if [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
+                    error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
+                fi
+                ;;
+            convert|rename)
+                # Require the target to be stopped. -- cwells
+                if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
+                    error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
+                fi
+                ;;
+            esac
+        fi
+        export TARGET
+        export JAILS
+    fi
     ;;
-destroy|edit|export|htop|import|limits|list|mount)
-    ;;
-pkg|rdr|rename|restart|service|start|stop|sysrc|umount)
-    ;;
-template|top|update|upgrade|verify|zfs)
-    ;;
-*)
-usage
+*) # Filter out all non-commands
+    usage
     ;;
 esac
 
@@ -157,7 +185,11 @@ if [ -f "${SCRIPTPATH}" ]; then
 
     : "${SH:=sh}"
 
-    exec "${SH}" "${SCRIPTPATH}" "$@"
+    if [ -n "${PARAMS}" ]; then
+        exec "${SH}" "${SCRIPTPATH}" "${PARAMS}"
+    else
+        exec "${SH}" "${SCRIPTPATH}" "$@"
+    fi
 else
     error_exit "${SCRIPTPATH} not found."
 fi

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -30,19 +30,14 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-bastille_colors_pre() {
-    ## so we can make it colorful
-    . /usr/local/share/bastille/colors.pre.sh
-}
+. /usr/local/share/bastille/common.sh
 
 ## root check first.
 bastille_root_check() {
     if [ "$(id -u)" -ne 0 ]; then
-        bastille_colors_pre
         ## permission denied
-        echo -e "${COLOR_RED}Bastille: Permission Denied${COLOR_RESET}" 1>&2
-        echo -e "${COLOR_RED}root / sudo / doas required${COLOR_RESET}" 1>&2
-        exit 1
+        error_notify "Bastille: Permission Denied"
+        error_exit "root / sudo / doas required"
     fi
 }
 
@@ -51,9 +46,7 @@ bastille_root_check
 ## check for config existance
 bastille_conf_check() {
     if [ ! -r "/usr/local/etc/bastille/bastille.conf" ]; then
-        bastille_colors_pre
-        echo -e "${COLOR_RED}Missing Configuration${COLOR_RESET}" 1>&2
-        exit 1
+        error_exit "Missing Configuration"
     fi
 }
 
@@ -68,11 +61,8 @@ bastille_perms_check() {
     if [ -d "${bastille_prefix}" ]; then
         BASTILLE_PREFIX_PERMS=$(stat -f "%Op" "${bastille_prefix}")
         if [ "${BASTILLE_PREFIX_PERMS}" != 40750 ]; then
-            bastille_colors_pre
-            echo -e "${COLOR_RED}Insecure permissions on ${bastille_prefix}${COLOR_RESET}" 1>&2
-            echo -e "${COLOR_RED}Try: chmod 0750 ${bastille_prefix}${COLOR_RESET}" 1>&2
-            echo
-            exit 1
+            error_notify "Insecure permissions on ${bastille_prefix}"
+            error_exit "Try: chmod 0750 ${bastille_prefix}"
         fi
     fi
 }
@@ -137,7 +127,6 @@ shift
 # Handle special-case commands first.
 case "${CMD}" in
 version|-v|--version)
-    bastille_colors_pre
     echo -e "${COLOR_GREEN}${BASTILLE_VERSION}${COLOR_RESET}"
     exit 0
     ;;
@@ -170,7 +159,5 @@ if [ -f "${SCRIPTPATH}" ]; then
 
     exec "${SH}" "${SCRIPTPATH}" "$@"
 else
-    bastille_colors_pre
-    echo -e "${COLOR_RED}${SCRIPTPATH} not found.${COLOR_RESET}" 1>&2
-    exit 1
+    error_exit "${SCRIPTPATH} not found."
 fi

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -28,17 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
-usage() {
-    echo -e "${COLOR_RED}Usage: bastille clone [TARGET] [NEW_NAME] [IPADRESS].${COLOR_RESET}"
-    exit 1
-}
 
-error_notify() {
-    # Notify message on error and exit
-    echo -e "$*" >&2
-    exit 1
+usage() {
+    error_exit "Usage: bastille clone [TARGET] [NEW_NAME] [IPADRESS]"
 }
 
 # Handle special-case commands first
@@ -73,8 +67,7 @@ validate_ip() {
             set ${TEST_IP}
             for quad in 1 2 3 4; do
                 if eval [ \$$quad -gt 255 ]; then
-                    echo "Invalid: (${TEST_IP})"
-                    exit 1
+                    error_exit "Invalid: (${TEST_IP})"
                 fi
             done
             if ifconfig | grep -qw "${TEST_IP}"; then
@@ -83,8 +76,7 @@ validate_ip() {
                 echo -e "${COLOR_GREEN}Valid: (${IP}).${COLOR_RESET}"
             fi
         else
-            echo -e "${COLOR_RED}Invalid: (${IP}).${COLOR_RESET}"
-            exit 1
+            error_exit "Invalid: (${IP})."
         fi
     fi
 }
@@ -176,17 +168,17 @@ clone_jail() {
                 # Just clone the jail directory
                 # Check if container is running
                 if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
-                    error_notify "${COLOR_RED}${TARGET} is running, See 'bastille stop ${TARGET}'.${COLOR_RESET}"
+                    error_exit "${TARGET} is running, See 'bastille stop ${TARGET}'."
                 fi
 
                 # Perform container file copy(archive mode)
                 cp -a "${bastille_jailsdir}/${TARGET}" "${bastille_jailsdir}/${NEWNAME}"
             fi
         else
-            error_notify "${COLOR_RED}${NEWNAME} already exists.${COLOR_RESET}"
+            error_exit "${NEWNAME} already exists."
         fi
     else
-        error_notify "${COLOR_RED}${TARGET} not found. See bootstrap.${COLOR_RESET}"
+        error_exit "${TARGET} not found. See bootstrap."
     fi
 
     # Generate jail configuration files
@@ -195,7 +187,7 @@ clone_jail() {
 
     # Display the exist status
     if [ "$?" -ne 0 ]; then
-        error_notify "${COLOR_RED}An error has occurred while attempting to clone '${TARGET}'.${COLOR_RESET}"
+        error_exit "An error has occurred while attempting to clone '${TARGET}'."
     else
         echo -e "${COLOR_GREEN}Cloned '${TARGET}' to '${NEWNAME}' successfully.${COLOR_RESET}"
     fi
@@ -203,8 +195,7 @@ clone_jail() {
 
 ## don't allow for dots(.) in container names
 if echo "${NEWNAME}" | grep -q "[.]"; then
-    echo -e "${COLOR_RED}Container names may not contain a dot(.)!${COLOR_RESET}"
-    exit 1
+    error_exit "Container names may not contain a dot(.)!"
 fi
 
 ## check if ip address is valid

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -41,18 +41,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -lt 2 ]; then
+if [ $# -eq 0 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -28,11 +28,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille cmd TARGET command.${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille cmd TARGET command"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -28,35 +28,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/colors.pre.sh
 
-usage() {
-    error_exit "Usage: bastille pkg TARGET command [args]"
+# Notify message on error, but do not exit
+error_notify() {
+    echo -e "${COLOR_RED}$*${COLOR_RESET}" 1>&2
 }
 
-# Handle special-case commands first.
-case "$1" in
-help|-h|--help)
-    usage
-    ;;
-esac
-
-if [ $# -lt 2 ]; then
-    usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
-
-for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
-    jexec -l "${_jail}" /usr/sbin/pkg "$@"
-    echo
-done
+# Notify message on error and exit
+error_exit() {
+    error_notify $@
+    exit 1
+}

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -31,7 +31,7 @@
 . /usr/local/share/bastille/common.sh
 
 usage() {
-    error_exit "Usage: bastille console TARGET [user]'."
+    error_exit "Usage: bastille console TARGET [user]'"
 }
 
 # Handle special-case commands first.
@@ -41,20 +41,11 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 2 ] || [ $# -lt 1 ]; then
+if [ $# -gt 1 ]; then
     usage
 fi
 
-TARGET="${1}"
-shift
 USER="${1}"
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
 
 validate_user() {
     if jexec -l "${_jail}" id "${USER}" >/dev/null 2>&1; then

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -28,11 +28,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille console TARGET [user]'.${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille console TARGET [user]'."
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/convert.sh
+++ b/usr/local/share/bastille/convert.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille convert TARGET."
+    error_exit "Usage: bastille convert TARGET"
 }
 
 # Handle special-case commands first.
@@ -42,12 +42,9 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+if [ $# -ne 0 ]; then
     usage
 fi
-
-TARGET="${1}"
-shift
 
 convert_symlinks() {
     # Work with the symlinks, revert on first cp error
@@ -130,11 +127,6 @@ start_convert() {
         error_exit "${TARGET} not found. See 'bastille create'."
     fi
 }
-
-# Check if container is running
-if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
-    error_exit "${TARGET} is running. See 'bastille stop'."
-fi
 
 # Check if is a thin container
 if [ ! -d "${bastille_jailsdir}/${TARGET}/root/.bastille" ]; then

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -42,20 +42,12 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 3 ] || [ $# -lt 3 ]; then
+if [ $# -ne 2 ]; then
     usage
 fi
 
-TARGET="${1}"
-CPSOURCE="${2}"
-CPDEST="${3}"
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
+CPSOURCE="${1}"
+CPDEST="${2}"
 
 for _jail in ${JAILS}; do
     bastille_jail_path="$(jls -j "${_jail}" path)"

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille cp TARGET HOST_PATH CONTAINER_PATH${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille cp TARGET HOST_PATH CONTAINER_PATH"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -28,25 +28,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille create [option] name release ip [interface].${COLOR_RESET}"
-    exit 1
-}
-
-error_notify() {
-    # Notify message on error and exit
-    echo -e "$*" >&2
-    exit 1
+    error_exit "Usage: bastille create [option] name release ip [interface]"
 }
 
 running_jail() {
     if [ -n "$(jls name | awk "/^${NAME}$/")" ]; then
-        error_notify "${COLOR_RED}A running jail matches name.${COLOR_RESET}"
+        error_exit "A running jail matches name."
     elif [ -d "${bastille_jailsdir}/${NAME}" ]; then
-        error_notify "${COLOR_RED}Jail: ${NAME} already created.${COLOR_RESET}"
+        error_exit "Jail: ${NAME} already created."
     fi
 }
 
@@ -54,7 +47,7 @@ validate_name() {
     local NAME_VERIFY=${NAME}
     local NAME_SANITY=$(echo "${NAME_VERIFY}" | tr -c -d 'a-zA-Z0-9-_')
     if [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
-        error_notify "${COLOR_RED}Container names may not contain special characters!${COLOR_RESET}"
+        error_exit "Container names may not contain special characters!"
     fi
 }
 
@@ -84,7 +77,7 @@ validate_ip() {
                 echo -e "${COLOR_GREEN}Valid: (${IP}).${COLOR_RESET}"
             fi
         else
-            error_notify "${COLOR_RED}Invalid: (${IP}).${COLOR_RESET}"
+            error_exit "Invalid: (${IP})."
         fi
     fi
 }
@@ -94,13 +87,13 @@ validate_netif() {
     if echo "${LIST_INTERFACES} VNET" | grep -qwo "${INTERFACE}"; then
         echo -e "${COLOR_GREEN}Valid: (${INTERFACE}).${COLOR_RESET}"
     else
-        error_notify "${COLOR_RED}Invalid: (${INTERFACE}).${COLOR_RESET}"
+        error_exit "Invalid: (${INTERFACE})."
     fi
 }
 
 validate_netconf() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
-        error_notify "${COLOR_RED}Invalid network configuration.${COLOR_RESET}"
+        error_exit "Invalid network configuration."
     fi
 }
 
@@ -280,7 +273,7 @@ create_jail() {
                     if [ "$?" -ne 0 ]; then
                         ## notify and clean stale files/directories
                         bastille destroy "${NAME}"
-                        error_notify "${COLOR_RED}Failed to copy release files, please retry create!${COLOR_RESET}"
+                        error_exit "Failed to copy release files. Please retry create!"
                     fi
                 fi
             done
@@ -310,7 +303,7 @@ create_jail() {
                     if [ "$?" -ne 0 ]; then
                         ## notify and clean stale files/directories
                         bastille destroy "${NAME}"
-                        error_notify "${COLOR_RED}Failed release base replication, please retry create!${COLOR_RESET}"
+                        error_exit "Failed release base replication. Please retry create!"
                     fi
                 fi
             else
@@ -319,7 +312,7 @@ create_jail() {
                 if [ "$?" -ne 0 ]; then
                     ## notify and clean stale files/directories
                     bastille destroy "${NAME}"
-                    error_notify "${COLOR_RED}Failed to copy release files, please retry create!${COLOR_RESET}"
+                    error_exit "Failed to copy release files. Please retry create!"
                 fi
             fi
         fi
@@ -437,7 +430,7 @@ else
             VNET_JAIL="1"
             ;;
         -*)
-            echo -e "${COLOR_RED}Unknown Option.${COLOR_RESET}"
+            error_notify "Unknown Option."
             usage
             ;;
     esac
@@ -502,19 +495,19 @@ if [ -z "${EMPTY_JAIL}" ]; then
         validate_release
         ;;
     *)
-        echo -e "${COLOR_RED}Unknown Release.${COLOR_RESET}"
+        error_notify "Unknown Release."
         usage
         ;;
     esac
 
     ## check for name/root/.bastille
     if [ -d "${bastille_jailsdir}/${NAME}/root/.bastille" ]; then
-        error_notify "${COLOR_RED}Jail: ${NAME} already created. ${NAME}/root/.bastille exists.${COLOR_RESET}"
+        error_exit "Jail: ${NAME} already created. ${NAME}/root/.bastille exists."
     fi
 
     ## check for required release
     if [ ! -d "${bastille_releasesdir}/${RELEASE}" ]; then
-        error_notify "${COLOR_RED}Release must be bootstrapped first; see 'bastille bootstrap'.${COLOR_RESET}"
+        error_exit "Release must be bootstrapped first; see 'bastille bootstrap'."
     fi
 
     ## check if ip address is valid

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille destroy [option] | [container|release]${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille destroy [option] | [container|release]"
 }
 
 destroy_jail() {
@@ -45,15 +44,13 @@ destroy_jail() {
         if [ "${FORCE}" = "1" ]; then
             bastille stop "${TARGET}"
         else
-            echo -e "${COLOR_RED}Jail running.${COLOR_RESET}"
-            echo -e "${COLOR_RED}See 'bastille stop ${TARGET}'.${COLOR_RESET}"
-            exit 1
+            error_notify "Jail running."
+            error_exit "See 'bastille stop ${TARGET}'."
         fi
     fi
 
     if [ ! -d "${bastille_jail_base}" ]; then
-        echo -e "${COLOR_RED}Jail not found.${COLOR_RESET}"
-        exit 1
+        error_exit "Jail not found."
     fi
 
     if [ -d "${bastille_jail_base}" ]; then
@@ -113,15 +110,14 @@ destroy_rel() {
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _jail in ${JAIL_LIST}; do
             if grep -qwo "${TARGET}" "${bastille_jailsdir}/${_jail}/fstab" 2>/dev/null; then
-                echo -e "${COLOR_RED}Notice: (${_jail}) depends on ${TARGET} base.${COLOR_RESET}"
+                error_notify "Notice: (${_jail}) depends on ${TARGET} base."
                 BASE_HASCHILD="1"
             fi
         done
     fi
 
     if [ ! -d "${bastille_rel_base}" ]; then
-        echo -e "${COLOR_RED}Release base not found.${COLOR_RESET}"
-        exit 1
+        error_exit "Release base not found."
     else
         if [ "${BASE_HASCHILD}" -eq "0" ]; then
             echo -e "${COLOR_GREEN}Deleting base: ${TARGET}.${COLOR_RESET}"
@@ -158,7 +154,7 @@ destroy_rel() {
             fi
             echo
         else
-            echo -e "${COLOR_RED}Cannot destroy base with containers child.${COLOR_RESET}"
+            error_notify "Cannot destroy base with child containers."
         fi
     fi
 }
@@ -180,7 +176,7 @@ case "${1}" in
         shift
         ;;
     -*)
-        echo -e "${COLOR_RED}Unknown Option.${COLOR_RESET}"
+        error_notify "Unknown Option."
         usage
         ;;
 esac

--- a/usr/local/share/bastille/edit.sh
+++ b/usr/local/share/bastille/edit.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille edit TARGET [filename]${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille edit TARGET [filename]"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/edit.sh
+++ b/usr/local/share/bastille/edit.sh
@@ -42,24 +42,14 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 2 ] || [ $# -lt 1 ]; then
+if [ $# -gt 1 ]; then
     usage
-fi
-
-TARGET="${1}"
-if [ $# == 2 ]; then
-    TARGET_FILENAME="${2}"
+elif [ $# -eq 1 ]; then
+    TARGET_FILENAME="${1}"
 fi
 
 if [ -z "${EDITOR}" ]; then
     EDITOR=vi
-fi
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(bastille list jails)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(bastille list jails | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille export TARGET.${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille export TARGET"
 }
 
 # Handle special-case commands first
@@ -49,13 +48,6 @@ fi
 
 TARGET="${1}"
 shift
-
-error_notify()
-{
-    # Notify message on error and exit
-    echo -e "$*" >&2
-    exit 1
-}
 
 jail_export()
 {
@@ -84,7 +76,7 @@ jail_export()
         fi
 
         if [ "$?" -ne 0 ]; then
-            error_notify "${COLOR_RED}Failed to export '${TARGET}' container.${COLOR_RESET}"
+            error_exit "Failed to export '${TARGET}' container."
         else
             # Generate container checksum file
             cd "${bastille_backupsdir}"
@@ -93,7 +85,7 @@ jail_export()
             exit 0
         fi
     else
-        error_notify "${COLOR_RED}Container '${TARGET}' does not exist.${COLOR_RESET}"
+        error_exit "Container '${TARGET}' does not exist."
     fi
 }
 
@@ -106,14 +98,14 @@ fi
 
 # Check if backups directory/dataset exist
 if [ ! -d "${bastille_backupsdir}" ]; then
-    error_notify "${COLOR_RED}Backups directory/dataset does not exist, See 'bastille bootstrap'.${COLOR_RESET}"
+    error_exit "Backups directory/dataset does not exist. See 'bastille bootstrap'."
 fi
 
 # Check if is a ZFS system
 if [ "${bastille_zfs_enable}" != "YES" ]; then
     # Check if container is running and ask for stop in UFS systems
     if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
-        error_notify "${COLOR_RED}${TARGET} is running, See 'bastille stop'.${COLOR_RESET}"
+        error_exit "${TARGET} is running. See 'bastille stop'."
     fi
 fi
 

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille htop TARGET${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille htop TARGET"
 }
 
 # Handle special-case commands first.
@@ -60,7 +59,7 @@ fi
 for _jail in ${JAILS}; do
     bastille_jail_path=$(jls -j "${_jail}" path)
     if [ ! -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
-        echo -e "${COLOR_RED}htop not found on ${_jail}.${COLOR_RESET}"
+        error_notify "htop not found on ${_jail}."
     elif [ -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
         echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
         jexec -l ${_jail} /usr/local/bin/htop

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -42,18 +42,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+if [ $# -ne 0 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -29,11 +29,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille limits TARGET option value${COLOR_RESET}"
+    error_notify "Usage: bastille limits TARGET option value"
     echo -e "Example: bastille limits JAILNAME memoryuse 1G"
     exit 1
 }

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -51,22 +51,12 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -lt 3 ]; then
+if [ $# -ne 2 ]; then
     usage
 fi
 
-TARGET="${1}"
-OPTION="${2}"
-VALUE="${3}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
+OPTION="${1}"
+VALUE="${2}"
 
 for _jail in ${JAILS}; do
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille list [-j] [release|template|(jail|container)|log|limit|(import|export|backup)].${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille list [-j] [release|template|(jail|container)|log|limit|(import|export|backup)]"
 }
 
 if [ $# -eq 0 ]; then

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -44,18 +44,7 @@ esac
 
 if [ $# -lt 2 ]; then
     usage
-fi
-
-TARGET=$1
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-else
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
-
-if [ $# -eq 2 ]; then
+elif [ $# -eq 2 ]; then
     _fstab="$@ nullfs ro 0 0"
 else
     _fstab="$@"

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -41,18 +41,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -25,12 +25,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille rdr TARGET [clear] | [list] | [tcp <host_port> <jail_port>] | [udp <host_port> <jail_port>]${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille rdr TARGET [clear] | [list] | [tcp <host_port> <jail_port>] | [udp <host_port> <jail_port>]"
 }
 
 # Handle special-case commands first.
@@ -49,35 +48,30 @@ shift
 
 # Can only redirect to single jail
 if [ "${TARGET}" = 'ALL' ]; then
-    echo -e "${COLOR_RED}Can only redirect to single jail${COLOR_RESET}"
-    exit 1
+    error_exit "Can only redirect to a single jail."
 fi
 
 # Check jail name valid
 JAIL_NAME=$(jls -j "${TARGET}" name 2>/dev/null)
 if [ -z "${JAIL_NAME}" ]; then
-    echo -e "${COLOR_RED}Jail not found: ${TARGET}${COLOR_RESET}"
-    exit 1
+    error_exit "Jail not found: ${TARGET}"
 fi
 
 # Check jail ip4 address valid
 JAIL_IP=$(jls -j "${TARGET}" ip4.addr 2>/dev/null)
 if [ -z "${JAIL_IP}" -o "${JAIL_IP}" = "-" ]; then
-    echo -e "${COLOR_RED}Jail IP not found: ${TARGET}${COLOR_RESET}"
-    exit 1
+    error_exit "Jail IP not found: ${TARGET}"
 fi
 
 # Check rdr-anchor is setup in pf.conf
 if ! (pfctl -sn | grep rdr-anchor | grep 'rdr/\*' >/dev/null); then
-    echo -e "${COLOR_RED}rdr-anchor not found in pf.conf${COLOR_RESET}"
-    exit 1
+    error_exit "rdr-anchor not found in pf.conf"
 fi
 
 # Check ext_if is setup in pf.conf
 EXT_IF=$(grep '^[[:space:]]*ext_if[[:space:]]*=' /etc/pf.conf)
 if [ -z "${JAIL_NAME}" ]; then
-    echo -e "${COLOR_RED}ext_if not defined in pf.conf${COLOR_RESET}"
-    exit 1
+    error_exit "ext_if not defined in pf.conf"
 fi
 
 while [ $# -gt 0 ]; do

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -28,11 +28,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille service TARGET service_name action${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille service TARGET service_name action"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -41,19 +41,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -lt 2 ]; then
+if [ $# -ne 2 ]; then
     usage
-fi
-
-TARGET=$1
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille start TARGET${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille start TARGET"
 }
 
 # Handle special-case commands first.
@@ -57,14 +56,14 @@ if [ "${TARGET}" != 'ALL' ]; then
     JAILS=$(bastille list jails | awk "/^${TARGET}$/")
     ## check if exist
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-        echo -e "${COLOR_RED}[${TARGET}]: Not found.${COLOR_RESET}"
+        error_exit "[${TARGET}]: Not found."
     fi
 fi
 
 for _jail in ${JAILS}; do
     ## test if running
     if [ "$(jls name | awk "/^${_jail}$/")" ]; then
-        echo -e "${COLOR_RED}[${_jail}]: Already started.${COLOR_RESET}"
+        error_notify "[${_jail}]: Already started."
 
     ## test if not running
     elif [ ! "$(jls name | awk "/^${_jail}$/")" ]; then
@@ -72,8 +71,7 @@ for _jail in ${JAILS}; do
         ip=$(grep 'ip4.addr' "${bastille_jailsdir}/${_jail}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
         if [ -n "${ip}" ]; then
             if ifconfig | grep -w "${ip}" >/dev/null; then
-                echo -e "${COLOR_RED}Error: IP address (${ip}) already in use.${COLOR_RESET}"
-                exit 1
+                error_exit "Error: IP address (${ip}) already in use."
             fi
         fi
 

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille stop TARGET${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille stop TARGET"
 }
 
 # Handle special-case commands first.
@@ -57,9 +56,9 @@ if [ "${TARGET}" != 'ALL' ]; then
     JAILS=$(jls name | awk "/^${TARGET}$/")
     ## check if exist or not running
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-        echo -e "${COLOR_RED}[${TARGET}]: Not found.${COLOR_RESET}"
+        error_exit "[${TARGET}]: Not found."
     elif [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
-        echo -e "${COLOR_RED}[${TARGET}]: Not started.${COLOR_RESET}"
+        error_exit "[${TARGET}]: Not started."
     fi
 fi
 

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -42,24 +42,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+if [ $# -ne 0 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-    ## check if exist or not running
-    if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-        error_exit "[${TARGET}]: Not found."
-    elif [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
-        error_exit "[${TARGET}]: Not started."
-    fi
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -41,19 +41,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -28,11 +28,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille sysrc TARGET args${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille sysrc TARGET args"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 bastille_usage() {
-    echo -e "${COLOR_RED}Usage: bastille template TARGET project/template.${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille template TARGET project/template"
 }
 
 # Handle special-case commands first.
@@ -66,26 +65,22 @@ case ${TEMPLATE} in
         if [ ! -d "${bastille_templatesdir}/${TEMPLATE_DIR}" ]; then
             echo -e "${COLOR_GREEN}Bootstrapping ${TEMPLATE}...${COLOR_RESET}"
             if ! bastille bootstrap "${TEMPLATE}"; then
-                echo -e "${COLOR_RED}Failed to bootstrap template: ${TEMPLATE}.${COLOR_RESET}"
-                exit 1
+                error_exit "Failed to bootstrap template: ${TEMPLATE}"
             fi
         fi
         TEMPLATE="${TEMPLATE_DIR}"
         ;;
     */*)
         if [ ! -d "${bastille_templatesdir}/${TEMPLATE}" ]; then
-            echo -e "${COLOR_RED}${TEMPLATE} not found.${COLOR_RESET}"
-            exit 1
+            error_exit "${TEMPLATE} not found."
         fi
         ;;
     *)
-        echo -e "${COLOR_RED}Template name/URL not recognized.${COLOR_RESET}"
-        exit 1
+        error_exit "Template name/URL not recognized."
 esac
 
 if [ -z "${JAILS}" ]; then
-    echo -e "${COLOR_RED}Container ${TARGET} is not running.${COLOR_RESET}"
-    exit 1
+    error_exit "Container ${TARGET} is not running."
 fi
 
 if [ -z "${HOOKS}" ]; then
@@ -151,10 +146,9 @@ for _jail in ${JAILS}; do
             esac
 
             if ! eval "bastille ${_cmd} ${_jail} ${_args}"; then
-                echo -e "${COLOR_RED}Failed to execute command: ${_cmd}${COLOR_RESET}"
                 set +f
                 unset IFS
-                exit 1
+                error_exit "Failed to execute command: ${_cmd}"
             fi
         done
         set +f

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -42,22 +42,11 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 2 ] || [ $# -lt 2 ]; then
+if [ $# -ne 1 ]; then
     bastille_usage
 fi
 
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
-
 TEMPLATE="${1}"
-shift
 
 case ${TEMPLATE} in
     http?://github.com/*/*|http?://gitlab.com/*/*)

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -41,19 +41,8 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
+if [ $# -ne 0 ]; then
     usage
-fi
-
-TARGET="${1}"
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -28,11 +28,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille top TARGET${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille top TARGET"
 }
 
 # Handle special-case commands first.

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille umount TARGET container_path${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille umount TARGET container_path"
 }
 
 # Handle special-case commands first.
@@ -65,20 +64,17 @@ for _jail in ${JAILS}; do
     _jailpath="${bastille_jailsdir}/${_jail}/root/${MOUNT_PATH}"
 
     if [ ! -d "${_jailpath}" ]; then
-        echo -e "${COLOR_RED}The specified mount point does not exist inside the jail.${COLOR_RESET}"
-        exit 1
+        error_exit "The specified mount point does not exist inside the jail."
     fi
 
     # Unmount the volume. -- cwells
     if ! umount "${_jailpath}"; then
-        echo -e "${COLOR_RED}Failed to unmount volume: ${MOUNT_PATH}${COLOR_RESET}"
-        exit 1
+        error_exit "Failed to unmount volume: ${MOUNT_PATH}"
     fi
 
     # Remove the entry from fstab so it is not automounted in the future. -- cwells
     if ! sed -E -i '' "\, +${_jailpath} +,d" "${bastille_jailsdir}/${_jail}/fstab"; then
-        echo -e "${COLOR_RED}Failed to delete fstab entry: ${_fstab_entry}${COLOR_RESET}"
-        exit 1
+        error_exit "Failed to delete fstab entry: ${_fstab_entry}"
     fi
 
     echo "Unmounted: ${MOUNT_PATH}"

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -42,21 +42,11 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -ne 2 ]; then
+if [ $# -ne 1 ]; then
     usage
 fi
 
-TARGET=$1
-shift
-
 MOUNT_PATH=$1
-shift
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-else
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
 
 for _jail in ${JAILS}; do
     echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille update [release|container].${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille update [release|container]"
 }
 
 # Handle special-case commands first.
@@ -51,8 +50,7 @@ TARGET="${1}"
 shift
 
 if freebsd-version | grep -qi HBSD; then
-    echo -e "${COLOR_RED}Not yet supported on HardenedBSD.${COLOR_RESET}"
-    exit 1
+    error_exit "Not yet supported on HardenedBSD."
 fi
 
 if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
@@ -61,20 +59,17 @@ if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
                 # Update a thick container.
                 CURRENT_VERSION=$(/usr/sbin/jexec -l "${TARGET}" freebsd-version 2>/dev/null)
                 if [ -z "${CURRENT_VERSION}" ]; then
-                    echo -e "${COLOR_RED}Can't determine '${TARGET}' version.${COLOR_RESET}"
-                    exit 1
+                    error_exit "Can't determine '${TARGET}' version."
                 else
                     env PAGER="/bin/cat" freebsd-update --not-running-from-cron -b "${bastille_jailsdir}/${TARGET}/root" \
                     fetch install --currently-running "${CURRENT_VERSION}"
                 fi
             else
-                echo -e "${COLOR_RED}${TARGET} is not running.${COLOR_RESET}"
-                echo -e "${COLOR_RED}See 'bastille start ${TARGET}'.${COLOR_RESET}"
-                exit 1
+                error_notify "${TARGET} is not running."
+                error_exit "See 'bastille start ${TARGET}'."
             fi
     else
-        echo -e "${COLOR_RED}${TARGET} is not a thick container.${COLOR_RESET}"
-        exit 1
+        error_exit "${TARGET} is not a thick container."
     fi
 else
     if [ -d "${bastille_releasesdir}/${TARGET}" ]; then
@@ -82,7 +77,6 @@ else
         env PAGER="/bin/cat" freebsd-update --not-running-from-cron -b "${bastille_releasesdir}/${TARGET}" \
         fetch install --currently-running "${TARGET}"
     else
-        echo -e "${COLOR_RED}${TARGET} not found. See bootstrap.${COLOR_RESET}"
-        exit 1
+        error_exit "${TARGET} not found. See 'bastille bootstrap'."
     fi
 fi

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille upgrade release newrelease.${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille upgrade release newrelease"
 }
 
 # Handle special-case commands first.
@@ -52,14 +51,11 @@ shift
 NEWRELEASE="$1"
 
 if freebsd-version | grep -qi HBSD; then
-    echo -e "${COLOR_RED}Not yet supported on HardenedBSD.${COLOR_RESET}"
-    exit 1
+    error_exit "Not yet supported on HardenedBSD."
 fi
-
 
 if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
     freebsd-update -b "${bastille_releasesdir}/${RELEASE}" -r "${NEWRELEASE}" upgrade
 else
-    echo -e "${COLOR_RED}${RELEASE} not found. See bootstrap.${COLOR_RESET}"
-    exit 1
+    error_exit "${RELEASE} not found. See 'bastille bootstrap'."
 fi

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -28,25 +28,22 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 bastille_usage() {
-    echo -e "${COLOR_RED}Usage: bastille verify [release|template].${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille verify [release|template]"
 }
 
 verify_release() {
     if freebsd-version | grep -qi HBSD; then
-        echo -e "${COLOR_RED}Not yet supported on HardenedBSD.${COLOR_RESET}"
-        exit 1
+        error_exit "Not yet supported on HardenedBSD."
     fi
 
     if [ -d "${bastille_releasesdir}/${RELEASE}" ]; then
         freebsd-update -b "${bastille_releasesdir}/${RELEASE}" --currently-running "${RELEASE}" IDS
     else
-        echo -e "${COLOR_RED}${RELEASE} not found. See bootstrap.${COLOR_RESET}"
-        exit 1
+        error_exit "${RELEASE} not found. See 'bastille bootstrap'."
     fi
 }
 
@@ -63,12 +60,10 @@ verify_template() {
             ## line count must match newline count
             if [ $(wc -l "${_path}" | awk '{print $1}') -ne $(grep -c $'\n' "${_path}") ]; then
                 echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
-                echo -e "${COLOR_RED}${BASTILLE_TEMPLATE}:${_hook} [failed].${COLOR_RESET}"
-                echo -e "${COLOR_RED}Line numbers don't match line breaks.${COLOR_RESET}"
+                error_notify "${BASTILLE_TEMPLATE}:${_hook} [failed]."
+                error_notify "Line numbers don't match line breaks."
                 echo
-                echo -e "${COLOR_RED}Template validation failed.${COLOR_RESET}"
-                exit 1
-
+                error_exit "Template validation failed."
             ## if INCLUDE; recursive verify
             elif [ ${_hook} = 'INCLUDE' ]; then
                 echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
@@ -87,8 +82,7 @@ verify_template() {
                             bastille verify "${BASTILLE_TEMPLATE_USER}/${BASTILLE_TEMPLATE_REPO}"
                         ;;
                         *)
-                            echo -e "${COLOR_RED}Template INCLUDE content not recognized.${COLOR_RESET}"
-                            exit 1
+                            error_exit "Template INCLUDE content not recognized."
                     ;;
                     esac
                 done < "${_path}"
@@ -117,8 +111,8 @@ verify_template() {
 
     ## remove bad templates
     if [ ${_hook_validate} -lt 1 ]; then
-        echo -e "${COLOR_RED}No valid template hooks found.${COLOR_RESET}"
-        echo -e "${COLOR_RED}Template discarded.${COLOR_RESET}"
+        error_notify "No valid template hooks found."
+        error_notify "Template discarded."
         rm -rf "${bastille_template}"
         exit 1
     fi

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -84,34 +84,21 @@ if [ -z "${bastille_zfs_zpool}" ]; then
     error_exit "ZFS zpool not defined."
 fi
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     usage
 fi
 
-TARGET="${1}"
-
-if [ "${TARGET}" = 'ALL' ]; then
-    JAILS=$(jls name)
-fi
-
-if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(jls name | awk "/^${TARGET}$/")
-fi
-
-case "$2" in
+case "$1" in
 set)
-    ATTRIBUTE=$3
-    JAILS=${JAILS}
+    ATTRIBUTE=$2
     zfs_set_value
     ;;
 get)
-    ATTRIBUTE=$3
-    JAILS=${JAILS}
+    ATTRIBUTE=$2
     zfs_get_value
     ;;
 snap|snapshot)
-    TAG=$3
-    JAILS=${JAILS}
+    TAG=$2
     zfs_snapshot
     ;;
 df|usage)

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -28,12 +28,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/colors.pre.sh
+. /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    echo -e "${COLOR_RED}Usage: bastille zfs TARGET [set|get|snap] [key=value|date]'${COLOR_RESET}"
-    exit 1
+    error_exit "Usage: bastille zfs TARGET [set|get|snap] [key=value|date]'"
 }
 
 zfs_snapshot() {
@@ -77,14 +76,12 @@ esac
 
 ## check ZFS enabled
 if [ ! "${bastille_zfs_enable}" = "YES" ]; then
-    echo -e "${COLOR_RED}ZFS not enabled.${COLOR_RESET}"
-    exit 1
+    error_exit "ZFS not enabled."
 fi
 
 ## check zpool defined
 if [ -z "${bastille_zfs_zpool}" ]; then
-    echo -e "${COLOR_RED}ZFS zpool not defined.${COLOR_RESET}"
-    exit 1
+    error_exit "ZFS zpool not defined."
 fi
 
 if [ $# -lt 2 ]; then


### PR DESCRIPTION
This reduces the number of places where the target is being parsed and validated. Then requires the target to be running for the following commands: cmd, console, htop, pkg, service, sysrc, template, top. Closes #239.

Note: I used the functions created in #250, so this looks like more changes than it is.