### PR TITLE
Use root as owner when installing from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 install:
 	@echo "Installing Bastille"
 	@echo
-	@cp -av usr /
+	@cp -Rv usr /
 	@echo
 	@echo "This method is for testing / development."
 


### PR DESCRIPTION
Fixes the permissions issue when installing from the Makefile.