### PR TITLE
Don't create or modify etc/fstab and etc/crontab on empty jail creation

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -386,8 +386,10 @@ create_jail() {
     # Creates a dummy fstab file
     # Disables adjkerntz, avoids spurious error messages
     # Set strict permissions on the jail by default
-    touch "etc/fstab"
-    sed -i '' 's|[0-9],[0-9]\{2\}.*[0-9]-[0-9].*root.*kerntz -a|#& # Disabled by bastille|' "etc/crontab"
+    if [ -z "${EMPTY_JAIL}" ]; then
+        touch "etc/fstab"
+        sed -i '' 's|[0-9],[0-9]\{2\}.*[0-9]-[0-9].*root.*kerntz -a|#& # Disabled by bastille|' "etc/crontab"
+    fi
     chmod 0700 "${bastille_jailsdir}/${NAME}"
 }
 


### PR DESCRIPTION
This will fix the etc/fstab and etc/crontab console errors when creating empty jails, since the jails is empty, there is no need for create/modify said files.

**Error before patch:**
```
root@mserver: ~# bastille create -E jail1
Creating empty jail: jail1.
touch: etc/fstab: No such file or directory
sed: etc/crontab: No such file or directory
```

**After patch:**
```
root@mserver: ~# bastille create -E jail1
Creating empty jail: jail1.
```

Regards