### PR TITLE
Option to create standard backups on ZFS setups

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -120,7 +120,7 @@ update_jailconf_vnet() {
 
     # If 0.0.0.0 set DHCP, else set static IP address
     if [ "${IP}" == "0.0.0.0" ]; then
-        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="DHCP"
+        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
     else
         sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
     fi

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille export TARGET"
+    error_exit "Usage: bastille export TARGET [option]"
 }
 
 # Handle special-case commands first
@@ -42,8 +42,23 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -ne 0 ]; then
+if [ $# -gt 1 ] || [ $# -lt 0 ]; then
     usage
+fi
+
+OPTION="${1}"
+
+# Handle some options
+if [ -n "${OPTION}" ]; then
+    if [ "${OPTION}" = "-t" -o "${OPTION}" = "--txz" ]; then
+        if [ "${bastille_zfs_enable}" = "YES" ]; then
+            # Temporarily disable ZFS so we can create a standard backup archive
+            bastille_zfs_enable="NO"
+        fi
+    else
+        error_notify "Invalid option!"
+        usage
+    fi
 fi
 
 jail_export()

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille export TARGET [option]"
+    error_exit "Usage: bastille export TARGET [option] | PATH"
 }
 
 # Handle special-case commands first
@@ -42,11 +42,17 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -gt 1 ] || [ $# -lt 0 ]; then
+# Check for unsupported actions
+if [ "${TARGET}" = "ALL" ]; then
+    error_exit "Batch export is unsupported."
+fi
+
+if [ $# -gt 2 ] || [ $# -lt 0 ]; then
     usage
 fi
 
 OPTION="${1}"
+EXPATH="${2}"
 
 # Handle some options
 if [ -n "${OPTION}" ]; then
@@ -55,9 +61,25 @@ if [ -n "${OPTION}" ]; then
             # Temporarily disable ZFS so we can create a standard backup archive
             bastille_zfs_enable="NO"
         fi
+    elif echo "${OPTION}" | grep -q "\/"; then
+        if [ -d "${OPTION}" ]; then
+            EXPATH="${OPTION}"
+        else
+            error_exit "Error: Path not found."
+        fi
     else
         error_notify "Invalid option!"
         usage
+    fi
+fi
+
+# Export directory check
+if [ -n "${EXPATH}" ]; then
+    if [ -d "${EXPATH}" ]; then
+        # Set the user defined export directory
+        bastille_backupsdir="${EXPATH}"
+    else
+        error_exit "Error: Path not found."
     fi
 fi
 
@@ -96,13 +118,6 @@ jail_export()
         exit 0
     fi
 }
-
-# Check for user specified file location
-if echo "${TARGET}" | grep -q '\/'; then
-    GETDIR="${TARGET}"
-    TARGET=$(echo ${TARGET} | awk -F '\/' '{print $NF}')
-    bastille_backupsdir=$(echo ${GETDIR} | sed "s/${TARGET}//")
-fi
 
 # Check if backups directory/dataset exist
 if [ ! -d "${bastille_backupsdir}" ]; then


### PR DESCRIPTION
This option will let the user create a standard backups(exports) from existing jails on bastille setups configured for ZFS, this may be useful for cross-filesystem portability and/or just for backward compatibiity purposes, note that this option has no effect on existing UFS setups as expected.

**Sample usage**

Exporting a jail with standard `.txz` backup archive(available options are -t|--txz):
```
root@mserver: ~# bastille export jail_test -t
Exporting 'jail_test' to a compressed .txz archive...
  100 %      428.8 KiB / 7410.0 KiB = 0.058                   0:01             
Exported '/mnt/storage/bastille/backups/jail_test_2020-10-15-155308.txz' successfully.
```

Importing a jail on a UFS configured system:
```
root@testmachine: ~# bastille list import
jail_test_2020-10-15-160913.txz

root@testmachine: ~# bastille import jail_test_2020-10-15-155956.txz
Validating file: jail_test_2020-10-15-155956.txz...
File validation successful!
Extracting files from 'jail_test_2020-10-15-155956.txz' archive...
Container 'jail_test' imported successfully.
```

Importing a `.txz` archived jail to a ZFS configured system:
```
root@mserver: ~# bastille import jail_test_2020-10-15-155956.txz
Validating file: jail_test_2020-10-15-155956.txz...
File validation successful!
Importing 'jail_test' from foreign compressed .txz archive.
Preparing zfs environment...
Extracting files from 'jail_test_2020-10-15-155956.txz' archive...
Container 'jail_test' imported successfully.
``` 

Note that both the `jail_name.txz` and the `jail_name.sha256` files should be present in the remote host **backups** folder if any, if there is no checksum file present, the option `-f` need to be used to override file checking.

Regards
