### PR TITLE
Normalize indentation in usr/local/share/bastille/template.sh

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -163,8 +163,8 @@ for _jail in ${JAILS}; do
 
     for _hook in ${HOOKS}; do
         if [ -s "${bastille_template}/${_hook}" ]; then
-        	# Default command is the lowercase hook name and default args are the line from the file. -- cwells
-        	_cmd=$(echo "${_hook}" | awk '{print tolower($1);}')
+            # Default command is the lowercase hook name and default args are the line from the file. -- cwells
+            _cmd=$(echo "${_hook}" | awk '{print tolower($1);}')
             _args_template='${_line}'
 
             # Override default command/args for some hooks. -- cwells
@@ -195,9 +195,9 @@ for _jail in ${JAILS}; do
                 bastille pkg "${_jail}" audit -F
             else
                 while read _line; do
-                	if [ -z "${_line}" ]; then
-                	    continue
-                	fi
+                    if [ -z "${_line}" ]; then
+                        continue
+                    fi
                     eval "_args=\"${_args_template}\""
                     bastille "${_cmd}" "${_jail}" ${_args} || exit 1
                 done < "${bastille_template}/${_hook}"


### PR DESCRIPTION
This just eliminates some errant tab characters that were meant to be spaces.

![image](https://user-images.githubusercontent.com/3409214/97001741-defc5d00-1506-11eb-809e-e6b42759c4fa.png)
I've got `nvim` set up to complain loudly about these ^ (the red double-dots indicate tabs, and red blocks are trailing/leading whitespace).

BTW, I considered wiring up an automated means to catch these in CI but it looks like that's still a roadmap objective for this repo.

Thanks for Bastille!