### PR TITLE
Upgrade thick jails from bastille

### DIFF
--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -74,7 +74,7 @@ jail_check() {
     if [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
         error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
     else
-        if cat "${bastille_jailsdir}/${TARGET}/fstab" 2>/dev/null | grep -w "${TARGET}" | grep -qw "/.*/.bastille"; then
+        if grep -qw "${bastille_jailsdir}/${TARGET}/root/.bastille" "${bastille_jailsdir}/${TARGET}/fstab"; then
             error_exit "${TARGET} is not a thick container."
         fi
     fi

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -80,14 +80,18 @@ jail_check() {
     fi
 }
 
+release_check() {
+    # Validate the release
+    if ! echo "${NEWRELEASE}" | grep -q "[0-9]\{2\}.[0-9]-RELEASE"; then
+        error_exit "${NEWRELEASE} is not a valid release."
+    fi
+}
+
 release_upgrade() {
     # Upgrade a release
     if [ -d "${bastille_releasesdir}/${TARGET}" ]; then
-        if echo "${NEWRELEASE}" | grep -q "[0-9]\{2\}.[0-9]-RELEASE"; then
-            freebsd-update ${OPTION} -b "${bastille_releasesdir}/${TARGET}" -r "${NEWRELEASE}" upgrade
-        else
-            error_exit "${NEWRELEASE} is not a valid release."
-        fi
+        release_check
+        freebsd-update ${OPTION} -b "${bastille_releasesdir}/${TARGET}" -r "${NEWRELEASE}" upgrade
     else
         error_exit "${TARGET} not found. See 'bastille bootstrap'."
     fi
@@ -97,6 +101,7 @@ jail_upgrade() {
     # Upgrade a thick container
     if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
         jail_check
+        release_check
         CURRENT_VERSION=$(jexec -l ${TARGET} freebsd-version)
         env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_jailsdir}/${TARGET}/root" --currently-running "${CURRENT_VERSION}" -r ${NEWRELEASE} upgrade
         echo


### PR DESCRIPTION
This enhancement to the `upgrade` command will let the user to seamlessly upgrade Thickjails from `bastille` as well in an easy way, as it was only for simple release upgrade previously.

`Usage: bastille upgrade release newrelease | target newrelease | target install | [option]`

Where **[option]** may be `-f|--force` and could be handy as to "_Force a fetch operation to proceed in thecase of an unfinished upgrade_".

**Here is a complete(almost) log of an upgrade of an existing Thickjail**

**FIRST STEP:**
```
root@nas-mserver: ~# bastille cmd emby freebsd-version
[emby]:
12.1-RELEASE-p10

root@nas-mserver: ~# bastille upgrade emby 12.2-RELEASE
src component not installed, skipped
Looking up update.FreeBSD.org mirrors... 3 mirrors found.
Fetching metadata signature for 12.1-RELEASE from update4.freebsd.org... done.
Fetching metadata index... done.
Inspecting system... done.

The following components of FreeBSD seem to be installed:
kernel/generic world/base world/doc

The following components of FreeBSD do not seem to be installed:
kernel/generic-dbg world/base-dbg world/lib32 world/lib32-dbg

Does this look reasonable (y/n)? y

Fetching metadata signature for 12.2-RELEASE from update4.freebsd.org... failed.
Fetching metadata signature for 12.2-RELEASE from update2.freebsd.org... done.
Fetching metadata index... done.
Fetching 1 metadata patches. done.
Applying metadata patches... done.
Fetching 1 metadata files... done.
Inspecting system... done.
Fetching files from 12.1-RELEASE for merging... done.
Preparing to download files... done.
Attempting to automatically merge changes in files... done.

The following changes, which occurred between FreeBSD 12.1-RELEASE and
FreeBSD 12.2-RELEASE have been merged into /etc/group:
--- current version
+++ new version
@@ -1,6 +1,6 @@
-# $FreeBSD: releng/12.1/etc/group 336525 2018-07-19 23:55:29Z ian $
+# $FreeBSD: releng/12.2/etc/group 359447 2020-03-30 17:07:05Z brooks $
 #
 wheel:*:0:root
 daemon:*:1:
 kmem:*:2:
 sys:*:3:
@@ -30,10 +30,11 @@
 audit:*:77:
 www:*:80:
 ntpd:*:123:
 _ypldap:*:160:
 hast:*:845:
+tests:*:977:
 nogroup:*:65533:
 nobody:*:65534:
 _tss:*:601:
 messagebus:*:556:
 avahi:*:558:
Does this look reasonable (y/n)? y

The following changes, which occurred between FreeBSD 12.1-RELEASE and
FreeBSD 12.2-RELEASE have been merged into /etc/master.passwd:
--- current version
+++ new version
@@ -1,6 +1,6 @@
-# $FreeBSD: releng/12.1/etc/master.passwd 337882 2018-08-15 23:18:34Z brd $
+# $FreeBSD: releng/12.2/etc/master.passwd 359447 2020-03-30 17:07:05Z brooks $
 #
 root::0:0::0:0:Charlie &:/root:/bin/csh
 toor:*:0:0::0:0:Bourne-again Superuser:/root:
 daemon:*:1:1::0:0:Owner of many system processes:/root:/usr/sbin/nologin
 operator:*:2:5::0:0:System &:/:/usr/sbin/nologin
@@ -23,10 +23,11 @@
 auditdistd:*:78:77::0:0:Auditdistd unprivileged user:/var/empty:/usr/sbin/nologin
 www:*:80:80::0:0:World Wide Web Owner:/nonexistent:/usr/sbin/nologin
 ntpd:*:123:123::0:0:NTP Daemon:/var/db/ntp:/usr/sbin/nologin
 _ypldap:*:160:160::0:0:YP LDAP unprivileged user:/var/empty:/usr/sbin/nologin
 hast:*:845:845::0:0:HAST unprivileged user:/var/empty:/usr/sbin/nologin
+tests:*:977:977::0:0:Unprivileged user for tests:/nonexistent:/usr/sbin/nologin
 nobody:*:65534:65534::0:0:Unprivileged user:/nonexistent:/usr/sbin/nologin
 _tss:*:601:601:daemon:0:0:TCG Software Stack user:/var/empty:/usr/sbin/nologin
 messagebus:*:556:556::0:0:D-BUS Daemon User:/nonexistent:/usr/sbin/nologin
 avahi:*:558:558::0:0:Avahi Daemon User:/nonexistent:/usr/sbin/nologin
 cups:*:193:193::0:0:Cups Owner:/nonexistent:/usr/sbin/nologin
Does this look reasonable (y/n)? y

The following changes, which occurred between FreeBSD 12.1-RELEASE and
FreeBSD 12.2-RELEASE have been merged into /etc/passwd:
--- current version
+++ new version
@@ -1,6 +1,6 @@
-# $FreeBSD: releng/12.1/etc/master.passwd 337882 2018-08-15 23:18:34Z brd $
+# $FreeBSD: releng/12.2/etc/master.passwd 359447 2020-03-30 17:07:05Z brooks $
 #
 root:*:0:0:Charlie &:/root:/bin/csh
 toor:*:0:0:Bourne-again Superuser:/root:
 daemon:*:1:1:Owner of many system processes:/root:/usr/sbin/nologin
 operator:*:2:5:System &:/:/usr/sbin/nologin
@@ -23,10 +23,11 @@
 auditdistd:*:78:77:Auditdistd unprivileged user:/var/empty:/usr/sbin/nologin
 www:*:80:80:World Wide Web Owner:/nonexistent:/usr/sbin/nologin
 ntpd:*:123:123:NTP Daemon:/var/db/ntp:/usr/sbin/nologin
 _ypldap:*:160:160:YP LDAP unprivileged user:/var/empty:/usr/sbin/nologin
 hast:*:845:845:HAST unprivileged user:/var/empty:/usr/sbin/nologin
+tests:*:977:977:Unprivileged user for tests:/nonexistent:/usr/sbin/nologin
 nobody:*:65534:65534:Unprivileged user:/nonexistent:/usr/sbin/nologin
 _tss:*:601:601:TCG Software Stack user:/var/empty:/usr/sbin/nologin
 messagebus:*:556:556:D-BUS Daemon User:/nonexistent:/usr/sbin/nologin
 avahi:*:558:558:Avahi Daemon User:/nonexistent:/usr/sbin/nologin
 cups:*:193:193:Cups Owner:/nonexistent:/usr/sbin/nologin
Does this look reasonable (y/n)? y
The following files will be removed as part of updating to
12.2-RELEASE-p0:
/etc/rc.d/abi
/usr/include/c++/v1/experimental/any
/usr/include/c++/v1/experimental/chrono
/usr/include/c++/v1/experimental/numeric
/usr/include/c++/v1/experimental/optional
/usr/include/c++/v1/experimental/ratio
/usr/include/c++/v1/experimental/string_view
/usr/include/c++/v1/experimental/system_error
/usr/include/c++/v1/experimental/tuple
/usr/include/net/if_tapvar.h
/usr/include/netinet/sctp_dtrace_declare.h
/usr/include/netinet/sctp_dtrace_define.h
/usr/include/ssp
/usr/include/ssp/ssp.h
/usr/include/ssp/stdio.h
/usr/include/ssp/string.h
/usr/include/ssp/unistd.h
/usr/lib/clang/8.0.1
/usr/lib/clang/8.0.1/include
/usr/lib/clang/8.0.1/include/__clang_cuda_builtin_vars.h
/usr/lib/clang/8.0.1/include/__clang_cuda_cmath.h
/usr/lib/clang/8.0.1/include/__clang_cuda_complex_builtins.h
/usr/lib/clang/8.0.1/include/__clang_cuda_device_functions.h
..................
.......................
.................................
......................................... etc etc etc etc
/var/db/etcupdate/current/etc/syslog.conf
/var/db/etcupdate/current/etc/syslog.d/ftp.conf
/var/db/etcupdate/current/etc/syslog.d/lpr.conf
/var/db/etcupdate/current/etc/syslog.d/ppp.conf
/var/db/etcupdate/current/etc/termcap.small
/var/db/etcupdate/current/etc/ttys
/var/db/etcupdate/current/root/.cshrc
/var/db/etcupdate/current/root/.k5login
/var/db/etcupdate/current/root/.login
/var/db/etcupdate/current/root/.profile
/var/db/etcupdate/log
/var/db/mergemaster.mtree
/var/db/services.db
/var/yp/Makefile.dist
To install the downloaded upgrades, run "/usr/sbin/freebsd-update install".

Please run 'bastille upgrade emby install' to finish installing updates.
```

**SECOND STEP:**
```
root@nas-mserver: ~# bastille upgrade emby install
src component not installed, skipped
Installing updates...
Kernel updates have been installed.  Please reboot and run
"/usr/sbin/freebsd-update install" again to finish installing updates.
root@nas-mserver: ~# bastille restart emby
[emby]:
emby: removed

[emby]:
e0a_bastille2
e0b_bastille2
emby: created

root@nas-mserver: ~# bastille upgrade emby install
src component not installed, skipped
Installing updates...Scanning /mnt/storage/bastille/jails/emby/root/usr/share/certs/blacklisted for certificates...
Scanning /mnt/storage/bastille/jails/emby/root/usr/share/certs/trusted for certificates...
Scanning /mnt/storage/bastille/jails/emby/root/usr/local/share/certs for certificates...
 done.
root@nas-mserver: ~# bastille cmd emby freebsd-version
[emby]:
12.2-RELEASE
```

Regards!
