### PR TITLE
Create info() and warn() for cleaner print statements.

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -127,7 +127,7 @@ shift
 # Handle special-case commands first.
 case "${CMD}" in
 version|-v|--version)
-    echo -e "${COLOR_GREEN}${BASTILLE_VERSION}${COLOR_RESET}"
+    info "${BASTILLE_VERSION}"
     exit 0
     ;;
 help|-h|--help)

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -68,7 +68,7 @@ validate_release_url() {
         if ! fetch -qo /dev/null "${UPSTREAM_URL}/MANIFEST" 2>/dev/null; then
             error_exit "Unable to fetch MANIFEST. See 'bootstrap urls'."
         fi
-        echo -e "${COLOR_GREEN}Bootstrapping ${PLATFORM_OS} distfiles...${COLOR_RESET}"
+        info "Bootstrapping ${PLATFORM_OS} distfiles..."
 
         # Alternate RELEASE/ARCH fetch support
         if [ "${OPTION}" = "--i386" -o "${OPTION}" = "--32bit" ]; then
@@ -203,7 +203,7 @@ bootstrap_release() {
         if [ -z "${bastille_bootstrap_archives}" ]; then
             error_exit "Bootstrap appears complete."
         else
-            echo -e "${COLOR_GREEN}Bootstrapping additional distfiles...${COLOR_RESET}"
+            info "Bootstrapping additional distfiles..."
         fi
     fi
 
@@ -211,7 +211,7 @@ bootstrap_release() {
         ## check if the dist files already exists then extract
         FETCH_VALIDATION="0"
         if [ -f "${bastille_cachedir}/${RELEASE}/${_archive}.txz" ]; then
-            echo -e "${COLOR_GREEN}Extracting ${PLATFORM_OS} ${RELEASE} ${_archive}.txz.${COLOR_RESET}"
+            info "Extracting ${PLATFORM_OS} ${RELEASE} ${_archive}.txz."
             if /usr/bin/tar -C "${bastille_releasesdir}/${RELEASE}" -xf "${bastille_cachedir}/${RELEASE}/${_archive}.txz"; then
                 ## silence motd at container login
                 touch "${bastille_releasesdir}/${RELEASE}/root/.hushlogin"
@@ -267,15 +267,15 @@ bootstrap_release() {
                         rm "${bastille_cachedir}/${RELEASE}/${_archive}.txz"
                         error_exit "Failed validation for ${_archive}.txz. Please retry bootstrap!"
                     else
-                        echo -e "${COLOR_GREEN}Validated checksum for ${RELEASE}:${_archive}.txz.${COLOR_RESET}"
-                        echo -e "${COLOR_GREEN}MANIFEST:${SHA256_DIST}${COLOR_RESET}"
-                        echo -e "${COLOR_GREEN}DOWNLOAD:${SHA256_FILE}${COLOR_RESET}"
+                        info "Validated checksum for ${RELEASE}: ${_archive}.txz"
+                        info "MANIFEST: ${SHA256_DIST}"
+                        info "DOWNLOAD: ${SHA256_FILE}"
                     fi
                 fi
 
                 ## extract the fetched dist files
                 if [ -f "${bastille_cachedir}/${RELEASE}/${_archive}.txz" ]; then
-                    echo -e "${COLOR_GREEN}Extracting ${PLATFORM_OS} ${RELEASE} ${_archive}.txz.${COLOR_RESET}"
+                    info "Extracting ${PLATFORM_OS} ${RELEASE} ${_archive}.txz."
                     if /usr/bin/tar -C "${bastille_releasesdir}/${RELEASE}" -xf "${bastille_cachedir}/${RELEASE}/${_archive}.txz"; then
                         ## silence motd at container login
                         touch "${bastille_releasesdir}/${RELEASE}/root/.hushlogin"
@@ -288,8 +288,8 @@ bootstrap_release() {
     done
     echo
 
-    echo -e "${COLOR_GREEN}Bootstrap successful.${COLOR_RESET}"
-    echo -e "${COLOR_GREEN}See 'bastille --help' for available commands.${COLOR_RESET}"
+    info "Bootstrap successful."
+    info "See 'bastille --help' for available commands."
     echo
 }
 

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -54,7 +54,7 @@ validate_ip() {
     IP6_MODE="disable"
     ip6=$(echo "${IP}" | grep -E '^(([a-fA-F0-9:]+$)|([a-fA-F0-9:]+\/[0-9]{1,3}$))')
     if [ -n "${ip6}" ]; then
-        echo -e "${COLOR_GREEN}Valid: (${ip6}).${COLOR_RESET}"
+        info "Valid: (${ip6})."
         IPX_ADDR="ip6.addr"
         IP6_MODE="new"
     else
@@ -69,9 +69,9 @@ validate_ip() {
                 fi
             done
             if ifconfig | grep -qw "${TEST_IP}"; then
-                echo -e "${COLOR_YELLOW}Warning: ip address already in use (${TEST_IP}).${COLOR_RESET}"
+                warn "Warning: IP address already in use (${TEST_IP})."
             else
-                echo -e "${COLOR_GREEN}Valid: (${IP}).${COLOR_RESET}"
+                info "Valid: (${IP})."
             fi
         else
             error_exit "Invalid: (${IP})."
@@ -144,7 +144,7 @@ update_fstab() {
 
 clone_jail() {
     # Attempt container clone
-    echo -e "${COLOR_GREEN}Attempting to clone '${TARGET}' to ${NEWNAME}...${COLOR_RESET}"
+    info "Attempting to clone '${TARGET}' to ${NEWNAME}..."
     if ! [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
         if [ "${bastille_zfs_enable}" = "YES" ]; then
             if [ -n "${bastille_zfs_zpool}" ]; then
@@ -183,7 +183,7 @@ clone_jail() {
     if [ "$?" -ne 0 ]; then
         error_exit "An error has occurred while attempting to clone '${TARGET}'."
     else
-        echo -e "${COLOR_GREEN}Cloned '${TARGET}' to '${NEWNAME}' successfully.${COLOR_RESET}"
+        info "Cloned '${TARGET}' to '${NEWNAME}' successfully."
     fi
 }
 

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -46,7 +46,7 @@ if [ $# -eq 0 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     jexec -l "${_jail}" "$@"
     echo
 done

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -40,3 +40,11 @@ error_exit() {
     error_notify $@
     exit 1
 }
+
+info() {
+    echo -e "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+warn() {
+    echo -e "${COLOR_YELLOW}$*${COLOR_RESET}"
+}

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -65,7 +65,7 @@ validate_user() {
 }
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     if [ -n "${USER}" ]; then
         validate_user
     else

--- a/usr/local/share/bastille/convert.sh
+++ b/usr/local/share/bastille/convert.sh
@@ -101,7 +101,7 @@ revert_convert() {
 start_convert() {
     # Attempt container conversion and handle some errors
     if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
-        echo -e "${COLOR_GREEN}Converting '${TARGET}' into a thickjail, this may take a while...${COLOR_RESET}"
+        info "Converting '${TARGET}' into a thickjail. This may take a while..."
 
         # Set some variables
         RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)|(current-BUILD-LATEST)' "${bastille_jailsdir}/${TARGET}/fstab")
@@ -118,7 +118,7 @@ start_convert() {
             sed -i '' -E "s|${FSTABMOD}|# Converted from thin to thick container on $(date)|g" "${bastille_jailsdir}/${TARGET}/fstab"
             mv "${bastille_jailsdir}/${TARGET}/root/.bastille" "${bastille_jailsdir}/${TARGET}/root/.bastille.old"
 
-            echo -e "${COLOR_GREEN}Conversion of '${TARGET}' completed successfully!${COLOR_RESET}"
+            info "Conversion of '${TARGET}' completed successfully!"
             exit 0
         else
             error_exit "Can't determine release version. See 'bastille bootstrap'."

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -51,7 +51,7 @@ CPDEST="${2}"
 
 for _jail in ${JAILS}; do
     bastille_jail_path="$(jls -j "${_jail}" path)"
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"
     RETURN="$?"
     if [ "${TARGET}" = "ALL" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -56,7 +56,7 @@ validate_ip() {
     IP6_MODE="disable"
     ip6=$(echo "${IP}" | grep -E '^(([a-fA-F0-9:]+$)|([a-fA-F0-9:]+\/[0-9]{1,3}$))')
     if [ -n "${ip6}" ]; then
-        echo -e "${COLOR_GREEN}Valid: (${ip6}).${COLOR_RESET}"
+        info "Valid: (${ip6})."
         IPX_ADDR="ip6.addr"
         IP6_MODE="new"
     else
@@ -72,9 +72,9 @@ validate_ip() {
                 fi
             done
             if ifconfig | grep -qw "${TEST_IP}"; then
-                echo -e "${COLOR_YELLOW}Warning: ip address already in use (${TEST_IP}).${COLOR_RESET}"
+                warn "Warning: IP address already in use (${TEST_IP})."
             else
-                echo -e "${COLOR_GREEN}Valid: (${IP}).${COLOR_RESET}"
+                info "Valid: (${IP})."
             fi
         else
             error_exit "Invalid: (${IP})."
@@ -85,7 +85,7 @@ validate_ip() {
 validate_netif() {
     local LIST_INTERFACES=$(ifconfig -l)
     if echo "${LIST_INTERFACES} VNET" | grep -qwo "${INTERFACE}"; then
-        echo -e "${COLOR_GREEN}Valid: (${INTERFACE}).${COLOR_RESET}"
+        info "Valid: (${INTERFACE})."
     else
         error_exit "Invalid: (${INTERFACE})."
     fi
@@ -248,12 +248,12 @@ create_jail() {
         ## MAKE SURE WE'RE IN THE RIGHT PLACE
         cd "${bastille_jail_path}"
         echo
-        echo -e "${COLOR_GREEN}NAME: ${NAME}.${COLOR_RESET}"
-        echo -e "${COLOR_GREEN}IP: ${IP}.${COLOR_RESET}"
+        info "NAME: ${NAME}."
+        info "IP: ${IP}."
         if [ -n  "${INTERFACE}" ]; then
-            echo -e "${COLOR_GREEN}INTERFACE: ${INTERFACE}.${COLOR_RESET}"
+            info "INTERFACE: ${INTERFACE}."
         fi
-        echo -e "${COLOR_GREEN}RELEASE: ${RELEASE}.${COLOR_RESET}"
+        info "RELEASE: ${RELEASE}."
         echo
 
         if [ -z "${THICK_JAIL}" ]; then
@@ -278,7 +278,7 @@ create_jail() {
                 fi
             done
         else
-            echo -e "${COLOR_GREEN}Creating a thickjail, this may take a while...${COLOR_RESET}"
+            info "Creating a thickjail. This may take a while..."
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     ## perform release base replication
@@ -527,7 +527,7 @@ if [ -z "${EMPTY_JAIL}" ]; then
         validate_netconf
     fi
 else
-    echo -e "${COLOR_GREEN}Creating empty jail: ${NAME}.${COLOR_RESET}"
+    info "Creating empty jail: ${NAME}."
 fi
 
 ## check if a running jail matches name or already exist

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -54,7 +54,7 @@ destroy_jail() {
     fi
 
     if [ -d "${bastille_jail_base}" ]; then
-        echo -e "${COLOR_GREEN}Deleting Jail: ${TARGET}.${COLOR_RESET}"
+        info "Deleting Jail: ${TARGET}."
         if [ "${bastille_zfs_enable}" = "YES" ]; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 if [ -n "${TARGET}" ]; then
@@ -79,13 +79,13 @@ destroy_jail() {
         ## archive jail log
         if [ -f "${bastille_jail_log}" ]; then
             mv "${bastille_jail_log}" "${bastille_jail_log}"-"$(date +%F)"
-            echo -e "${COLOR_GREEN}Note: jail console logs archived.${COLOR_RESET}"
-            echo -e "${COLOR_GREEN}${bastille_jail_log}-$(date +%F)${COLOR_RESET}"
+            info "Note: jail console logs archived."
+            info "${bastille_jail_log}-$(date +%F)"
         fi
 
         ## clear any active rdr rules
         if [ ! -z "$(pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null)" ]; then
-            echo -e "${COLOR_GREEN}Clearing RDR rules:${COLOR_RESET}"
+            info "Clearing RDR rules:"
             pfctl -a "rdr/${TARGET}" -Fn
         fi
         echo
@@ -120,7 +120,7 @@ destroy_rel() {
         error_exit "Release base not found."
     else
         if [ "${BASE_HASCHILD}" -eq "0" ]; then
-            echo -e "${COLOR_GREEN}Deleting base: ${TARGET}.${COLOR_RESET}"
+            info "Deleting base: ${TARGET}"
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     if [ -n "${TARGET}" ]; then

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -90,8 +90,8 @@ jail_export()
     if [ "${bastille_zfs_enable}" = "YES" ]; then
         if [ -n "${bastille_zfs_zpool}" ]; then
             FILE_EXT="xz"
-            echo -e "${COLOR_GREEN}Exporting '${TARGET}' to a compressed .${FILE_EXT} archive.${COLOR_RESET}"
-            echo -e "${COLOR_GREEN}Sending zfs data stream...${COLOR_RESET}"
+            info "Exporting '${TARGET}' to a compressed .${FILE_EXT} archive."
+            info "Sending zfs data stream..."
             # Take a recursive temporary snapshot
             zfs snapshot -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}"
 
@@ -104,7 +104,7 @@ jail_export()
     else
         # Create standard backup archive
         FILE_EXT="txz"
-        echo -e "${COLOR_GREEN}Exporting '${TARGET}' to a compressed .${FILE_EXT} archive...${COLOR_RESET}"
+        info "Exporting '${TARGET}' to a compressed .${FILE_EXT} archive..."
         cd "${bastille_jailsdir}" && tar -cf - "${TARGET}" | xz ${bastille_compress_xz_options} > "${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}"
     fi
 
@@ -114,7 +114,7 @@ jail_export()
         # Generate container checksum file
         cd "${bastille_backupsdir}"
         sha256 -q "${TARGET}_${DATE}.${FILE_EXT}" > "${TARGET}_${DATE}.sha256"
-        echo -e "${COLOR_GREEN}Exported '${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}' successfully.${COLOR_RESET}"
+        info "Exported '${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}' successfully."
         exit 0
     fi
 }

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -51,7 +51,7 @@ for _jail in ${JAILS}; do
     if [ ! -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
         error_notify "htop not found on ${_jail}."
     elif [ -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
-        echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+        info "[${_jail}]:"
         jexec -l ${_jail} /usr/local/bin/htop
     fi
     echo -e "${COLOR_RESET}"

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -59,7 +59,7 @@ OPTION="${1}"
 VALUE="${2}"
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
 
     _rctl_rule="jail:${_jail}:${OPTION}:deny=${VALUE}/jail"
 

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -60,37 +60,37 @@ _checks=$(echo "${_fstab}" | awk '{print $5" "$6}')
 ## if any variables are empty, bail out
 if [ -z "${_hostpath}" ] || [ -z "${_jailpath}" ] || [ -z "${_type}" ] || [ -z "${_perms}" ] || [ -z "${_checks}" ]; then
     error_notify "FSTAB format not recognized."
-    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
-    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    warn "Format: /host/path jail/path nullfs ro 0 0"
+    warn "Read: ${_fstab}"
     exit 1
 fi
 
 ## if host path doesn't exist or type is not "nullfs"
 if [ ! -d "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     error_notify "Detected invalid host path or incorrect mount type in FSTAB."
-    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
-    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    warn "Format: /host/path jail/path nullfs ro 0 0"
+    warn "Read: ${_fstab}"
     exit 1
 fi
 
 ## if mount permissions are not "ro" or "rw"
 if [ "${_perms}" != "ro" ] && [ "${_perms}" != "rw" ]; then
     error_notify "Detected invalid mount permissions in FSTAB."
-    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
-    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    warn "Format: /host/path jail/path nullfs ro 0 0"
+    warn "Read: ${_fstab}"
     exit 1
 fi
 
 ## if check & pass are not "0 0 - 1 1"; bail out
 if [ "${_checks}" != "0 0" ] && [ "${_checks}" != "1 0" ] && [ "${_checks}" != "0 1" ] && [ "${_checks}" != "1 1" ]; then
     error_notify "Detected invalid fstab options in FSTAB."
-    echo -e "${COLOR_YELLOW}Format: /host/path jail/path nullfs ro 0 0${COLOR_RESET}"
-    echo -e "${COLOR_YELLOW}Read: ${_fstab}${COLOR_RESET}"
+    warn "Format: /host/path jail/path nullfs ro 0 0"
+    warn "Read: ${_fstab}"
     exit 1
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
 
     ## aggregate variables into FSTAB entry
     _jailpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -46,7 +46,7 @@ if [ $# -lt 1 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     jexec -l "${_jail}" /usr/sbin/pkg "$@"
     echo
 done

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -88,7 +88,7 @@ update_fstab() {
 
 change_name() {
     # Attempt container name change
-    echo -e "${COLOR_GREEN}Attempting to rename '${TARGET}' to ${NEWNAME}...${COLOR_RESET}"
+    info "Attempting to rename '${TARGET}' to ${NEWNAME}..."
     if [ "${bastille_zfs_enable}" = "YES" ]; then
         if [ -n "${bastille_zfs_zpool}" ] && [ -n "${bastille_zfs_prefix}" ]; then
             # Check and rename container ZFS dataset accordingly
@@ -131,7 +131,7 @@ change_name() {
     if [ "$?" -ne 0 ]; then
         error_exit "An error has occurred while attempting to rename '${TARGET}'."
     else
-        echo -e "${COLOR_GREEN}Renamed '${TARGET}' to '${NEWNAME}' successfully.${COLOR_RESET}"
+        info "Renamed '${TARGET}' to '${NEWNAME}' successfully."
     fi
 }
 

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -46,7 +46,7 @@ if [ $# -ne 2 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     jexec -l "${_jail}" /usr/sbin/service "$@"
     echo
 done

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -76,7 +76,7 @@ for _jail in ${JAILS}; do
         fi
 
         ## start the container
-        echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+        info "[${_jail}]:"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -c "${_jail}"
 
         ## add rctl limits

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -64,7 +64,7 @@ for _jail in ${JAILS}; do
         fi
 
         ## stop container
-        echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+        info "[${_jail}]:"
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r "${_jail}"
     fi
     echo

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -46,7 +46,7 @@ if [ $# -lt 1 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     jexec -l "${_jail}" /usr/sbin/sysrc "$@"
     echo -e "${COLOR_RESET}"
 done

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -46,7 +46,7 @@ if [ $# -ne 0 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     jexec -l "${_jail}" /usr/bin/top
     echo -e "${COLOR_RESET}"
 done

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -49,7 +49,7 @@ fi
 MOUNT_PATH=$1
 
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
 
     _jailpath="${bastille_jailsdir}/${_jail}/root/${MOUNT_PATH}"
 

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -55,22 +55,22 @@ verify_template() {
         _path=${_template_path}/${_hook}
         if [ -s "${_path}" ]; then
             _hook_validate=$((_hook_validate+1))
-            echo -e "${COLOR_GREEN}Detected ${_hook} hook.${COLOR_RESET}"
+            info "Detected ${_hook} hook."
 
             ## line count must match newline count
             if [ $(wc -l "${_path}" | awk '{print $1}') -ne $(grep -c $'\n' "${_path}") ]; then
-                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                info "[${_hook}]:"
                 error_notify "${BASTILLE_TEMPLATE}:${_hook} [failed]."
                 error_notify "Line numbers don't match line breaks."
                 echo
                 error_exit "Template validation failed."
             ## if INCLUDE; recursive verify
             elif [ ${_hook} = 'INCLUDE' ]; then
-                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                info "[${_hook}]:"
                 cat "${_path}"
                 echo
                 while read _include; do
-                    echo -e "${COLOR_GREEN}[${_hook}]:[${_include}]:${COLOR_RESET}"
+                    info "[${_hook}]:[${_include}]:"
 
                     case ${_include} in
                         http?://github.com/*/*|http?://gitlab.com/*/*)
@@ -89,11 +89,11 @@ verify_template() {
 
             ## if tree; tree -a bastille_template/_dir
             elif [ ${_hook} = 'OVERLAY' ]; then
-                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                info "[${_hook}]:"
                 cat "${_path}"
                 echo
                 while read _dir; do
-                    echo -e "${COLOR_GREEN}[${_hook}]:[${_dir}]:${COLOR_RESET}"
+                    info "[${_hook}]:[${_dir}]:"
                         if [ -x /usr/local/bin/tree ]; then
                             /usr/local/bin/tree -a "${_template_path}/${_dir}"
                         else
@@ -102,7 +102,7 @@ verify_template() {
                     echo
                 done < "${_path}"
             else
-                echo -e "${COLOR_GREEN}[${_hook}]:${COLOR_RESET}"
+                info "[${_hook}]:"
                 cat "${_path}"
                 echo
             fi
@@ -119,7 +119,7 @@ verify_template() {
 
     ## if validated; ready to use
     if [ ${_hook_validate} -gt 0 ]; then
-        echo -e "${COLOR_GREEN}Template ready to use.${COLOR_RESET}"
+        info "Template ready to use."
     fi
 }
 

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -37,7 +37,7 @@ usage() {
 
 zfs_snapshot() {
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     zfs snapshot -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
     echo
 done
@@ -45,7 +45,7 @@ done
 
 zfs_set_value() {
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     zfs "${ATTRIBUTE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
     echo
 done
@@ -53,7 +53,7 @@ done
 
 zfs_get_value() {
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     zfs get "${ATTRIBUTE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
     echo
 done
@@ -61,7 +61,7 @@ done
 
 zfs_disk_usage() {
 for _jail in ${JAILS}; do
-    echo -e "${COLOR_GREEN}[${_jail}]:${COLOR_RESET}"
+    info "[${_jail}]:"
     zfs list -t all -o name,used,avail,refer,mountpoint,compress,ratio -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
     echo
 done


### PR DESCRIPTION
Adds a `warn()` function for yellow console messages and an `info()` function for green console messages. Makes console messages easier to read and write.