### PR TITLE
Fix bug preventing commands against stopped jails.

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -154,7 +154,7 @@ clone|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|service|st
                 fi
             done
         else
-            JAILS=$(jls name | awk "/^${TARGET}$/")
+            JAILS="${TARGET}"
 
             # Ensure the target exists. -- cwells
             if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -50,8 +50,8 @@ CPSOURCE="${1}"
 CPDEST="${2}"
 
 for _jail in ${JAILS}; do
-    bastille_jail_path="$(jls -j "${_jail}" path)"
     info "[${_jail}]:"
+    bastille_jail_path="${bastille_jailsdir}/${_jail}/root"
     cp -av "${CPSOURCE}" "${bastille_jail_path}/${CPDEST}"
     RETURN="$?"
     if [ "${TARGET}" = "ALL" ]; then


### PR DESCRIPTION
This allows `edit` and `cp` to work with stopped jails.

Likely fixes the same bug for `clone`, `export`, `limits`, `mount`, `umount`, and `zfs`. I did not verify the bug exists in those other commands, though.