### PR TITLE
Properly escape config property and value.

### DIFF
--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -71,7 +71,8 @@ for _jail in ${JAILS}; do
         continue
     fi
 
-    MATCH_LINE=$(grep "^\s*${PROPERTY}[ =;]" "${FILE}" 2>/dev/null)
+    ESCAPED_PROPERTY=$(echo "${PROPERTY}" | sed 's/\./\\\./g')
+    MATCH_LINE=$(grep "^ *${ESCAPED_PROPERTY}[ =;]" "${FILE}" 2>/dev/null)
     MATCH_FOUND=$?
 
     if [ "${ACTION}" = 'get' ]; then
@@ -89,6 +90,7 @@ for _jail in ${JAILS}; do
         fi
     else # Setting the value. -- cwells
         if [ -n "${VALUE}" ]; then
+            VALUE=$(echo "${VALUE}" | sed 's/\//\\\//g')
             if echo "${VALUE}" | grep ' ' > /dev/null 2>&1; then # Contains a space, so wrap in quotes. -- cwells
                 VALUE="'${VALUE}'"
             fi
@@ -100,7 +102,7 @@ for _jail in ${JAILS}; do
         if [ $MATCH_FOUND -ne 0 ]; then # No match, so insert the property at the end. -- cwells
             echo "$(awk -v line="${LINE}" '$0 == "}" { print line; } 1 { print $0; }' "${FILE}")" > "${FILE}"
         else # Replace the existing value. -- cwells
-            sed -i '' -E "s/ *${PROPERTY}[ =;].*/${LINE}/" "${FILE}"
+            sed -i '' -E "s/ *${ESCAPED_PROPERTY}[ =;].*/${LINE}/" "${FILE}"
         fi
     fi
 done


### PR DESCRIPTION
This resolves an issue setting values that contain a forward slash. I also fixed a potential issue where a dot in the property name could cause a false positive match on a property with a different character in the same position, but that shouldn't ever happen since real property names are not that similar.

You may want to wait for more feedback on the config feature before merging this one since I could amend the PR to include additional changes. I don't mind submitting another PR later if you want to get this fix in, though.