### PR TITLE
Update help usage on update command

### DIFF
--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille update [release|container]"
+    error_exit "Usage: bastille update [release|container] | [option]"
 }
 
 # Handle special-case commands first.


### PR DESCRIPTION
This is a quick update for the `bastille update` command for the recent changes and improvements.

`Usage: bastille update [release|container] | [option]`

Where **[option]** may be `-f|--force` in order to "_Force freebsd-update fetch to proceed in the case of an unfinished upgrade._"


Regards