### PR TITLE
Fix grep when UTF-8 is not used.

### DIFF
--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -72,7 +72,7 @@ for _jail in ${JAILS}; do
     fi
 
     ESCAPED_PROPERTY=$(echo "${PROPERTY}" | sed 's/\./\\\./g')
-    MATCH_LINE=$(grep "^ *${ESCAPED_PROPERTY}[ =;]" "${FILE}" 2>/dev/null)
+    MATCH_LINE=$(grep "^[[:blank:]]*${ESCAPED_PROPERTY}[[:blank:]=;]" "${FILE}" 2>/dev/null)
     MATCH_FOUND=$?
 
     if [ "${ACTION}" = 'get' ]; then

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -266,7 +266,7 @@ for _jail in ${JAILS}; do
 
     if [ -s "${bastille_template}/Bastillefile" ]; then
         # Ignore blank lines and comments. -- cwells
-        SCRIPT=$(grep -v '^\s*$' "${bastille_template}/Bastillefile" | grep -v '^\s*#')
+        SCRIPT=$(grep -v '^[[:blank:]]*$' "${bastille_template}/Bastillefile" | grep -v '^[[:blank:]]*#')
         # Use a newline as the separator. -- cwells
         IFS='
 '


### PR DESCRIPTION
Support tabs and spaces in templates/config.

This is a better fix for the non-UTF-8 issue.