### PR TITLE
adding a couple vnet exceptions for ip4.addr checks

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -58,9 +58,11 @@ if [ -z "${JAIL_NAME}" ]; then
 fi
 
 # Check jail ip4 address valid
-JAIL_IP=$(jls -j "${TARGET}" ip4.addr 2>/dev/null)
-if [ -z "${JAIL_IP}" -o "${JAIL_IP}" = "-" ]; then
-    error_exit "Jail IP not found: ${TARGET}"
+if [ "$(bastille config $TARGET get vnet)" != 'enabled' ]; then
+    JAIL_IP=$(jls -j "${TARGET}" ip4.addr 2>/dev/null)
+    if [ -z "${JAIL_IP}" -o "${JAIL_IP}" = "-" ]; then
+        error_exit "Jail IP not found: ${TARGET}"
+    fi
 fi
 
 # Check rdr-anchor is setup in pf.conf

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -226,10 +226,12 @@ for _jail in ${JAILS}; do
 
     ## jail-specific variables.
     bastille_jail_path=$(jls -j "${_jail}" path)
-    _jail_ip=$(jls -j "${_jail}" ip4.addr 2>/dev/null)
-    if [ -z "${_jail_ip}" -o "${_jail_ip}" = "-" ]; then
-        error_notify "Jail IP not found: ${_jail}"
-        _jail_ip='' # In case it was -. -- cwells
+    if [ "$(bastille config $TARGET get vnet)" != 'enabled' ]; then
+        _jail_ip=$(jls -j "${_jail}" ip4.addr 2>/dev/null)
+        if [ -z "${_jail_ip}" -o "${_jail_ip}" = "-" ]; then
+            error_notify "Jail IP not found: ${_jail}"
+            _jail_ip='' # In case it was -. -- cwells
+        fi
     fi
 
     ## TARGET


### PR DESCRIPTION
We check for ip4.addr in a few places. This adds exceptions to these checks for VNET containers as they're not going to return the data we want.