### PR TITLE
bastille cmd exit code not respected #272

### DIFF
--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -45,8 +45,29 @@ if [ $# -eq 0 ]; then
     usage
 fi
 
+COUNT=0
+RETURN=0
+
 for _jail in ${JAILS}; do
+    COUNT=$(($COUNT+1))
     info "[${_jail}]:"
     jexec -l "${_jail}" "$@"
+    ERROR_CODE=$?
+    info "[${_jail} - Return code]: ${ERROR_CODE}"
+
+    if [ "$COUNT" -eq 1 ]; then
+        RETURN=$ERROR_CODE
+    else 
+        RETURN=$(($RETURN+$ERROR_CODE))
+    fi
+
     echo
 done
+
+# Check when a command is executed in all running jails. (bastille cmd ALL ...)
+
+if [ "$COUNT" -gt 1 ] && [ "$RETURN" -gt 0 ]; then
+    RETURN=1
+fi 
+
+return "$RETURN"


### PR DESCRIPTION
I think there are 2 possibilities, execute a command in 1 jail or in all running jails.

When executing in one jail. I returned the right exit code:

root@bastille:~# bastille cmd test cat /etc/passwd
[test - Return code]: 0
root@bastille:~# echo $?
0

root@bastille:~ # bastille cmd test more xxx
[test]:
xxx: No such file or directory
[test - Return code]: 1

root@bastille:~ # echo $?
1

root@bastille:~ # bastille cmd test diff /test1 /test2
[test]:
diff: /test1: No such file or directory
[test - Return code]: 2

root@bastille:~ # echo $?
2

Running a command in all running jails:
After each jail, I returned the exit code.  If everything runs fine, I return "0", otherwise "1"

root@bastille:~ # bastille cmd ALL diff /test1 /test2
[test]:
diff: /test1: No such file or directory
[test - Return code]: 2

[test1]:
diff: /test1: No such file or directory
[test1 - Return code]: 2

root@bastille:~ # echo $?
1




