### PR TITLE
add required 'pass' to rdr rules

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
                 usage
             fi
             ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-              printf '%s\nrdr on $ext_if inet proto tcp to port %s -> %s port %s\n' "$EXT_IF" "$2" "$JAIL_IP" "$3" ) \
+              printf '%s\nrdr pass on $ext_if inet proto tcp to port %d -> %s port %d\n' "$EXT_IF" "$2" "$JAIL_IP" "$3" ) \
                   | pfctl -a "rdr/${JAIL_NAME}" -f-
             shift 3
             ;;
@@ -100,7 +100,7 @@ while [ $# -gt 0 ]; do
                 usage
             fi
             ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-              printf '%s\nrdr on $ext_if inet proto udp to port %s -> %s port %s\n' "$EXT_IF" "$2" "$JAIL_IP" "$3" ) \
+              printf '%s\nrdr pass on $ext_if inet proto udp to port %d -> %s port %d\n' "$EXT_IF" "$2" "$JAIL_IP" "$3" ) \
                   | pfctl -a "rdr/${JAIL_NAME}" -f-
             shift 3
             ;;


### PR DESCRIPTION
The `rdr` sub-command properly adds the rule to the `rdr-anchor` **however** it was missing the required "pass" to allow traffic.