### PR TITLE
Enable or disable a jail

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -138,7 +138,7 @@ help|-h|--help)
 bootstrap|create|destroy|import|list|rdr|restart|start|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
-clone|config|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)
+clone|config|cmd|console|convert|cp|disable|edit|enable|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)
     # Parse the target and ensure it exists. -- cwells
     if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
         PARAMS='help'
@@ -178,6 +178,10 @@ clone|config|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|ser
                 if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
                     error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
                 fi
+                ;;
+            enable|disable)
+                # Don't care what the status of the jail is. Running or not
+                :
                 ;;
             esac
         fi

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -45,8 +45,29 @@ if [ $# -eq 0 ]; then
     usage
 fi
 
+COUNT=0
+RETURN=0
+
 for _jail in ${JAILS}; do
+    COUNT=$(($COUNT+1))
     info "[${_jail}]:"
     jexec -l "${_jail}" "$@"
+    ERROR_CODE=$?
+    info "[${_jail} - Return code]: ${ERROR_CODE}"
+
+    if [ "$COUNT" -eq 1 ]; then
+        RETURN=$ERROR_CODE
+    else 
+        RETURN=$(($RETURN+$ERROR_CODE))
+    fi
+
     echo
 done
+
+# Check when a command is executed in all running jails. (bastille cmd ALL ...)
+
+if [ "$COUNT" -gt 1 ] && [ "$RETURN" -gt 0 ]; then
+    RETURN=1
+fi 
+
+return "$RETURN"

--- a/usr/local/share/bastille/disable.sh
+++ b/usr/local/share/bastille/disable.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    error_exit "Usage: bastille disable TARGET"
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+for _jail in ${JAILS}; do
+    ENABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf"
+    DISABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf.disabled"
+
+    if [ -f "$ENABLE_FILE" ] && [ -f "$DISABLE_FILE" ]; then
+        error_notify "${_jail}: Both files exist but only one file can exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    elif [ -f "$DISABLE_FILE" ]; then
+        warn "${_jail}: Is already disabled."
+    elif [ -f "$ENABLE_FILE" ]; then
+        info "${_jail}: Disabled." 
+        mv ${ENABLE_FILE} ${DISABLE_FILE}
+    else
+        error_notify "${_jail}: Very strange. Both files are missing. One file must exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    fi
+
+done

--- a/usr/local/share/bastille/enable.sh
+++ b/usr/local/share/bastille/enable.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    error_exit "Usage: bastille enable TARGET"
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+for _jail in ${JAILS}; do
+    ENABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf"
+    DISABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf.disabled"
+
+    if [ -f "$ENABLE_FILE" ] && [ -f "$DISABLE_FILE" ]; then
+        error_notify "${_jail}: Both files exist but only one file can exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    elif [ -f "$ENABLE_FILE" ]; then
+        warn "${_jail}: Is already enabled."
+    elif [ -f "$DISABLE_FILE" ]; then
+        info "${_jail}: Enabled." 
+        mv ${DISABLE_FILE} ${ENABLE_FILE}
+    else
+        error_notify "${_jail}: Very strange. Both files are missing. One file must exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    fi
+
+done


### PR DESCRIPTION
When rebooting the server, all the jails start up. Sometimes this is not what you want. Now, it is possible to enable or disable a jail.

root@bastille:~ # bastille enable test
test: Enabled.
root@bastille:~ # bastille disable test
test: Disabled.

When the jail is "disabled' it won't start up when the server is rebooted.

I have not changed the command "bastille list" because I have no idea what the best option is.