### PR TITLE
Jail cpu an memory statistics

### DIFF
--- a/jls2.sh
+++ b/jls2.sh
@@ -1,0 +1,13 @@
+#/bin/sh
+
+printf "   %-4s %-15s %-28s  %-36s  %-10s  %-12s  %-10s\n"       "JID"  "IP Address" "Hostname" "Path" "Memory" "Virtual Mem" "Disk"
+for JID in `jls | grep -v JID | awk '{print $1}'`
+do
+a=`jls -j $JID | sed 1d`
+b=`ps -J $JID -o rss | awk '{rss += $1} END {print rss}'`
+v=`ps -J $JID -o vsz | awk '{cpu += $1} END {print cpu}'`
+m=`jls -j $JID | sed 1d | awk '{print $4}'`
+d=`zfs list -H -o used $m`
+
+printf "%-90s  %-10s  %-12s  %-10s\n" "$a" "$(( ${b%% *} / 1024)) MB" "$(( ${v%% *} / 1024)) MB" "$d"
+done

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -103,6 +103,7 @@ Available Commands:
   rename      Rename a container.
   restart     Restart a running container.
   service     Manage services within targeted container(s).
+  stat        Print jails statistics.
   start       Start a stopped container.
   stop        Stop a running container.
   sysrc       Safely edit rc files within targeted container(s).
@@ -135,7 +136,7 @@ version|-v|--version)
 help|-h|--help)
     usage
     ;;
-bootstrap|create|destroy|import|list|rdr|restart|start|update|upgrade|verify)
+bootstrap|create|destroy|import|list|rdr|restart|start|stat|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
 clone|config|cmd|console|convert|cp|disable|edit|enable|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -138,7 +138,7 @@ help|-h|--help)
 bootstrap|create|destroy|import|list|rdr|restart|start|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
-clone|config|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)
+clone|config|cmd|console|convert|cp|disable|edit|enable|export|htop|limits|mount|pkg|rename|service|stop|sysrc|template|top|umount|zfs)
     # Parse the target and ensure it exists. -- cwells
     if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
         PARAMS='help'
@@ -178,6 +178,10 @@ clone|config|cmd|console|convert|cp|edit|export|htop|limits|mount|pkg|rename|ser
                 if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
                     error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
                 fi
+                ;;
+            enable|disable)
+                # Don't care what the status of the jail is. Running or not
+                :
                 ;;
             esac
         fi

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -45,8 +45,29 @@ if [ $# -eq 0 ]; then
     usage
 fi
 
+COUNT=0
+RETURN=0
+
 for _jail in ${JAILS}; do
+    COUNT=$(($COUNT+1))
     info "[${_jail}]:"
     jexec -l "${_jail}" "$@"
+    ERROR_CODE=$?
+    info "[${_jail} - Return code]: ${ERROR_CODE}"
+
+    if [ "$COUNT" -eq 1 ]; then
+        RETURN=$ERROR_CODE
+    else 
+        RETURN=$(($RETURN+$ERROR_CODE))
+    fi
+
     echo
 done
+
+# Check when a command is executed in all running jails. (bastille cmd ALL ...)
+
+if [ "$COUNT" -gt 1 ] && [ "$RETURN" -gt 0 ]; then
+    RETURN=1
+fi 
+
+return "$RETURN"

--- a/usr/local/share/bastille/disable.sh
+++ b/usr/local/share/bastille/disable.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    error_exit "Usage: bastille disable TARGET"
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+for _jail in ${JAILS}; do
+    ENABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf"
+    DISABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf.disabled"
+
+    if [ -f "$ENABLE_FILE" ] && [ -f "$DISABLE_FILE" ]; then
+        error_notify "${_jail}: Both files exist but only one file can exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    elif [ -f "$DISABLE_FILE" ]; then
+        warn "${_jail}: Is already disabled."
+    elif [ -f "$ENABLE_FILE" ]; then
+        info "${_jail}: Disabled." 
+        mv ${ENABLE_FILE} ${DISABLE_FILE}
+    else
+        error_notify "${_jail}: Very strange. Both files are missing. One file must exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    fi
+
+done

--- a/usr/local/share/bastille/enable.sh
+++ b/usr/local/share/bastille/enable.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    error_exit "Usage: bastille enable TARGET"
+}
+
+# Handle special-case commands first.
+case "$1" in
+help|-h|--help)
+    usage
+    ;;
+esac
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+for _jail in ${JAILS}; do
+    ENABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf"
+    DISABLE_FILE="${bastille_jailsdir}/${_jail}/jail.conf.disabled"
+
+    if [ -f "$ENABLE_FILE" ] && [ -f "$DISABLE_FILE" ]; then
+        error_notify "${_jail}: Both files exist but only one file can exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    elif [ -f "$ENABLE_FILE" ]; then
+        warn "${_jail}: Is already enabled."
+    elif [ -f "$DISABLE_FILE" ]; then
+        info "${_jail}: Enabled." 
+        mv ${DISABLE_FILE} ${ENABLE_FILE}
+    else
+        error_notify "${_jail}: Very strange. Both files are missing. One file must exist!!!\n\t${ENABLE_FILE}\n\t${DISABLE_FILE}"
+    fi
+
+done

--- a/usr/local/share/bastille/stat.sh
+++ b/usr/local/share/bastille/stat.sh
@@ -38,9 +38,11 @@ if [ $# -gt 0 ]; then
     usage
 fi
 
-ps -axwww -o jail,%mem,%cpu,rss | grep -v "^-" | tail +2 | sort -k 1,1 | awk \
+ps -axwww -o jail,%mem,%cpu,rss | grep -v "^-" | tail +2 | awk \
 '
-BEGIN { jail_string_length = 0}
+BEGIN { 
+    jail_string_length = 0
+}
 
 {
     if (jail_string_length < length($1))
@@ -54,13 +56,13 @@ BEGIN { jail_string_length = 0}
 
 END {
     format1 = "%-" jail_string_length + 2 "s %-5s %-5s %-10s \n"
-    format2 =  "%-" jail_string_length + 2 "s %-5s %-5s %-10.2f \n"
+    format2 = "%-" jail_string_length + 2 "s %-5s %-5s %-10.2f \n"
     print ""
 
     printf format1,"Hostname","%mem","%cpu","rss MB"
 
     for (hostname in jail_hostname)
-        printf format2,hostname,jail[hostname,"%mem"],jail[hostname,"%cpu"],jail[hostname,"rss"] / 1024
+        printf format2,hostname,jail[hostname,"%mem"],jail[hostname,"%cpu"],jail[hostname,"rss"] / 1024 | "sort -k 1,1"
 }'
 
 echo

--- a/usr/local/share/bastille/stat.sh
+++ b/usr/local/share/bastille/stat.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+
+usage() {
+    error_exit "Usage: bastille stat"
+}
+
+if [ $# -gt 0 ]; then
+    usage
+fi
+
+ps -axwww -o jail,%mem,%cpu,rss | grep -v "^-" | tail +2 | sort -k 1,1 | awk \
+'
+BEGIN { jail_string_length = 0}
+
+{
+    if (jail_string_length < length($1))
+        jail_string_length = length($1);
+
+    jail_hostname[$1] = $1
+    jail[$1,"%mem"] += $2
+    jail[$1,"%cpu"] += $3
+    jail[$1,"rss"]  += $4
+}
+
+END {
+    format1 = "%-" jail_string_length + 2 "s %-5s %-5s %-10s \n"
+    format2 =  "%-" jail_string_length + 2 "s %-5s %-5s %-10.2f \n"
+    print ""
+
+    printf format1,"Hostname","%mem","%cpu","rss MB"
+
+    for (hostname in jail_hostname)
+        printf format2,hostname,jail[hostname,"%mem"],jail[hostname,"%cpu"],jail[hostname,"rss"] / 1024
+}'
+
+echo


### PR DESCRIPTION
Sometimes you want to know what a jail is doing. The command "bastille stat" gives a sorted jails overview with cpu and memory statistics. It gives an indication. The figures are not 100% correct because libraries are shared between the jails. The cpu% can grow beyond the 100%. If you have 8 cores then the total of the cpu % can grow until 800%. But when you have a high cpu load it is a fast way to find a potential bottleneck.

root@bastille:~ # bastille stat

Hostname                                    %mem  %cpu    rss MB
bugs_bunny                                    1.6         63      15.10
chicken_farm                                  1.6         33      15.11
test                                                   0.6        0        5.27
test1                                                 0.6        0        5.25
this_is_a_very_long_hostname       2           0        19.38

rss = the real memory (resident set) size in MB

If it is interesting, than the command should be tested on different servers. Maybe there is a better solution with dtrace but that's another level. It would be great to also find netwerk and disk IO statistics.