### PR TITLE
rdr now persists rules by default; rdr.sh cleanup

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -42,9 +42,6 @@ post_command_hook() {
 
     case $_cmd in
         rdr)
-            if ! grep -qs "${_args}" "${bastille_jailsdir}/${_jail}/rdr.conf"; then
-                echo "${_args}" >> "${bastille_jailsdir}/${_jail}/rdr.conf"
-            fi
             echo -e ${_args}
     esac
 }


### PR DESCRIPTION
This patch does some general cleanup in the `rdr.sh` file and consolidates rdr rule persistence into the rdr sub-command. Now redirect rules will automatically be written by both sub-command and template application.

Other changes include adding missing(?) copyright, usage output cleanup and simplification of the tcp and udp rules additions.

Removed rule persistence check from `template.sh` as it is redundant.