### PR TITLE
Create vnet error

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018-2020, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2021, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -34,6 +34,9 @@
 usage() {
     error_exit "Usage: bastille create [option] name release ip [interface]"
 }
+usage_vnet() {
+    error_exit "Usage: bastille create -V name release ip interface"
+}
 
 running_jail() {
     if [ -n "$(jls name | awk "/^${NAME}$/")" ]; then
@@ -443,6 +446,10 @@ INTERFACE="$4"
 if [ -n "${EMPTY_JAIL}" ]; then
     if [ $# -ne 1 ]; then
         usage
+    fi
+elif [ -n "${VNET_JAIL}" ]; then
+    if [ $# -ne 4 ]; then
+        usage_vnet
     fi
 else
     if [ $# -gt 4 ] || [ $# -lt 3 ]; then


### PR DESCRIPTION
`create -V` requires a gateway interface otherwise creating will fail:

> root@bastille01:~ # bastille create -V poudriere01 12.2-RELEASE 192.168.240.20
> Valid: (192.168.178.20).
> 
> NAME: poudriere01.
> IP: 192.168.240.20.
> RELEASE: 12.2-RELEASE.
> 
> [poudriere01]:
> Usage: jib addm [-b BRIDGE_NAME] NAME [!]iface0 [[!]iface1 ...]
>         Creates e0b_NAME [e1b_NAME ...]
> jail: poudriere01: jib addm bastille2: failed
> 
> [poudriere01]: Not started. See 'bastille start poudriere01'.
> [poudriere01]: Not started. See 'bastille start poudriere01'.
> [poudriere01]:
> Usage: jib addm [-b BRIDGE_NAME] NAME [!]iface0 [[!]iface1 ...]
>         Creates e0b_NAME [e1b_NAME ...]
> jail: poudriere01: jib addm bastille2: failed
> 

This adds a simple check and according error message.