### PR TITLE
Basic Gitea/Git-Web/universal template bootstrapping.

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -420,10 +420,10 @@ current-build-latest|current-BUILD-LATEST|CURRENT-BUILD-LATEST)
     PLATFORM_OS="HardenedBSD"
     validate_release_url
     ;;
-http?://github.com/*/*|http?://gitlab.com/*/*)
+http://*/*/*|https://*/*/*)
     BASTILLE_TEMPLATE_URL=${1}
-    BASTILLE_TEMPLATE_USER=$(echo "${1}" | awk -F / '{ print $4 }')
-    BASTILLE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $5 }')
+	BASTILLE_TEMPLATE_USER=$(echo "${1}" | awk -F / '{ print $(NF-1) }')
+	BASTILLE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $NF }')
     bootstrap_template
     ;;
 *)


### PR DESCRIPTION
I use a Gitea repository for my Bastille templates. It would be nice to be able to use that repository instead of just GitLab or GitHub for `bastille bootstrap [template]`.

My "fix" is very basic and could probably be improved. It still assumes that the last two segments of the URL are the repo user and repo name.

This should also work for Git Web installations although I have only tested it with Gitea. It also works on the LAN, where the repository URL contains an IP address and port number.