### PR TITLE
Add support for bastille RAW image exports/imports, also extended help usage

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -259,17 +259,25 @@ create_jail() {
         echo
 
         if [ -z "${THICK_JAIL}" ]; then
-            LINK_LIST="bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/sbin usr/share usr/src"
+            LINK_LIST="bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/sbin usr/share"
             for _link in ${LINK_LIST}; do
                 ln -sf /.bastille/${_link} ${_link}
             done
-            # Properly link shared ports on thin jails in read-write.
+            # Copy optional distfiles if they exist on the base release.
             if [ -d "${bastille_releasesdir}/${RELEASE}/usr/ports" ]; then
                 if [ ! -d "${bastille_jail_path}/usr/ports" ]; then
-                    mkdir ${bastille_jail_path}/usr/ports
+                    info "Copying ports tree..."
+                    cp -a ${bastille_releasesdir}/${RELEASE}/usr/ports ${bastille_jail_path}/usr
                 fi
-                echo -e "${bastille_releasesdir}/${RELEASE}/usr/ports ${bastille_jail_path}/usr/ports nullfs rw 0 0" >> "${bastille_jail_fstab}"
             fi
+            if [ -d "${bastille_releasesdir}/${RELEASE}/usr/src" ]; then
+                if [ ! -d "${bastille_jail_path}/usr/src" ]; then
+                    info "Copying source tree..."
+                    ln -sf usr/src sys
+                    cp -a ${bastille_releasesdir}/${RELEASE}/usr/src ${bastille_jail_path}/usr
+                fi
+            fi
+            echo
         fi
 
         if [ -z "${THICK_JAIL}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -430,32 +430,36 @@ EMPTY_JAIL=""
 THICK_JAIL=""
 VNET_JAIL=""
 
-## handle combined options then shift
-if [ "${1}" = "-T" -o "${1}" = "--thick" -o "${1}" = "thick" ] && \
-    [ "${2}" = "-V" -o "${2}" = "--vnet" -o "${2}" = "vnet" ]; then
-    THICK_JAIL="1"
-    VNET_JAIL="1"
-    shift 2
-else
-    ## handle single options
+# Handle and parse options
+while [ $# -gt 0 ]; do
     case "${1}" in
         -E|--empty|empty)
-            shift
             EMPTY_JAIL="1"
+            shift
             ;;
         -T|--thick|thick)
-            shift
             THICK_JAIL="1"
+            shift
             ;;
         -V|--vnet|vnet)
-            shift
             VNET_JAIL="1"
+            shift
             ;;
-        -*)
+        -*|--*)
             error_notify "Unknown Option."
             usage
             ;;
+       *)
+            break
+            ;;
     esac
+done
+
+## validate for combined options
+if [ -n "${EMPTY_JAIL}" ]; then 
+    if [ -n "${THICK_JAIL}" ] || [ -n "${VNET_JAIL}" ]; then
+        error_exit "Error: Empty jail option can't be used with other options."
+    fi
 fi
 
 NAME="$1"

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -32,13 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille export TARGET [options] | PATH
-    \n
-    \nOptions:
-    \n
-      -t|--txz    -- Export to a standard .txz archive even if bastille is configured for zfs\n
-      -s|--safe   -- Safely stop the jail to snapshot it then start it again to proceed exporting\n
-      -r|--raw    -- Export the jail to an uncompressed raw image\n"
+    error_exit "Usage: bastille export TARGET [safe|tarball] | PATH"
 }
 
 # Handle special-case commands first
@@ -53,60 +47,40 @@ if [ "${TARGET}" = "ALL" ]; then
     error_exit "Batch export is unsupported."
 fi
 
-if [ $# -gt 4 ] || [ $# -lt 0 ]; then
+if [ $# -gt 2 ] || [ $# -lt 0 ]; then
     usage
 fi
 
+OPTION="${1}"
+EXPATH="${2}"
 SAFE_EXPORT=
-RAW_EXPORT=
-DIR_EXPORT=
-TXZ_EXPORT=
 
-# Handle and parse option args
-while [ $# -gt 0 ]; do
-    case "${1}" in
-        -t|--txz)
-            TXZ_EXPORT="1"
-            if [ "${bastille_zfs_enable}" = "YES" ]; then
-                bastille_zfs_enable="NO"
-            fi
-            shift
-            ;;
-        -s|--safe)
-            SAFE_EXPORT="1"
-            shift
-            ;;
-        -r|--raw)
-            RAW_EXPORT="1"
-            shift
-            ;;
-        *)
-            if echo "${1}" | grep -q "\/"; then
-                DIR_EXPORT="${1}"
-            else
-               usage
-            fi
-            shift
-            ;;
-    esac
-done
-
-## validate for combined options
-if [ -n "${TXZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
-    error_exit "Error: Archive mode and Safe mode exports can't be used together."
-fi
-if [ -n "${SAFE_EXPORT}" ]; then
-    # Check if container is running, otherwise don't try to stop/start the jail
-    if [ -z "$(jls name | awk "/^${TARGET}$/")" ]; then
-        SAFE_EXPORT=
+# Handle some options
+if [ -n "${OPTION}" ]; then
+    if [ "${OPTION}" = "-t" -o "${OPTION}" = "--txz" -o ${OPTION} = "tarball" ]; then
+        if [ "${bastille_zfs_enable}" = "YES" ]; then
+            # Temporarily disable ZFS so we can create a standard backup archive
+            bastille_zfs_enable="NO"
+        fi
+    elif [ "${OPTION}" = "-s" -o "${OPTION}" = "--safe" -o ${OPTION} = "safe" ]; then
+        SAFE_EXPORT="1"
+    elif echo "${OPTION}" | grep -q "\/"; then
+        if [ -d "${OPTION}" ]; then
+            EXPATH="${OPTION}"
+        else
+            error_exit "Error: Path not found."
+        fi
+    else
+        error_notify "Invalid option!"
+        usage
     fi
 fi
 
 # Export directory check
-if [ -n "${DIR_EXPORT}" ]; then
-    if [ -d "${DIR_EXPORT}" ]; then
+if [ -n "${EXPATH}" ]; then
+    if [ -d "${EXPATH}" ]; then
         # Set the user defined export directory
-        bastille_backupsdir="${DIR_EXPORT}"
+        bastille_backupsdir="${EXPATH}"
     else
         error_exit "Error: Path not found."
     fi
@@ -118,63 +92,36 @@ create_zfs_snap(){
     zfs snapshot -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}"
 }
 
-export_check(){
-    # Inform the user about the exporting method
-    if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
-        EXPORT_AS="Hot exporting"
-    else
-        EXPORT_AS="Exporting"
-    fi
-    if [ -n "${RAW_EXPORT}" ]; then
-        EXPORT_INFO="to a raw"
-    else
-        EXPORT_INFO="to a compressed ${FILE_EXT}"
-    fi
-
-    # Safely stop and snapshot the jail
-    if [ -n "${SAFE_EXPORT}" ]; then
-        info "Safely exporting '${TARGET}' ${EXPORT_INFO} archive."
-        bastille stop ${TARGET}
-        create_zfs_snap
-        bastille start ${TARGET}
-    else
-        info "${EXPORT_AS} '${TARGET}' ${EXPORT_INFO} archive."
-        create_zfs_snap
-    fi
-    info "Sending ZFS data stream..."
-}
-
 jail_export()
 {
     # Attempt to export the container
     DATE=$(date +%F-%H%M%S)
     if [ "${bastille_zfs_enable}" = "YES" ]; then
         if [ -n "${bastille_zfs_zpool}" ]; then
-            if [ -n "${RAW_EXPORT}" ]; then
-                FILE_EXT=""
-                export_check
+            FILE_EXT="xz"
 
-                # Export the raw container recursively and cleanup temporary snapshots
-                zfs send -R "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}" \
-                > "${bastille_backupsdir}/${TARGET}_${DATE}"
-                zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}/root@bastille_export_${DATE}"
-                zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}"
+            if [ -n "${SAFE_EXPORT}" ]; then
+                info "Safely exporting '${TARGET}' to a compressed .${FILE_EXT} archive."
+                bastille stop ${TARGET}
+                create_zfs_snap
+                bastille start ${TARGET}
             else
-                FILE_EXT=".xz"
-                export_check
-
-                # Export the container recursively and cleanup temporary snapshots
-                zfs send -R "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}" | \
-                xz ${bastille_compress_xz_options} > "${bastille_backupsdir}/${TARGET}_${DATE}${FILE_EXT}"
-                zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}/root@bastille_export_${DATE}"
-                zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}"
+                info "Hot exporting '${TARGET}' to a compressed .${FILE_EXT} archive."
+                create_zfs_snap
             fi
+
+            info "Sending ZFS data stream..."
+            # Export the container recursively and cleanup temporary snapshots
+            zfs send -R "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}" | \
+            xz ${bastille_compress_xz_options} > "${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}"
+            zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}/root@bastille_export_${DATE}"
+            zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}@bastille_export_${DATE}"
         fi
     else
         # Create standard backup archive
-        FILE_EXT=".txz"
-        info "Exporting '${TARGET}' to a compressed ${FILE_EXT} archive..."
-        cd "${bastille_jailsdir}" && tar -cf - "${TARGET}" | xz ${bastille_compress_xz_options} > "${bastille_backupsdir}/${TARGET}_${DATE}${FILE_EXT}"
+        FILE_EXT="txz"
+        info "Exporting '${TARGET}' to a compressed .${FILE_EXT} archive..."
+        cd "${bastille_jailsdir}" && tar -cf - "${TARGET}" | xz ${bastille_compress_xz_options} > "${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}"
     fi
 
     if [ "$?" -ne 0 ]; then
@@ -182,8 +129,8 @@ jail_export()
     else
         # Generate container checksum file
         cd "${bastille_backupsdir}"
-        sha256 -q "${TARGET}_${DATE}${FILE_EXT}" > "${TARGET}_${DATE}.sha256"
-        info "Exported '${bastille_backupsdir}/${TARGET}_${DATE}${FILE_EXT}' successfully."
+        sha256 -q "${TARGET}_${DATE}.${FILE_EXT}" > "${TARGET}_${DATE}.sha256"
+        info "Exported '${bastille_backupsdir}/${TARGET}_${DATE}.${FILE_EXT}' successfully."
         exit 0
     fi
 }

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -60,11 +60,13 @@ fi
 SAFE_EXPORT=
 RAW_EXPORT=
 DIR_EXPORT=
+TXZ_EXPORT=
 
 # Handle and parse option args
 while [ $# -gt 0 ]; do
     case "${1}" in
         -t|--txz)
+            TXZ_EXPORT="1"
             if [ "${bastille_zfs_enable}" = "YES" ]; then
                 bastille_zfs_enable="NO"
             fi
@@ -88,6 +90,17 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+## validate for combined options
+if [ -n "${TXZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
+    error_exit "Error: Archive mode and Safe mode exports can't be used together."
+fi
+if [ -n "${SAFE_EXPORT}" ]; then
+    # Check if container is running, otherwise don't try to stop/start the jail
+    if [ -z "$(jls name | awk "/^${TARGET}$/")" ]; then
+        SAFE_EXPORT=
+    fi
+fi
 
 # Export directory check
 if [ -n "${DIR_EXPORT}" ]; then

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -32,11 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille import FILE [option]
-    \n
-    \nOptions:
-    \n
-      -f|--force   -- Force an archive import even if the checksum file is missing or don't match\n"
+    error_exit "Usage: bastille import file [force]"
 }
 
 # Handle special-case commands first
@@ -51,21 +47,8 @@ if [ $# -gt 2 ] || [ $# -lt 1 ]; then
 fi
 
 TARGET="${1}"
+OPTION="${2}"
 shift
-OPT_FORCE=
-
-# Handle and parse option args
-while [ $# -gt 0 ]; do
-    case "${1}" in
-        -f|force|--force)
-            OPT_FORCE="1"
-            shift
-            ;;
-        *)
-            usage
-            ;;
-    esac
-done
 
 validate_archive() {
     # Compare checksums on the target archive
@@ -83,7 +66,7 @@ validate_archive() {
                 fi
             else
                 # Check if user opt to force import
-                if [ -n "${OPT_FORCE}" ]; then
+                if [ "${OPTION}" = "-f" -o "${OPTION}" = "force" ]; then
                     warn "Warning: Skipping archive validation!"
                 else
                     error_exit "Checksum file not found. See 'bastille import TARGET -f'."
@@ -420,17 +403,6 @@ jail_import() {
                     else
                         update_config
                     fi
-                elif [ -z "${FILE_EXT}" ]; then
-                    if echo "${TARGET}" | grep -q '_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}$'; then
-                    # Based on the file name, looks like we are importing a raw bastille image
-                    # Import from uncompressed image file
-                    info "Importing '${TARGET_TRIM}' from uncompressed image archive."
-                    info "Receiving ZFS data stream..."
-                    zfs receive -u "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}" < "${bastille_backupsdir}/${TARGET}"
-
-                    # Update ZFS mountpoint property if required
-                    update_zfsmount
-                    fi
                 else
                     error_exit "Unknown archive format."
                 fi
@@ -493,9 +465,9 @@ fi
 # Check if archive exist then trim archive name
 if [ -f "${bastille_backupsdir}/${TARGET}" ]; then
     # Filter unsupported/unknown archives
-    if echo "${TARGET}" | grep -q '_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}$\|_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}.xz$\|_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}.txz$\|_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}.zip$\|-[0-9]\{12\}.[0-9]\{2\}.tar.gz$\|@[0-9]\{12\}.[0-9]\{2\}.tar$'; then
+    if echo "${TARGET}" | grep -q '_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}.xz$\|_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}.txz$\|_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}.zip$\|-[0-9]\{12\}.[0-9]\{2\}.tar.gz$\|@[0-9]\{12\}.[0-9]\{2\}.tar$'; then
         if ls "${bastille_backupsdir}" | awk "/^${TARGET}$/" >/dev/null; then
-            TARGET_TRIM=$(echo "${TARGET}" | sed "s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*.xz//;s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*.txz//;s/_[0-9]*-[0-9]*-[0-9]*.zip//;s/-[0-9]\{12\}.[0-9]\{2\}.tar.gz//;s/@[0-9]\{12\}.[0-9]\{2\}.tar//;s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*//")
+            TARGET_TRIM=$(echo "${TARGET}" | sed "s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*.xz//;s/_[0-9]*-[0-9]*-[0-9]*-[0-9]*.txz//;s/_[0-9]*-[0-9]*-[0-9]*.zip//;s/-[0-9]\{12\}.[0-9]\{2\}.tar.gz//;s/@[0-9]\{12\}.[0-9]\{2\}.tar//")
         fi
     else
         error_exit "Unrecognized archive name."

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -93,26 +93,27 @@ for _jail in ${JAILS}; do
     info "[${_jail}]:"
 
     ## aggregate variables into FSTAB entry
-    _jailpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"
-    _fstab_entry="${_hostpath} ${_jailpath} ${_type} ${_perms} ${_checks}"
+    _jailpath_entry="${bastille_jailsdir}/${_jail}/root${_jailpath}"
+    _fstab_entry="${_hostpath} ${_jailpath_entry} ${_type} ${_perms} ${_checks}"
 
     ## Create mount point if it does not exist. -- cwells
-    if [ ! -d "${bastille_jailsdir}/${_jail}/root/${_jailpath}" ]; then
-        if ! mkdir -p "${bastille_jailsdir}/${_jail}/root/${_jailpath}"; then
+    if [ ! -d "${bastille_jailsdir}/${_jail}/root${_jailpath}" ]; then
+        if ! mkdir -p "${bastille_jailsdir}/${_jail}/root${_jailpath}"; then
             error_exit "Failed to create mount point inside jail."
         fi
     fi
 
     ## if entry doesn't exist, add; else show existing entry
-    if ! egrep -q "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
+    if ! egrep -q "[[:blank:]]${_jailpath_entry}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
         if ! echo "${_fstab_entry}" >> "${bastille_jailsdir}/${_jail}/fstab"; then
             error_exit "Failed to create fstab entry: ${_fstab_entry}"
         fi
         echo "Added: ${_fstab_entry}"
     else
         warn "Mountpoint already present in ${bastille_jailsdir}/${_jail}/fstab"
-        egrep "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
+        egrep "[[:blank:]]${_jailpath_entry}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
     fi
     mount -F "${bastille_jailsdir}/${_jail}/fstab" -a
+    _jailpath_entry=
     echo
 done

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -57,7 +57,7 @@ for _jail in ${JAILS}; do
         fi
 
         # Check if pfctl is present
-        if test -f /sbin/pfctl; then
+        if which -s pfctl; then
             if [ "$(bastille rdr ${_jail} list)" ]; then
                 bastille rdr ${_jail} clear
             fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -55,9 +55,12 @@ for _jail in ${JAILS}; do
                 pfctl -q -t jails -T delete "$(jls -j ${_jail} ip4.addr)"
             fi
         fi
-        
-        if [ "$(bastille rdr ${_jail} list)" ]; then
-            bastille rdr ${_jail} clear
+
+        # Check if pfctl is present
+        if test -f /sbin/pfctl; then
+            if [ "$(bastille rdr ${_jail} list)" ]; then
+                bastille rdr ${_jail} clear
+            fi
         fi
 
         ## remove rctl limits


### PR DESCRIPTION
This PR add support for bastille RAW image exports and imports, also extended the built-in help usage for convenience.

**Extended usage:**
```
root@server: ~# bastille export
Usage: bastille export TARGET [options] | PATH 
 
Options: 
 -t|--txz -- Export to a standard .txz archive even if bastille is configured for zfs
 -s|--safe -- Safely stop the jail to snapshot it then start it again to proceed exporting
 -r|--raw -- Export the jail to an uncompressed raw image
```

```
root@server: ~# bastille import
Usage: bastille import FILE [option] 
 
Options: 
 -f|--force -- Force an archive import even if the checksum file is missing or don't match
```

Also this replaces the clunky if statements for handle options in favor better case/esac style

Regards