### PR TITLE
revert default template link; error->notify for bootstrap

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -178,7 +178,6 @@ bootstrap_directories() {
         else
             mkdir -p "${bastille_templatesdir}"
         fi
-        ln -s "${bastille_sharedir}/templates/default" "${bastille_templatesdir}/default"
     fi
 
     ## ${bastille_releasesdir}
@@ -216,7 +215,7 @@ bootstrap_release() {
 
         ## check if release already bootstrapped, else continue bootstrapping
         if [ -z "${bastille_bootstrap_archives}" ]; then
-            error_exit "Bootstrap appears complete."
+            error_notify "Bootstrap appears complete."
         else
             info "Bootstrapping additional distfiles..."
         fi


### PR DESCRIPTION
This removes the unneeded symlink for a `default` template.
Also changes error to notify for bootstrap complete.