### PR TITLE
added the new option -a (aka all, --all) for list

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -54,13 +54,15 @@ if [ $# -gt 0 ]; then
         if [ -d "${bastille_jailsdir}" ] && [ "$(find "${bastille_jailsdir}" -type d -links 2)" ]; then
 
             SPACER=4
-            MAX_LENGTH_JAIL_NAME=$(ls "${bastille_jailsdir}" | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_NAME=$(ls ${bastille_jailsdir}/*/jail.conf | sed "s/^.*\/\(.*\)\/jail.conf$/\1/" | awk '{ print length($0) }' | sort -nr | head -n 1)
             MAX_LENGTH_JAIL_NAME=${MAX_LENGTH_JAIL_NAME:-3}
+            if [ ${MAX_LENGTH_JAIL_NAME} -lt 3 ]; then MAX_LENGTH_JAIL_NAME=3; fi
             MAX_LENGTH_JAIL_IP=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name jail.conf -exec grep "ip4.addr" {} \; | sed -ne "s/^[ ]*ip4.addr[ ]*=[ ]*\(.*\);$/\1/p" | awk '{ print length($0) }' | sort -nr | head -n 1)
             MAX_LENGTH_JAIL_IP=${MAX_LENGTH_JAIL_IP:-10}
             if [ ${MAX_LENGTH_JAIL_IP} -lt 10 ]; then MAX_LENGTH_JAIL_IP=10; fi
             MAX_LENGTH_JAIL_HOSTNAME=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name jail.conf -exec grep "host.hostname" {} \; | sed -ne "s/^[ ]*host.hostname[ ]*=[ ]*\(.*\);$/\1/p" | awk '{ print length($0) }' | sort -nr | head -n 1)
             MAX_LENGTH_JAIL_HOSTNAME=${MAX_LENGTH_JAIL_HOSTNAME:-8}
+            if [ ${MAX_LENGTH_JAIL_HOSTNAME} -lt 8 ]; then MAX_LENGTH_JAIL_HOSTNAME=8; fi
             MAX_LENGTH_JAIL_PORTS=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name rdr.conf -exec awk '{ lines++; chars += length($0)} END { chars += lines - 1; print chars }' {} \; | sort -nr | head -n 1)
             MAX_LENGTH_JAIL_PORTS=${MAX_LENGTH_JAIL_PORTS:-15}
             if [ ${MAX_LENGTH_JAIL_PORTS} -lt 15 ]; then MAX_LENGTH_JAIL_PORTS=15; fi

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille list [-j] [release|template|(jail|container)|log|limit|(import|export|backup)]"
+    error_exit "Usage: bastille list [-j][-a] [release|template|(jail|container)|log|limit|(import|export|backup)]"
 }
 
 if [ $# -eq 0 ]; then
@@ -49,6 +49,49 @@ if [ $# -gt 0 ]; then
     case "$1" in
     help|-h|--help)
         usage
+        ;;
+    all|-a|--all)
+        if [ -d "${bastille_jailsdir}" ] && [ "$(find "${bastille_jailsdir}" -type d -links 2)" ]; then
+
+            SPACER=4
+            MAX_LENGTH_JAIL_NAME=$(ls "${bastille_jailsdir}" | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_NAME=${MAX_LENGTH_JAIL_NAME:-3}
+            MAX_LENGTH_JAIL_IP=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name jail.conf -exec grep "ip4.addr" {} \; | sed -ne "s/^[ ]*ip4.addr[ ]*=[ ]*\(.*\);$/\1/p" | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_IP=${MAX_LENGTH_JAIL_IP:-10}
+            if [ ${MAX_LENGTH_JAIL_IP} -lt 10 ]; then MAX_LENGTH_JAIL_IP=10; fi
+            MAX_LENGTH_JAIL_HOSTNAME=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name jail.conf -exec grep "host.hostname" {} \; | sed -ne "s/^[ ]*host.hostname[ ]*=[ ]*\(.*\);$/\1/p" | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_HOSTNAME=${MAX_LENGTH_JAIL_HOSTNAME:-8}
+            MAX_LENGTH_JAIL_PORTS=$(find "${bastille_jailsdir}" -maxdepth 2 -type f -name rdr.conf -exec awk '{ lines++; chars += length($0)} END { chars += lines - 1; print chars }' {} \; | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_PORTS=${MAX_LENGTH_JAIL_PORTS:-15}
+            if [ ${MAX_LENGTH_JAIL_PORTS} -lt 15 ]; then MAX_LENGTH_JAIL_PORTS=15; fi
+            if [ ${MAX_LENGTH_JAIL_PORTS} -gt 30 ]; then MAX_LENGTH_JAIL_PORTS=30; fi
+
+            printf " JID%*sState%*sIP Address%*sPublished Ports%*sHostname%*sPath\n" "$((${MAX_LENGTH_JAIL_NAME} + ${SPACER} - 3))" "" "$((${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} + ${SPACER} - 10))" "" "$((${MAX_LENGTH_JAIL_PORTS} + ${SPACER} - 15))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} + ${SPACER} - 8))" ""
+
+            JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
+            for _JAIL in ${JAIL_LIST}; do
+                if [ -f "${bastille_jailsdir}/${_JAIL}/jail.conf" ]; then
+                        if [ "$(jls name | awk "/^${_JAIL}$/")" ]; then
+                                JAIL_STATE="Up"
+                                JAIL_IP=$(jls -j ${_JAIL} ip4.addr 2> /dev/null)
+                                JAIL_HOSTNAME=$(jls -j ${_JAIL} host.hostname 2> /dev/null)
+                                JAIL_PORTS=$(pfctl -a "rdr/${_JAIL}" -Psn 2> /dev/null | awk '{ printf "%s/%s:%s"",",$7,$14,$18 }' | sed "s/,$//")
+                                JAIL_PATH=$(jls -j ${_JAIL} path 2> /dev/null)
+                        else
+                                JAIL_STATE="Down"
+                                JAIL_IP=$(grep "ip4.addr" "${bastille_jailsdir}/${_JAIL}/jail.conf" | sed -ne "s/^[ ]*ip4.addr[ ]*=[ ]*\(.*\);$/\1/p")
+                                JAIL_HOSTNAME=$(grep "host.hostname" "${bastille_jailsdir}/${_JAIL}/jail.conf" | sed -ne "s/^[ ]*host.hostname[ ]*=[ ]*\(.*\);$/\1/p")
+                                JAIL_PORTS=$(awk '$1 ~ /^[tcp|udp]/ { printf "%s/%s:%s"",",$1,$2,$3 }' "${bastille_jailsdir}/${_JAIL}/rdr.conf" 2> /dev/null | sed "s/,$//")
+                                JAIL_PATH=$(grep "path" "${bastille_jailsdir}/${_JAIL}/jail.conf" | sed -ne "s/^[ ]*path[ ]*=[ ]*\(.*\);$/\1/p")
+                        fi
+                        JAIL_IP=${JAIL_IP:-"-"}
+                        JAIL_PORTS=${JAIL_PORTS:-"-"}
+                        if [ ${#JAIL_PORTS} -gt ${MAX_LENGTH_JAIL_PORTS} ]; then JAIL_PORTS="$(echo ${JAIL_PORTS} | cut -c-$((${MAX_LENGTH_JAIL_PORTS} - 3)))..."; fi
+
+                        printf " ${_JAIL}%*s${JAIL_STATE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#_JAIL} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" ""
+                fi
+            done
+        fi
         ;;
     release|releases)
         if [ -d "${bastille_releasesdir}" ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -67,7 +67,7 @@ if [ $# -gt 0 ]; then
             MAX_LENGTH_JAIL_PORTS=${MAX_LENGTH_JAIL_PORTS:-15}
             if [ ${MAX_LENGTH_JAIL_PORTS} -lt 15 ]; then MAX_LENGTH_JAIL_PORTS=15; fi
             if [ ${MAX_LENGTH_JAIL_PORTS} -gt 30 ]; then MAX_LENGTH_JAIL_PORTS=30; fi
-            MAX_LENGTH_JAIL_RELEASE=$(find "${bastille_jailsdir}" f -name fstab -maxdepth 3 -exec sed "s/^.*releases\/\(.*\) \/.*$/\1/" {} \; | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_RELEASE=$(find "${bastille_jailsdir}" -type f -name fstab -maxdepth 3 -exec sed "s/^.*releases\/\(.*\) \/.*$/\1/" {} \; | awk '{ print length($0) }' | sort -nr | head -n 1)
             MAX_LENGTH_JAIL_RELEASE=${MAX_LENGTH_JAIL_RELEASE:-7}
             if [ ${MAX_LENGTH_JAIL_RELEASE} -lt 7 ]; then MAX_LENGTH_JAIL_RELEASE=7; fi
 

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -67,8 +67,11 @@ if [ $# -gt 0 ]; then
             MAX_LENGTH_JAIL_PORTS=${MAX_LENGTH_JAIL_PORTS:-15}
             if [ ${MAX_LENGTH_JAIL_PORTS} -lt 15 ]; then MAX_LENGTH_JAIL_PORTS=15; fi
             if [ ${MAX_LENGTH_JAIL_PORTS} -gt 30 ]; then MAX_LENGTH_JAIL_PORTS=30; fi
+            MAX_LENGTH_JAIL_RELEASE=$(find "${bastille_jailsdir}" f -name fstab -maxdepth 3 -exec sed "s/^.*releases\/\(.*\) \/.*$/\1/" {} \; | awk '{ print length($0) }' | sort -nr | head -n 1)
+            MAX_LENGTH_JAIL_RELEASE=${MAX_LENGTH_JAIL_RELEASE:-7}
+            if [ ${MAX_LENGTH_JAIL_RELEASE} -lt 7 ]; then MAX_LENGTH_JAIL_RELEASE=7; fi
 
-            printf " JID%*sState%*sIP Address%*sPublished Ports%*sHostname%*sPath\n" "$((${MAX_LENGTH_JAIL_NAME} + ${SPACER} - 3))" "" "$((${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} + ${SPACER} - 10))" "" "$((${MAX_LENGTH_JAIL_PORTS} + ${SPACER} - 15))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} + ${SPACER} - 8))" ""
+            printf " JID%*sState%*sIP Address%*sPublished Ports%*sHostname%*sRelease%*sPath\n" "$((${MAX_LENGTH_JAIL_NAME} + ${SPACER} - 3))" "" "$((${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} + ${SPACER} - 10))" "" "$((${MAX_LENGTH_JAIL_PORTS} + ${SPACER} - 15))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} + ${SPACER} - 8))" "" "$((${MAX_LENGTH_JAIL_RELEASE} + ${SPACER} - 7))" ""
 
             JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
             for _JAIL in ${JAIL_LIST}; do
@@ -89,8 +92,9 @@ if [ $# -gt 0 ]; then
                         JAIL_IP=${JAIL_IP:-"-"}
                         JAIL_PORTS=${JAIL_PORTS:-"-"}
                         if [ ${#JAIL_PORTS} -gt ${MAX_LENGTH_JAIL_PORTS} ]; then JAIL_PORTS="$(echo ${JAIL_PORTS} | cut -c-$((${MAX_LENGTH_JAIL_PORTS} - 3)))..."; fi
+                        JAIL_RELEASE=$(sed "s/^.*releases\/\(.*\) \/.*$/\1/" "${bastille_jailsdir}/${_JAIL}/fstab")
 
-                        printf " ${_JAIL}%*s${JAIL_STATE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#_JAIL} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" ""
+                        printf " ${_JAIL}%*s${JAIL_STATE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_RELEASE}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#_JAIL} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_RELEASE} - ${#JAIL_RELEASE} + ${SPACER}))" ""
                 fi
             done
         fi


### PR DESCRIPTION
### bastille list -a
This new option lists all jails, show state 'Up' or 'Down', published ports (rdr) and releases, used command jls -j <jail> to collect infos for active jails and the files jail.conf, rdr.conf for inactive jails.

```shell
root@beastie:~ # bastille list -h
Usage: bastille list [-j|-a] [release|template|(jail|container)|log|limit|(import|export|backup)]

root@beastie:~ # bastille list -a
 JID             State    IP Address     Published Ports                   Hostname        Release         Path
 alcatraz        Up       172.16.10.1    tcp/8080:80                       alcatraz        12.2-RELEASE    /usr/local/bastille/jails/alcatraz/root
 askaban         Down     172.16.10.4    -                                 askaban         12.2-RELEASE    /usr/local/bastille/jails/askaban/root
 conciergerie    Up       172.16.10.2    tcp/8282:82,udp/8484:84,tcp...    conciergerie    11.4-RELEASE    /usr/local/bastille/jails/conciergerie/root
 newgate         Down     172.16.10.3    -                                 newgate         13.0-RELEASE    /usr/local/bastille/jails/newgate/root
```