### PR TITLE
Fixed #368 allowing mixed case YES values for bastille_zfs_enable

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -35,6 +35,10 @@ usage() {
     error_exit "Usage: bastille bootstrap [release|template] [update|arch]"
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -35,6 +35,10 @@ usage() {
     error_exit "Usage: bastille clone [TARGET] [NEW_NAME] [IPADRESS]"
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -48,3 +48,13 @@ info() {
 warn() {
     echo -e "${COLOR_YELLOW}$*${COLOR_RESET}"
 }
+
+# Used before comparing bastille.conf arguments
+capitalise_conf_yes() {
+  answer=$1
+  case $1 in
+      y|yes|Y|Yes|YEs|yEs|yeS|yES)
+          answer="YES"
+          ;;
+  esac
+}

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -417,6 +417,10 @@ create_jail() {
     fi
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -165,6 +165,10 @@ destroy_rel() {
     fi
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -35,6 +35,10 @@ usage() {
     error_exit "Usage: bastille export TARGET [option] | PATH"
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -35,6 +35,10 @@ usage() {
     error_exit "Usage: bastille import file [option]"
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first
 case "$1" in
 help|-h|--help)

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -45,6 +45,10 @@ validate_name() {
     fi
 }
 
+# Capitalise bastille.conf $bastille_zfs_enable value
+capitalise_conf_yes $bastille_zfs_enable
+bastille_zfs_enable=$answer
+
 # Handle special-case commands first
 case "$1" in
 help|-h|--help)


### PR DESCRIPTION
It took me quite a while to realise the `bastille_zfs_enable` value had to be UPPERCASE. This adds a function to capitalise any case 'yes' value, it also avoids touching the logical if statements in the various files. I've added the necessary code in any file where `bastille_zfs_enable` is used. It may be preferred to source a normalise.sh file at the top of every script, just after sourcing bastille.conf to avoid this cruft and ensure it's called in any new scripts, if the normalise method is preferred I'll submit another fix.