### PR TITLE
Don't include jail path twice

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -97,8 +97,8 @@ for _jail in ${JAILS}; do
     _fstab_entry="${_hostpath} ${_jailpath} ${_type} ${_perms} ${_checks}"
 
     ## Create mount point if it does not exist. -- cwells
-    if [ ! -d "${bastille_jailsdir}/${_jail}/root/${_jailpath}" ]; then
-        if ! mkdir -p "${bastille_jailsdir}/${_jail}/root/${_jailpath}"; then
+    if [ ! -d "${_jailpath}" ]; then
+        if ! mkdir -p "${_jailpath}"; then
             error_exit "Failed to create mount point inside jail."
         fi
     fi


### PR DESCRIPTION
In ed50e3fa041b35f274a30e0f2ac425252485e7f0 _jailpath was updated to include the full path on the host.
The test and if required mkdir are now done with the jail’s root directory perpended to that full path.