### PR TITLE
Add support for BSD grep in list command, no need extended regex.

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep -Ev "*.sha256"
+        ls "${bastille_backupsdir}" | grep -v ".*\.sha256"
     exit 0
     ;;
     *)


### PR DESCRIPTION
wildcard `*` only supported in GNU grep, and since we're not specifying that GNU grep as dependency, was thinking we should support standard BSD grep too.
![Screenshot from 2021-06-06 20-16-40](https://user-images.githubusercontent.com/177826/120925839-ab241f80-c704-11eb-9d55-5fbabdfdea5e.png)

I think we could use better display here with more information. Willing to work on it if there is some suggestion.