### PR TITLE
Fixes #338 Network access on jail startup 

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -83,6 +83,8 @@ for _jail in ${JAILS}; do
                 error_notify "Error: IP address (${ip}) already in use."
                 continue
             fi
+            ## add ip4.addr to firewall table:jails
+            pfctl -q -t jails -T add "${ip}"
         fi
 
         ## start the container
@@ -101,13 +103,6 @@ for _jail in ${JAILS}; do
             while read _rules; do
                 bastille rdr "${_jail}" ${_rules}
             done < "${bastille_jailsdir}/${_jail}/rdr.conf"
-        fi
-
-        ## add ip4.addr to firewall table:jails
-        if [ -n "${bastille_network_loopback}" ]; then
-            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-                pfctl -q -t jails -T add "$(jls -j ${_jail} ip4.addr)"
-            fi
         fi
     fi
     echo


### PR DESCRIPTION
This fixes the referenced issue.

This PR will apply cleanly on master but would conflict with my other pull request #386 where I added ipv6 support. Which ever you decide to merge first I will rework the other one so that it applies cleanly.

I updated the PR to remove duplicate code, a jail ip was already fetched in the code right above. I am not a fan of the grep|awk|sed in place and I left this code as is, but I can improve on it if you prefer.