### PR TITLE
Allow any case for bastille_zfs_enable value.

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -54,6 +54,7 @@ bastille_conf_check
 
 ## we only load the config if conf_check passes
 . /usr/local/etc/bastille/bastille.conf
+bastille_zfs_enable=$(echo "${bastille_zfs_enable}" | tr [:lower:] [:upper:])
 
 ## bastille_prefix should be 0750
 ## this restricts file system access to privileged users
@@ -195,12 +196,10 @@ if [ -f "${SCRIPTPATH}" ]; then
     : "${UMASK:=022}"
     umask "${UMASK}"
 
-    : "${SH:=sh}"
-
     if [ -n "${PARAMS}" ]; then
-        exec "${SH}" "${SCRIPTPATH}" "${PARAMS}"
+        . "${SCRIPTPATH}" "${PARAMS}"
     else
-        exec "${SH}" "${SCRIPTPATH}" "$@"
+        . "${SCRIPTPATH}" "$@"
     fi
 else
     error_exit "${SCRIPTPATH} not found."

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille bootstrap [release|template] [update|arch]"
 }

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille clone [TARGET] [NEW_NAME] [IPADRESS]"
 }

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-
 usage() {
     error_exit "Usage: bastille cmd TARGET command"
 }

--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille config TARGET get|set propertyName [newValue]"
 }

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille console TARGET [user]"
 }

--- a/usr/local/share/bastille/convert.sh
+++ b/usr/local/share/bastille/convert.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille convert TARGET"
 }

--- a/usr/local/share/bastille/cp.sh
+++ b/usr/local/share/bastille/cp.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille cp [OPTION] TARGET HOST_PATH CONTAINER_PATH"
 }

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille create [empty|thick|vnet] name release ip [interface]"
 }

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille destroy [force] | [container|release]"
 }

--- a/usr/local/share/bastille/edit.sh
+++ b/usr/local/share/bastille/edit.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille edit TARGET [filename]"
 }

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille export TARGET [safe|tarball] | PATH"
 }

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille htop TARGET"
 }

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille import file [force]"
 }

--- a/usr/local/share/bastille/limits.sh
+++ b/usr/local/share/bastille/limits.sh
@@ -29,9 +29,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_notify "Usage: bastille limits TARGET option value"
     echo -e "Example: bastille limits JAILNAME memoryuse 1G"

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille list [-j|-a] [release|template|(jail|container)|log|limit|(import|export|backup)]"
 }

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille mount TARGET host_path container_path [filesystem_type options dump pass_number]"
 }

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-
 usage() {
     error_exit "Usage: bastille pkg TARGET command [args]"
 }

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille rdr TARGET [clear|list|(tcp|udp host_port jail_port)]"
 }

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille rename TARGET NEW_NAME"
 }

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-
 usage() {
     error_exit "Usage: bastille service TARGET service_name action"
 }

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille start TARGET"
 }

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille stop TARGET"
 }
@@ -55,7 +52,7 @@ for _jail in ${JAILS}; do
                 pfctl -q -t jails -T delete "$(jls -j ${_jail} ip4.addr)"
             fi
         fi
-        
+
         if [ "$(bastille rdr ${_jail} list)" ]; then
             bastille rdr ${_jail} clear
         fi

--- a/usr/local/share/bastille/sysrc.sh
+++ b/usr/local/share/bastille/sysrc.sh
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-
 usage() {
     error_exit "Usage: bastille sysrc TARGET args"
 }

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 bastille_usage() {
     error_exit "Usage: bastille template TARGET|--convert project/template"
 }

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-
 usage() {
     error_exit "Usage: bastille top TARGET"
 }

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille umount TARGET container_path"
 }

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille update [release|container] | [force]"
 }
@@ -87,7 +84,7 @@ jail_check() {
 jail_update() {
     # Update a thick container
     if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
-        jail_check    
+        jail_check
         CURRENT_VERSION=$(/usr/sbin/jexec -l "${TARGET}" freebsd-version 2>/dev/null)
         if [ -z "${CURRENT_VERSION}" ]; then
             error_exit "Can't determine '${TARGET}' version."

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille upgrade release newrelease | target newrelease | target install | [force]"
 }
@@ -120,7 +117,7 @@ jail_upgrade() {
 
 jail_updates_install() {
     # Finish installing upgrade on a thick container
-    if [ -d "${bastille_jailsdir}/${TARGET}" ]; then 
+    if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
         jail_check
         env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_jailsdir}/${TARGET}/root" install
     else
@@ -130,7 +127,7 @@ jail_updates_install() {
 
 release_updates_install() {
     # Finish installing upgrade on a release
-    if [ -d "${bastille_releasesdir}/${TARGET}" ]; then 
+    if [ -d "${bastille_releasesdir}/${TARGET}" ]; then
         env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_releasesdir}/${TARGET}" install
     else
         error_exit "${TARGET} not found. See 'bastille bootstrap'."

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 bastille_usage() {
     error_exit "Usage: bastille verify [release|template]"
 }

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -28,9 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/share/bastille/common.sh
-. /usr/local/etc/bastille/bastille.conf
-
 usage() {
     error_exit "Usage: bastille zfs TARGET [set|get|snap] [key=value|date]'"
 }


### PR DESCRIPTION
Allow any case for bastille_zfs_enable value.
Make common.sh and bastille.conf available to all command scripts.

Closes #368.