### PR TITLE
Update template.rst

### DIFF
--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -1,53 +1,84 @@
 ========
 Template
 ========
-Looking for ready made CI/CD validated [Bastille
-Templates](https://gitlab.com/BastilleBSD-Templates)?
+
+Looking for ready made CI/CD validated `Bastille Templates <https://gitlab.com/BastilleBSD-Templates>`_?
 
 Bastille supports a templating system allowing you to apply files, pkgs and
 execute commands inside the containers automatically.
 
 Currently supported template hooks are: `LIMITS`, `INCLUDE`, `PRE`, `FSTAB`,
-`PKG`, `OVERLAY`, `SYSRC`, `SERVICE`, `CMD`.
+`PKG`, `OVERLAY`, `SYSRC`, `SERVICE`, `CMD`, and `RDR`.
+
+Before Bastille 0.7.x
+---------------------
 
 Templates are created in `${bastille_prefix}/templates` and can leverage any of
 the template hooks.
 
 Bastille 0.7.x
 --------------
+
 Bastille 0.7.x introduces a template syntax that is more flexible and allows
 any-order scripting. Previous versions had a hard template execution order and
 instructions were spread across multiple files. The new syntax is done in a
 `Bastillefile` and the template hook (see below) files are replaced with
 template hook commands.
 
+The Bastillefile should be stored in the root of each template. For example, here is
+a structure including the Bastillefile::
+
+  ${bastille_prefix} (likely /usr/local/bastille)
+  + templates
+    + my-namespace
+      + default
+        - Bastillefile
+      + openldap
+        - Bastillefile
+        + usr
+          + local
+            + etc
+              + openldap
+                - slapd.conf
+
+This structure shows where the Bastillefile is placed for both a default template, and a
+container specific template. The latter case also includes an example OVERLAY structure.
+For this case the Bastillefile would include::
+
+  OVERLAY usr
+
+It is worth noting that the previous multi-file method can be used but should only be used
+while migrating to the new method.
+
 Template Automation Hooks
 -------------------------
 
-+---------+-------------------+-----------------------------------------+
-| HOOK    | format            | example                                 |
-+=========+===================+=========================================+
-| LIMITS  | resource value    | memoryuse 1G                            |
-+---------+-------------------+-----------------------------------------+
-| INCLUDE | template path/URL | http?://TEMPLATE_URL or project/path    |
-+---------+-------------------+-----------------------------------------+
-| PRE     | /bin/sh command   | mkdir -p /usr/local/my_app/html         |
-+---------+-------------------+-----------------------------------------+
-| FSTAB   | fstab syntax      | /host/path container/path nullfs ro 0 0 |
-+---------+-------------------+-----------------------------------------+
-| PKG     | port/pkg name(s)  | vim-console zsh git-lite tree htop      |
-+---------+-------------------+-----------------------------------------+
-| OVERLAY | path(s)           | etc root usr (one per line)             |
-+---------+-------------------+-----------------------------------------+
-| SYSRC   | sysrc command(s)  | nginx_enable=YES                        |
-+---------+-------------------+-----------------------------------------+
-| SERVICE | service command   | 'nginx start' OR 'postfix reload'       |
-+---------+-------------------+-----------------------------------------+
-| CMD     | /bin/sh command   | /usr/bin/chsh -s /usr/local/bin/zsh     |
-+---------+-------------------+-----------------------------------------+
++---------+-----------------------------------+-----------------------------------------+
+| HOOK    | format                            | example                                 |
++=========+===================================+=========================================+
+| LIMITS  | resource value                    | memoryuse 1G                            |
++---------+-----------------------------------+-----------------------------------------+
+| INCLUDE | template path/URL                 | http://TEMPLATE_URL or project/path     |
++---------+-----------------------------------+-----------------------------------------+
+| PRE     | /bin/sh command                   | mkdir -p /usr/local/my_app/html         |
++---------+-----------------------------------+-----------------------------------------+
+| FSTAB   | fstab syntax                      | /host/path container/path nullfs ro 0 0 |
++---------+-----------------------------------+-----------------------------------------+
+| PKG     | port/pkg name(s)                  | vim-console zsh git-lite tree htop      |
++---------+-----------------------------------+-----------------------------------------+
+| OVERLAY | path(s)                           | etc root usr (one per line)             |
++---------+-----------------------------------+-----------------------------------------+
+| SYSRC   | sysrc command(s)                  | nginx_enable=YES                        |
++---------+-----------------------------------+-----------------------------------------+
+| SERVICE | service command                   | 'nginx start' OR 'postfix reload'       |
++---------+-----------------------------------+-----------------------------------------+
+| CMD     | /bin/sh command                   | /usr/bin/chsh -s /usr/local/bin/zsh     |
++---------+-----------------------------------+-----------------------------------------+
+| RDR     | protocol host-port container-port | RDR tcp 2200 22                         |
++---------+-----------------------------------+-----------------------------------------+
 
 Note: SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
-ie; (`\\"`)
+ie; (`\\"`). More details on RDR can be `found here <https://bastillebsd.org/blog/2021/01/13/bastille-port-redirection-and-persistence/>`_.
 
 Place these uppercase template hook commands into a `Bastillefile` in any order
 and automate container setup as needed.
@@ -71,7 +102,7 @@ use, be sure to include `usr` in the template OVERLAY definition. eg;
 
 .. code-block:: shell
 
-  echo "usr" > /usr/local/bastille/templates/username/template/OVERLAY
+  echo "OVERLAY usr" >> /usr/local/bastille/templates/username/template/Bastillefile
 
 The above example "usr" will include anything under "usr" inside the template.
 You do not need to list individual files. Just include the top-level directory


### PR DESCRIPTION
* Made the difference between old style and post 0.7.x style configuration more clear
* Fixed the template link at the top of the page
* Added more explanation about file layout for the Bastillefile and overlay structure
* Added some notes about the RDR hook
* Changed the command example to add usr as an OVERLAY to use the new style configuration