### PR TITLE
fix list.sh for BSD grep

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep -Ev "*.sha256$"
+        ls "${bastille_backupsdir}" | grep -Ev '*.sha256$'
     exit 0
     ;;
     *)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep -Ev "*.sha256"
+        ls "${bastille_backupsdir}" | grep -Ev "*.sha256$"
     exit 0
     ;;
     *)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep .sha256$
+        ls "${bastille_backupsdir}" | grep "*.*sha256$"
     exit 0
     ;;
     *)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep -Ev '*.sha256$'
+        ls "${bastille_backupsdir}" | grep .sha256$
     exit 0
     ;;
     *)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -158,7 +158,7 @@ if [ $# -gt 0 ]; then
         rctl -h jail:
         ;;
     import|imports|export|exports|backup|backups)
-        ls "${bastille_backupsdir}" | grep "*.*sha256$"
+        ls "${bastille_backupsdir}" | grep -v ".sha256$"
     exit 0
     ;;
     *)


### PR DESCRIPTION
This PR fixes list.sh import.

>grep: repetition-operator operand invalid