### PR TITLE
fix issue #410 so CMD properly uses jailed env (root)

### DIFF
--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -47,6 +47,6 @@ fi
 
 for _jail in ${JAILS}; do
     info "[${_jail}]:"
-    jexec -l "${_jail}" "$@"
+    jexec -l -U root "${_jail}" "$@"
     echo
 done


### PR DESCRIPTION
This fixes issue #410 and uses jailed root env instead of host env.