### PR TITLE
release preparation for 0.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Use "bastille command -h|--help" for more information about a command.
 
 ```
 
-## 0.8-beta
+## 0.9-beta
 This document outlines the basic usage of the Bastille container management
 framework. This release is still considered beta.
 
@@ -236,8 +236,8 @@ not using ZFS and can safely ignore these settings.
 bastille bootstrap
 ------------------
 Before you can begin creating containers, Bastille needs to "bootstrap" a
-release.  Current supported releases are 11.3-RELEASE, 12.0-RELEASE and
-12.1-RELEASE.
+release.  Current supported releases are 11.4-RELEASE, 12.2-RELEASE and
+13.0-RELEASE.
 
 **Important: If you need ZFS support see the above section BEFORE
 bootstrapping.**
@@ -245,14 +245,14 @@ bootstrapping.**
 To `bootstrap` a release, run the bootstrap sub-command with the
 release version as the argument.
 
-**FreeBSD 11.3-RELEASE**
+**FreeBSD 11.4-RELEASE**
 ```shell
-ishmael ~ # bastille bootstrap 11.3-RELEASE
+ishmael ~ # bastille bootstrap 11.4-RELEASE
 ```
 
-**FreeBSD 12.1-RELEASE**
+**FreeBSD 12.2-RELEASE**
 ```shell
-ishmael ~ # bastille bootstrap 12.1-RELEASE
+ishmael ~ # bastille bootstrap 12.2-RELEASE
 ```
 
 **HardenedBSD 11-STABLE-BUILD-XX**
@@ -292,9 +292,9 @@ bootstrapping templates from GitHub or GitLab.
 See `bastille update` to ensure your bootstrapped releases include the latest
 patches.
 
-**Ubuntu Linux [new since 0.9]**
+** Ubuntu Linux [new since 0.9] **
 
-The bootstrap process for Linux containers is very different from the *BSD process.
+The bootstrap process for Linux containers is very different from the BSD process.
 You will need the package debootstrap and some kernel modules for that.
 But don't worry, Bastille will do that for that for you.
 
@@ -339,24 +339,24 @@ IP at container creation.
 
 **ip4**
 ```shell
-ishmael ~ # bastille create folsom 12.1-RELEASE 10.17.89.10
+ishmael ~ # bastille create folsom 12.2-RELEASE 10.17.89.10
 Valid: (10.17.89.10).
 
 NAME: folsom.
 IP: 10.17.89.10.
-RELEASE: 12.1-RELEASE.
+RELEASE: 12.2-RELEASE.
 
 syslogd_flags: -s -> -ss
 sendmail_enable: NO -> NONE
 cron_flags:  -> -J 60
 ```
 
-This command will create a 12.1-RELEASE container assigning the 10.17.89.10 ip
+This command will create a 12.2-RELEASE container assigning the 10.17.89.10 ip
 address to the new system.
 
 **ip6**
 ```shell
-ishmael ~ # bastille create folsom 12.1-RELEASE fd35:f1fd:2cb6:6c5c::13
+ishmael ~ # bastille create folsom 12.2-RELEASE fd35:f1fd:2cb6:6c5c::13
 Valid: (fd35:f1fd:2cb6:6c5c::13).
 
 NAME: folsom.
@@ -368,12 +368,12 @@ sendmail_enable: NO -> NONE
 cron_flags:  -> -J 60
 ```
 
-This command will create a 12.1-RELEASE container assigning the
+This command will create a 12.2-RELEASE container assigning the
 fd35:f1fd:2cb6:6c5c::13  ip address to the new system.
 
 **VNET**
 ```shell
-ishmael ~ # bastille create -V vnetjail 12.1-RELEASE 192.168.87.55/24 em0
+ishmael ~ # bastille create -V vnetjail 12.2-RELEASE 192.168.87.55/24 em0
 Valid: (192.168.87.55/24).
 Valid: (em0).
 
@@ -389,7 +389,7 @@ ifconfig_e0b_bastille0_name:  -> vnet0
 ifconfig_vnet0:  -> inet 192.168.87.55/24
 ```
 
-This command will create a 12.1-RELEASE container assigning the
+This command will create a 12.2-RELEASE container assigning the
 192.168.87.55/24 ip address to the new system.
 
 VNET-enabled containers are attached to a virtual bridge interface for
@@ -409,7 +409,7 @@ private base. This is sometimes referred to as a "thick" container (whereas the
 shared base container is a "thin").
 
 ```shell
-ishmael ~ # bastille create -T folsom 12.0-RELEASE 10.17.89.10
+ishmael ~ # bastille create -T folsom 12.2-RELEASE 10.17.89.10
 ```
 
 **Linux**
@@ -670,9 +670,8 @@ Templates](https://gitlab.com/BastilleBSD-Templates)?
 Bastille supports a templating system allowing you to apply files, pkgs and
 execute commands inside the container automatically.
 
-Currently supported template hooks are: `ARG`, `LIMITS`, `INCLUDE`, `PRE`,
- `FSTAB`, `PKG`, `OVERLAY`, `SYSRC`, `SERVICE`, `CMD`, `RENDER`.
-Planned template hooks include: `PF`, `LOG`
+Currently supported template hooks are: `ARG`, `LIMITS`, `INCLUDE`,
+ `MOUNT`, `PKG`, `CP`, `SYSRC`, `SERVICE`, `RDR`, `CMD`, `RENDER`.
 
 Templates are created in `${bastille_prefix}/templates` and can leverage any of
 the template hooks. Simply create a new directory in the format project/repo,
@@ -686,9 +685,9 @@ To leverage a template hook, create an UPPERCASE file in the root of the
 template directory named after the hook you want to execute. eg;
 
 ```shell
-echo "zsh vim-console git-lite htop" > /usr/local/bastille/templates/username/base-template/PKG
-echo "/usr/bin/chsh -s /usr/local/bin/zsh" > /usr/local/bastille/templates/username/base-template/CMD
-echo "usr" > /usr/local/bastille/templates/username/base-template/OVERLAY
+echo "PKG zsh vim-console git-lite htop" >> /usr/local/bastille/templates/username/base-template/Bastillefile
+echo "CMD /usr/bin/chsh -s /usr/local/bin/zsh" >> /usr/local/bastille/templates/username/base-template/Bastillefile
+echo "CP usr" > /usr/local/bastille/templates/username/base-template/Bastillefile
 ```
 
 Template hooks are executed in specific order and require specific syntax to
@@ -707,11 +706,7 @@ work as expected. This table outlines that order and those requirements:
 | SERVICE   | service command(s)    | nginx restart                                  |
 | CMD       | /bin/sh command       | /usr/bin/chsh -s /usr/local/bin/zsh            |
 | RENDER    | paths (one/line)      | /usr/local/etc/nginx                           |
-
-| PLANNED | format           | example                                                        |
-|---------|------------------|----------------------------------------------------------------|
-| RDR     | pf rdr entry     | rdr pass inet proto tcp from any to any port 80 -> 10.17.89.80 |
-| LOG     | path             | /var/log/nginx/access.log                                      |
+| RDR       | protocol port port    | tcp 2200 22                                    |
 
 Note: SYSRC requires NO quotes or that quotes (`"`) be escaped. ie; `\"`)
 
@@ -740,8 +735,8 @@ After populating `usr/local/` with custom config files that your container will
 use, be sure to include `usr` in the template OVERLAY definition. eg;
 
 ```shell
-echo "etc" > /usr/local/bastille/templates/username/base/OVERLAY
-echo "usr" >> /usr/local/bastille/templates/username/base/OVERLAY
+echo "CP etc" >> /usr/local/bastille/templates/username/base/Bastillefile
+echo "CP usr" >> /usr/local/bastille/templates/username/base/Bastillefile
 ```
 
 The above example will include anything under "etc" and "usr" inside
@@ -932,21 +927,21 @@ The `update` command targets a release instead of a container. Because every
 container is based on a release, when the release is updated all the containers
 are automatically updated as well.
 
-To update all containers based on the 11.2-RELEASE `release`:
+To update all containers based on the 11.4-RELEASE `release`:
 
-Up to date 11.2-RELEASE:
+Up to date 11.4-RELEASE:
 ```shell
-ishmael ~ # bastille update 11.2-RELEASE
+ishmael ~ # bastille update 11.4-RELEASE
 Targeting specified release.
-11.2-RELEASE
+11.4-RELEASE
 
 Looking up update.FreeBSD.org mirrors... 2 mirrors found.
-Fetching metadata signature for 11.2-RELEASE from update4.freebsd.org... done.
+Fetching metadata signature for 11.4-RELEASE from update4.freebsd.org... done.
 Fetching metadata index... done.
 Inspecting system... done.
 Preparing to download files... done.
 
-No updates needed to update system to 11.2-RELEASE-p4.
+No updates needed to update system to 11.4-RELEASE-p4.
 No updates are available to install.
 ```
 
@@ -1080,11 +1075,7 @@ Example (create, start, console)
 This example creates, starts and consoles into the container.
 
 ```shell
-ishmael ~ # bastille create alcatraz 11.2-RELEASE 10.17.89.7
-
-RELEASE: 11.2-RELEASE.
-NAME: alcatraz.
-IP: 10.17.89.7.
+ishmael ~ # bastille create alcatraz 11.4-RELEASE 10.17.89.7
 ```
 
 ```shell
@@ -1096,7 +1087,7 @@ alcatraz: created
 ```shell
 ishmael ~ # bastille console alcatraz
 [alcatraz]:
-FreeBSD 11.2-RELEASE-p4 (GENERIC) #0: Thu Sep 27 08:16:24 UTC 2018
+FreeBSD 11.4-RELEASE-p4 (GENERIC) #0: Thu Sep 27 08:16:24 UTC 2018
 
 Welcome to FreeBSD!
 

--- a/docs/chapters/installation.rst
+++ b/docs/chapters/installation.rst
@@ -4,7 +4,7 @@ Bastille is available in the official FreeBSD ports tree at
 `sysutils/bastille`. Binary packages available in `quarterly` and `latest`
 repositories.
 
-Current version is `0.8.20210115`.
+Current version is `0.9.20210714`.
 
 To install from the FreeBSD package repository:
 

--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -7,14 +7,14 @@ Templates](https://gitlab.com/BastilleBSD-Templates)?
 Bastille supports a templating system allowing you to apply files, pkgs and
 execute commands inside the containers automatically.
 
-Currently supported template hooks are: `LIMITS`, `INCLUDE`, `PRE`, `FSTAB`,
-`PKG`, `OVERLAY`, `SYSRC`, `SERVICE`, `CMD`.
+Currently supported template hooks are: `CMD`, `CP`, `INCLUDE`, `LIMITS`, `MOUNT`,
+`PKG`, `RDR`, `SERVICE`, `SYSRC`.
 
 Templates are created in `${bastille_prefix}/templates` and can leverage any of
 the template hooks.
 
-Bastille 0.7.x
---------------
+Bastille 0.7.x+
+---------------
 Bastille 0.7.x introduces a template syntax that is more flexible and allows
 any-order scripting. Previous versions had a hard template execution order and
 instructions were spread across multiple files. The new syntax is done in a
@@ -27,23 +27,23 @@ Template Automation Hooks
 +---------+-------------------+-----------------------------------------+
 | HOOK    | format            | example                                 |
 +=========+===================+=========================================+
-| LIMITS  | resource value    | memoryuse 1G                            |
+| CMD     | /bin/sh command   | /usr/bin/chsh -s /usr/local/bin/zsh     |
++---------+-------------------+-----------------------------------------+
+| CP      | path(s)           | etc root usr (one per line)             |
 +---------+-------------------+-----------------------------------------+
 | INCLUDE | template path/URL | http?://TEMPLATE_URL or project/path    |
 +---------+-------------------+-----------------------------------------+
-| PRE     | /bin/sh command   | mkdir -p /usr/local/my_app/html         |
+| LIMITS  | resource value    | memoryuse 1G                            |
 +---------+-------------------+-----------------------------------------+
-| FSTAB   | fstab syntax      | /host/path container/path nullfs ro 0 0 |
+| MOUNT   | fstab syntax      | /host/path container/path nullfs ro 0 0 |
 +---------+-------------------+-----------------------------------------+
 | PKG     | port/pkg name(s)  | vim-console zsh git-lite tree htop      |
 +---------+-------------------+-----------------------------------------+
-| OVERLAY | path(s)           | etc root usr (one per line)             |
-+---------+-------------------+-----------------------------------------+
-| SYSRC   | sysrc command(s)  | nginx_enable=YES                        |
+| RDR     | tcp port port     | tcp 2200 22 (hostport jailport)         |
 +---------+-------------------+-----------------------------------------+
 | SERVICE | service command   | 'nginx start' OR 'postfix reload'       |
 +---------+-------------------+-----------------------------------------+
-| CMD     | /bin/sh command   | /usr/bin/chsh -s /usr/local/bin/zsh     |
+| SYSRC   | sysrc command(s)  | nginx_enable=YES                        |
 +---------+-------------------+-----------------------------------------+
 
 Note: SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
@@ -71,7 +71,7 @@ use, be sure to include `usr` in the template OVERLAY definition. eg;
 
 .. code-block:: shell
 
-  echo "usr" > /usr/local/bastille/templates/username/template/OVERLAY
+  echo "CP usr" >> /usr/local/bastille/templates/username/template/Bastillefile
 
 The above example "usr" will include anything under "usr" inside the template.
 You do not need to list individual files. Just include the top-level directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ copyright = '2018-2021, Christer Edwards'
 author = 'Christer Edwards'
 
 # The short X.Y version
-version = '0.8.20210115'
+version = '0.9.20210714'
 # The full version, including alpha/beta/rc tags
-release = '0.8.20210115-beta'
+release = '0.8.20210714-beta'
 
 
 # -- General configuration ---------------------------------------------------

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -70,7 +70,7 @@ bastille_perms_check() {
 bastille_perms_check
 
 ## version
-BASTILLE_VERSION="0.8.20210115"
+BASTILLE_VERSION="0.9.20210714"
 
 usage() {
     cat << EOF

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -330,13 +330,6 @@ create_jail() {
         ## MAKE SURE WE'RE IN THE RIGHT PLACE
         cd "${bastille_jail_path}"
         echo
-        info "NAME: ${NAME}."
-        info "IP: ${IP}."
-        if [ -n  "${INTERFACE}" ]; then
-            info "INTERFACE: ${INTERFACE}."
-        fi
-        info "RELEASE: ${RELEASE}."
-        echo
 
         if [ -z "${THICK_JAIL}" ]; then
             LINK_LIST="bin boot lib libexec rescue sbin usr/bin usr/include usr/lib usr/lib32 usr/libdata usr/libexec usr/sbin usr/share usr/src"


### PR DESCRIPTION
This updates versions and documentation for the 0.9.x release. Also removes some output in the create command that was useful during build and debugging but is unnecessary now.