### PR TITLE
Refactor: Creates Linux jails bootstrap functions

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -373,7 +373,6 @@ ensure_debootstrap() {
                 ;;
             [Yy][Ee][Ss]|[Yy])
                 pkg install -y debootstrap
-                debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
                 ;;
         esac
     fi

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -342,25 +342,25 @@ bootstrap_template() {
 }
 
 check_linux_prerequisites() {
-#check and install OS dependencies @hackacad
-if [ ! "$(sysrc -f /boot/loader.conf -n linprocfs_load)" = "YES" ] && [ ! "$(sysrc -f /boot/loader.conf -n linsysfs_load)" = "YES" ] && [ ! "$(sysrc -f /boot/loader.conf -n tmpfs_load)" = "YES" ]; then
-    warn "linprocfs_load, linsysfs_load, tmpfs_load not enabled in /boot/loader.conf or linux_enable not active. Should I do that for you?  (N|y)"
-    read  answer
-    case $answer in
-        [Nn][Oo]|[Nn]|"")
-            error_exit "Exiting."
-            ;;
-        [Yy][Ee][Ss]|[Yy])
-            info "Loading modules"
-            kldload linux linux64 linprocfs linsysfs tmpfs
-            info "Persisting modules"
-            sysrc linux_enable=YES
-            sysrc -f /boot/loader.conf linprocfs_load=YES
-            sysrc -f /boot/loader.conf linsysfs_load=YES
-            sysrc -f /boot/loader.conf tmpfs_load=YES
-            ;;
-    esac
-fi
+    #check and install OS dependencies @hackacad
+    if [ ! "$(sysrc -f /boot/loader.conf -n linprocfs_load)" = "YES" ] && [ ! "$(sysrc -f /boot/loader.conf -n linsysfs_load)" = "YES" ] && [ ! "$(sysrc -f /boot/loader.conf -n tmpfs_load)" = "YES" ]; then
+        warn "linprocfs_load, linsysfs_load, tmpfs_load not enabled in /boot/loader.conf or linux_enable not active. Should I do that for you?  (N|y)"
+        read  answer
+        case $answer in
+            [Nn][Oo]|[Nn]|"")
+                error_exit "Exiting."
+                ;;
+            [Yy][Ee][Ss]|[Yy])
+                info "Loading modules"
+                kldload linux linux64 linprocfs linsysfs tmpfs
+                info "Persisting modules"
+                sysrc linux_enable=YES
+                sysrc -f /boot/loader.conf linprocfs_load=YES
+                sysrc -f /boot/loader.conf linsysfs_load=YES
+                sysrc -f /boot/loader.conf tmpfs_load=YES
+                ;;
+        esac
+    fi
 }
 
 HW_MACHINE=$(sysctl hw.machine | awk '{ print $2 }')

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -363,6 +363,22 @@ check_linux_prerequisites() {
     fi
 }
 
+ensure_debootstrap() {
+    if ! which -s debootstrap; then
+        warn "Debootstrap not found. Should it be installed? (N|y)"
+        read  answer
+        case $answer in
+            [Nn][Oo]|[Nn]|"")
+                error_exit "Exiting. You need to install debootstap before boostrapping a Linux jail."
+                ;;
+            [Yy][Ee][Ss]|[Yy])
+                pkg install -y debootstrap
+                debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
+                ;;
+        esac
+    fi
+}
+
 HW_MACHINE=$(sysctl hw.machine | awk '{ print $2 }')
 HW_MACHINE_ARCH=$(sysctl hw.machine_arch | awk '{ print $2 }')
 RELEASE="${1}"
@@ -455,41 +471,18 @@ http?://*/*/*)
 ubuntu_bionic|bionic|ubuntu-bionic)
     check_linux_prerequisites
 
-    if which -s debootstrap; then
-        debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
-    else
-        warn "Debootstrap not found. Should it be installed? (N|y)"
-        read  answer
-        case $answer in
-            [Nn][Oo]|[Nn]|"")
-                error_exit "Exiting. You need to install debootstap before boostrapping a Linux jail."
-                ;;
-            [Yy][Ee][Ss]|[Yy])
-                pkg install -y debootstrap
-                debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
-                ;;
-        esac
-    fi
+    ensure_debootstrap
+
+    debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
+    
     echo "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/Ubuntu_1804/etc/apt/apt.conf.d/00aptitude
     ;;
 ubuntu_focal|focal|ubuntu-focal)
     check_linux_prerequisites
 
-    if which -s debootstrap; then
-        debootstrap --foreign --arch=amd64 --no-check-gpg focal "${bastille_releasesdir}"/Ubuntu_2004
-    else
-        warn "Debootstrap not found. Should it be installed? (N|y)"
-        read  answer
-        case $answer in
-            [Nn][Oo]|[Nn]|"")
-                error_exit "Exiting. You need to install debootstap before boostrapping a Linux jail."
-                ;;
-            [Yy][Ee][Ss]|[Yy])
-                pkg install -y debootstrap
-                debootstrap --foreign --arch=amd64 --no-check-gpg focal "${bastille_releasesdir}"/Ubuntu_2004
-                ;;
-        esac
-    fi
+    ensure_debootstrap
+
+    debootstrap --foreign --arch=amd64 --no-check-gpg focal "${bastille_releasesdir}"/Ubuntu_2004
     ;;
 *)
     usage

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -470,18 +470,13 @@ http?://*/*/*)
 #adding Ubuntu Bionic as valid "RELEASE" for POC @hackacad
 ubuntu_bionic|bionic|ubuntu-bionic)
     check_linux_prerequisites
-
     ensure_debootstrap
-
     debootstrap --foreign --arch=amd64 --no-check-gpg bionic "${bastille_releasesdir}"/Ubuntu_1804
-    
     echo "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/Ubuntu_1804/etc/apt/apt.conf.d/00aptitude
     ;;
 ubuntu_focal|focal|ubuntu-focal)
     check_linux_prerequisites
-
     ensure_debootstrap
-
     debootstrap --foreign --arch=amd64 --no-check-gpg focal "${bastille_releasesdir}"/Ubuntu_2004
     ;;
 *)


### PR DESCRIPTION
This helps preventing code repetition.

Also prevents typo mistakes due the creation of `ensure_debootstrap` allowing using the debootstrap command only once during the process (due the `if` logic that was before).