### PR TITLE
fix overloaded variable in mount command

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -93,25 +93,25 @@ for _jail in ${JAILS}; do
     info "[${_jail}]:"
 
     ## aggregate variables into FSTAB entry
-    _jailpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"
-    _fstab_entry="${_hostpath} ${_jailpath} ${_type} ${_perms} ${_checks}"
+    _fullpath="${bastille_jailsdir}/${_jail}/root/${_jailpath}"
+    _fstab_entry="${_hostpath} ${_fullpath} ${_type} ${_perms} ${_checks}"
 
     ## Create mount point if it does not exist. -- cwells
-    if [ ! -d "${_jailpath}" ]; then
-        if ! mkdir -p "${_jailpath}"; then
+    if [ ! -d "${_fullpath}" ]; then
+        if ! mkdir -p "${_fullpath}"; then
             error_exit "Failed to create mount point inside jail."
         fi
     fi
 
     ## if entry doesn't exist, add; else show existing entry
-    if ! egrep -q "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
+    if ! egrep -q "[[:blank:]]${_fullpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab" 2> /dev/null; then
         if ! echo "${_fstab_entry}" >> "${bastille_jailsdir}/${_jail}/fstab"; then
             error_exit "Failed to create fstab entry: ${_fstab_entry}"
         fi
         echo "Added: ${_fstab_entry}"
     else
         warn "Mountpoint already present in ${bastille_jailsdir}/${_jail}/fstab"
-        egrep "[[:blank:]]${_jailpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
+        egrep "[[:blank:]]${_fullpath}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"
     fi
     mount -F "${bastille_jailsdir}/${_jail}/fstab" -a
     echo


### PR DESCRIPTION
The `_jailpath` variable got overloaded between the mount argument and the fully qualified path to the jail mount point. It also caused duplicate entries appended to fstab.

This patch resolves this and works as expected for mount ALL commands.