### PR TITLE
Sets require NETWORKING in the rc script

### DIFF
--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -3,7 +3,7 @@
 # Bastille jail startup script
 #
 # PROVIDE: bastille
-# REQUIRE: LOGIN
+# REQUIRE: NETWORKING
 # KEYWORD: shutdown
 
 # Add the following to /etc/rc.conf[.local] to enable this service


### PR DESCRIPTION
In general and knowing what role will play bastille in the system, has more sense to require networking than login.

This can also helps speeding up boot time if for instance some jails in bastille provide some kind of networking role like acting as a DNS server.