### PR TITLE
PKG.SH::CHANGED:: use host's pkg to install packages in jails

### DIFF
--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -53,7 +53,7 @@ for _jail in ${JAILS}; do
     elif [ -f "${bastille_jail_path}/usr/bin/apt" ]; then
         jexec -l "${_jail}" /usr/bin/apt "$@"
     else
-        jexec -l -U root "${_jail}" /usr/sbin/pkg "$@"
+        /usr/sbin/pkg -j "${_jail}" "$@"
     fi
     echo
 done


### PR DESCRIPTION
This change has several benefits:
- avoid installing the pkg system in jails
- allow potential ENVVARs to be taken into account when executing the bastille command