### PR TITLE
TEMPLATE.SH::ADDED:: ability to apply templates using a custom directory path

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -186,7 +186,11 @@ case ${TEMPLATE} in
         ;;
     */*)
         if [ ! -d "${bastille_templatesdir}/${TEMPLATE}" ]; then
-            error_exit "${TEMPLATE} not found."
+            if [ ! -d ${TEMPLATE} ]; then
+                error_exit "${TEMPLATE} not found."
+            else
+                bastille_template=${TEMPLATE}
+            fi
         fi
         ;;
     *)


### PR DESCRIPTION
Allow users to give a custom directory path when applying a template, this permits:
- quick template creation/application during developpement/tests
- increase usability and simplicity while using templating

This modification could allow (for example) quick and easy application of template(s) contained in a cloned git environment