### PR TITLE
Add a description to the host vnet interface

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -212,6 +212,7 @@ ${NAME} {
   vnet;
   vnet.interface = e0b_${uniq_epair};
   exec.prestart += "jib addm ${uniq_epair} ${bastille_jail_conf_interface}";
+  exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet host interface for Bastille jail ${NAME}"";
   exec.poststop += "jib destroy ${uniq_epair}";
 }
 EOF


### PR DESCRIPTION
This makes it much easier to understand `ifconfig` when run on the jail host. Not sure how to test this, but manually appyling this via `bastille edit` to an existing vnet jail had the right effects when I restarted the jail.
