### PR TITLE
Use the devfs_ruleset number from imported iocage jails

### DIFF
--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -173,6 +173,7 @@ generate_config() {
     # Attempt to read previous config file and set required variables accordingly
     # If we can't get a valid interface, fallback to lo1 and warn user
     info "Generating jail.conf..."
+    DEVFS_RULESET=4
 
     if [ "${FILE_EXT}" = ".zip" ]; then
         # Gather some bits from foreign/iocage config files
@@ -180,6 +181,8 @@ generate_config() {
         if [ -n "${JSON_CONFIG}" ]; then
             IPV4_CONFIG=$(grep -wo '\"ip4_addr\": \".*\"' "${JSON_CONFIG}" | tr -d '" ' | sed 's/ip4_addr://')
             IPV6_CONFIG=$(grep -wo '\"ip6_addr\": \".*\"' "${JSON_CONFIG}" | tr -d '" ' | sed 's/ip6_addr://')
+	    DEVFS_RULESET=$(grep -wo '\"devfs_ruleset\": \".*\"' "${JSON_CONFIG}" | tr -d '" ' | sed 's/devfs_ruleset://')
+	    DEVFS_RULESET=${DEVFS_RULESET:-4}
         fi
     elif [ "${FILE_EXT}" = ".tar.gz" ]; then
         # Gather some bits from foreign/ezjail config files
@@ -257,7 +260,7 @@ generate_config() {
     # Generate a basic jail configuration file on foreign imports
     cat << EOF > "${bastille_jailsdir}/${TARGET_TRIM}/jail.conf"
 ${TARGET_TRIM} {
-  devfs_ruleset = 4;
+  devfs_ruleset = ${DEVFS_RULESET};
   enforce_statfs = 2;
   exec.clean;
   exec.consolelog = ${bastille_logsdir}/${TARGET_TRIM}_console.log;


### PR DESCRIPTION
This property is not set by default on all iocage jails. By default, iocage assumes this value is 4. Confusingly, if you query this value from iocage while the jail is running, it will give a dynamically generated value. However, a jail must be stopped to be exported, so we can trust the value in `config.json`.

Tested on an exported jail from iocage with `devfs_rulset` set to 48. The generated `jail.conf` showed the same rulset.
