### PR TITLE
Use host's time zone by default for jails

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -25,7 +25,7 @@ bastille_sharedir="/usr/local/share/bastille"                         ## default
 bastille_bootstrap_archives="base"                                    ## default: "base"
 
 ## default timezone
-bastille_tzdata="Etc/UTC"                                             ## default: "Etc/UTC"
+bastille_tzdata=""                                                    ## default: empty to use host's time zone
 
 ## default jail resolv.conf
 bastille_resolv_conf="/etc/resolv.conf"                               ## default: "/etc/resolv.conf"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -440,8 +440,13 @@ create_jail() {
                 ln -s usr/home home
             fi
 
-            ## TZ: configurable (default: Etc/UTC)
-            ln -s "/usr/share/zoneinfo/${bastille_tzdata}" etc/localtime
+            ## TZ: configurable (default: empty to use host's time zone)
+            if [ -z "${bastille_tzdata}" ]; then
+                # uses cp as a way to prevent issues with symlinks if the host happens to use that for tz configuration
+                cp /etc/localtime etc/localtime
+            else
+                ln -s "/usr/share/zoneinfo/${bastille_tzdata}" etc/localtime
+            fi
 
             # Post-creation jail misc configuration
             # Create a dummy fstab file

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -442,8 +442,11 @@ create_jail() {
 
             ## TZ: configurable (default: empty to use host's time zone)
             if [ -z "${bastille_tzdata}" ]; then
-                # uses cp as a way to prevent issues with symlinks if the host happens to use that for tz configuration
-                cp /etc/localtime etc/localtime
+                # Note that if host has no time zone, FreeBSD assumes UTC anyway
+                if [ -e /etc/localtime ]; then
+                    # uses cp as a way to prevent issues with symlinks if the host happens to use that for tz configuration
+                    cp /etc/localtime etc/localtime
+                fi
             else
                 ln -s "/usr/share/zoneinfo/${bastille_tzdata}" etc/localtime
             fi


### PR DESCRIPTION
In order to not give surprises to Bastille's users, the time zone for jails should be the host's time zone by default. Note that if the host has no time zone set, FreeBSD assumes UTC anyway.

Currently if a user installs Bastille, all jails will use UTC as the default time zone for jails and there is no reason why Bastille should do that. Since Bastille installation comes _after_ a server has been installed, we can assume the host's time zone is the desired one instead of a given value. If a user happens to want a different time zone for its jails, the option is kept so the user tweak it.

This will prevent this annoying case scenario:

1. User installs a FreeBSD server (usually this implies setting a time zone).
2. User starts creating jails to then find apps in those jails are in UTC time zone, different one if user set a time zone for its host.
3. Now user needs to manually change all those jails time zones manually in order to use its desired time zone.

The less the user needs to tweak on a Bastille installation, the better.