### PR TITLE
use full path when calling jls binary

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -164,7 +164,7 @@ clone_jail() {
         else
             # Just clone the jail directory
             # Check if container is running
-            if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
+            if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
                 error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
             fi
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -50,7 +50,7 @@ EOF
 }
 
 running_jail() {
-    if [ -n "$(jls name | awk "/^${NAME}$/")" ]; then
+    if [ -n "$(/usr/sbin/jls name | awk "/^${NAME}$/")" ]; then
         error_exit "A running jail matches name."
     elif [ -d "${bastille_jailsdir}/${NAME}" ]; then
         error_exit "Jail: ${NAME} already created."

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -40,7 +40,7 @@ destroy_jail() {
     bastille_jail_base="${bastille_jailsdir}/${TARGET}"            ## dir
     bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
 
-    if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
+    if [ "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         if [ "${FORCE}" = "1" ]; then
             bastille stop "${TARGET}"
         else

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -172,7 +172,7 @@ fi
 
 if [ -n "${SAFE_EXPORT}" ]; then
     # Check if container is running, otherwise just ignore
-    if [ -z "$(jls name | awk "/^${TARGET}$/")" ]; then
+    if [ -z "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         SAFE_EXPORT=
     fi
 fi
@@ -212,7 +212,7 @@ clean_zfs_snap() {
 export_check() {
     # Inform the user about the exporting method
     if [ -z "${USER_EXPORT}" ]; then
-        if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
+        if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
             if [ -n "${SAFE_EXPORT}" ]; then
                 EXPORT_AS="Safely exporting"
             else
@@ -336,7 +336,7 @@ if [ -n "${TARGET}" ]; then
     # Check if is a ZFS system
     if [ "${bastille_zfs_enable}" != "YES" ]; then
         # Check if container is running and ask for stop in non ZFS systems
-        if [ -n "$(jls name | awk "/^${TARGET}$/")" ]; then
+        if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
             error_exit "${TARGET} is running. See 'bastille stop'."
         fi
     fi

--- a/usr/local/share/bastille/htop.sh
+++ b/usr/local/share/bastille/htop.sh
@@ -47,7 +47,7 @@ if [ $# -ne 0 ]; then
 fi
 
 for _jail in ${JAILS}; do
-    bastille_jail_path=$(jls -j "${_jail}" path)
+    bastille_jail_path=$(/usr/sbin/jls -j "${_jail}" path)
     if [ ! -x "${bastille_jail_path}/usr/local/bin/htop" ]; then
         error_notify "htop not found on ${_jail}."
     elif [ -x "${bastille_jail_path}/usr/local/bin/htop" ]; then

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -580,7 +580,7 @@ else
 fi
 
 # Check if a running jail matches name or already exist
-if [ -n "$(jls name | awk "/^${TARGET_TRIM}$/")" ]; then
+if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET_TRIM}$/")" ]; then
     error_exit "A running jail matches name."
 elif [ -n "${TARGET_TRIM}" ]; then
     if [ -d "${bastille_jailsdir}/${TARGET_TRIM}" ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -36,11 +36,11 @@ usage() {
 }
 
 if [ $# -eq 0 ]; then
-   jls -N
+   /usr/sbin/jls -N
 fi
 
 if [ "$1" == "-j" ]; then
-    jls -N --libxo json
+    /usr/sbin/jls -N --libxo json
     exit 0
 fi
 
@@ -80,18 +80,18 @@ if [ $# -gt 0 ]; then
             JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
             for _JAIL in ${JAIL_LIST}; do
                 if [ -f "${bastille_jailsdir}/${_JAIL}/jail.conf" ]; then
-                        if [ "$(jls name | awk "/^${_JAIL}$/")" ]; then
+                        if [ "$(/usr/sbin/jls name | awk "/^${_JAIL}$/")" ]; then
                                 JAIL_STATE="Up"
                                 if [ "$(awk '$1 == "vnet;" { print $1 }' "${bastille_jailsdir}/${_JAIL}/jail.conf")" ]; then
                                         JAIL_IP=$(jexec -l ${_JAIL} ifconfig -n vnet0 inet 2> /dev/null | sed -n "/.inet /{s///;s/ .*//;p;}")
                                         if [ ! ${JAIL_IP} ]; then JAIL_IP=$(jexec -l ${_JAIL} ifconfig -n vnet0 inet6 2> /dev/null | awk '/inet6 / && (!/fe80::/ || !/%vnet0/)' | sed -n "/.inet6 /{s///;s/ .*//;p;}"); fi
                                 else
-                                        JAIL_IP=$(jls -j ${_JAIL} ip4.addr 2> /dev/null)
-                                        if [ ${JAIL_IP} = "-" ]; then JAIL_IP=$(jls -j ${_JAIL} ip6.addr 2> /dev/null); fi
+                                        JAIL_IP=$(/usr/sbin/jls -j ${_JAIL} ip4.addr 2> /dev/null)
+                                        if [ ${JAIL_IP} = "-" ]; then JAIL_IP=$(/usr/sbin/jls -j ${_JAIL} ip6.addr 2> /dev/null); fi
                                 fi
-                                JAIL_HOSTNAME=$(jls -j ${_JAIL} host.hostname 2> /dev/null)
+                                JAIL_HOSTNAME=$(/usr/sbin/jls -j ${_JAIL} host.hostname 2> /dev/null)
                                 JAIL_PORTS=$(pfctl -a "rdr/${_JAIL}" -Psn 2> /dev/null | awk '{ printf "%s/%s:%s"",",$7,$14,$18 }' | sed "s/,$//")
-                                JAIL_PATH=$(jls -j ${_JAIL} path 2> /dev/null)
+                                JAIL_PATH=$(/usr/sbin/jls -j ${_JAIL} path 2> /dev/null)
                                 JAIL_RELEASE=$(jexec -l ${_JAIL} freebsd-version -u 2> /dev/null)
                         else
                                 JAIL_STATE=$(if [ "$(sed -n "/^${_JAIL} {$/,/^}$/p" "${bastille_jailsdir}/${_JAIL}/jail.conf" | awk '$0 ~ /^'${_JAIL}' \{|\}/ { printf "%s",$0 }')" == "${_JAIL} {}" ]; then echo "Down"; else echo "n/a"; fi)

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -47,7 +47,7 @@ fi
 
 for _jail in ${JAILS}; do
     info "[${_jail}]:"
-    bastille_jail_path=$(jls -j "${_jail}" path)
+    bastille_jail_path=$(/usr/sbin/jls -j "${_jail}" path)
     if [ -f "/usr/sbin/mport" ]; then
         jexec -l -U root "${_jail}" /usr/sbin/mport "$@"
     elif [ -f "${bastille_jail_path}/usr/bin/apt" ]; then

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -59,14 +59,14 @@ check_jail_validity() {
     fi
 
     # Check if jail name is valid
-    JAIL_NAME=$(jls -j "${TARGET}" name 2>/dev/null)
+    JAIL_NAME=$(/usr/sbin/jls -j "${TARGET}" name 2>/dev/null)
     if [ -z "${JAIL_NAME}" ]; then
         error_exit "Jail not found: ${TARGET}"
     fi
 
     # Check if jail ip4 address (ip4.addr) is valid (non-VNET only)
     if [ "$(bastille config $TARGET get vnet)" != 'enabled' ]; then
-        JAIL_IP=$(jls -j "${TARGET}" ip4.addr 2>/dev/null)
+        JAIL_IP=$(/usr/sbin/jls -j "${TARGET}" ip4.addr 2>/dev/null)
         if [ -z "${JAIL_IP}" -o "${JAIL_IP}" = "-" ]; then
             error_exit "Jail IP not found: ${TARGET}"
         fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -62,11 +62,11 @@ fi
 
 for _jail in ${JAILS}; do
     ## test if running
-    if [ "$(jls name | awk "/^${_jail}$/")" ]; then
+    if [ "$(/usr/sbin/jls name | awk "/^${_jail}$/")" ]; then
         error_notify "[${_jail}]: Already started."
 
     ## test if not running
-    elif [ ! "$(jls name | awk "/^${_jail}$/")" ]; then
+    elif [ ! "$(/usr/sbin/jls name | awk "/^${_jail}$/")" ]; then
         # Verify that the configured interface exists. -- cwells
         if [ "$(bastille config $_jail get vnet)" != 'enabled' ]; then
             _interface=$(bastille config $_jail get interface)

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -48,11 +48,11 @@ fi
 
 for _jail in ${JAILS}; do
     ## test if running
-    if [ "$(jls name | awk "/^${_jail}$/")" ]; then
+    if [ "$(/usr/sbin/jls name | awk "/^${_jail}$/")" ]; then
         ## remove ip4.addr from firewall table:jails
         if [ -n "${bastille_network_loopback}" ]; then
             if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-                pfctl -q -t jails -T delete "$(jls -j ${_jail} ip4.addr)"
+                pfctl -q -t jails -T delete "$(/usr/sbin/jls -j ${_jail} ip4.addr)"
             fi
         fi
 

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -226,9 +226,9 @@ for _jail in ${JAILS}; do
     info "Applying template: ${TEMPLATE}..."
 
     ## jail-specific variables.
-    bastille_jail_path=$(jls -j "${_jail}" path)
+    bastille_jail_path=$(/usr/sbin/jls -j "${_jail}" path)
     if [ "$(bastille config $TARGET get vnet)" != 'enabled' ]; then
-        _jail_ip=$(jls -j "${_jail}" ip4.addr 2>/dev/null)
+        _jail_ip=$(/usr/sbin/jls -j "${_jail}" ip4.addr 2>/dev/null)
         if [ -z "${_jail_ip}" -o "${_jail_ip}" = "-" ]; then
             error_notify "Jail IP not found: ${_jail}"
             _jail_ip='' # In case it was -. -- cwells

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -75,7 +75,7 @@ fi
 
 jail_check() {
     # Check if the jail is thick and is running
-    if [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
+    if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
     else
         if grep -qw "${bastille_jailsdir}/${TARGET}/root/.bastille" "${bastille_jailsdir}/${TARGET}/fstab"; then

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -76,7 +76,7 @@ esac
 
 jail_check() {
     # Check if the jail is thick and is running
-    if [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
+    if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
     else
         if grep -qw "${bastille_jailsdir}/${TARGET}/root/.bastille" "${bastille_jailsdir}/${TARGET}/fstab"; then


### PR DESCRIPTION
This patch fixes #460 for every reference of `jls`.