### PR TITLE
add Debian 11 'bullseye' to Linux supported list

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -391,7 +391,7 @@ debootstrap_release() {
     fi
 
     case "${LINUX_FLAVOR}" in
-        bionic|stretch|buster)
+        bionic|stretch|buster|bullseye)
         info "Increasing APT::Cache-Start"
         echo "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/${DIR_BOOTSTRAP}/etc/apt/apt.conf.d/00aptitude
         ;;
@@ -553,6 +553,13 @@ debian_buster|buster|debian-buster)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="buster"
     DIR_BOOTSTRAP="Debian10"
+    ARCH_BOOTSTRAP="amd64"
+    debootstrap_release
+    ;;
+debian_bullseye|bullseye|debian-bullseye)
+    PLATFORM_OS="Debian/Linux"
+    LINUX_FLAVOR="bullseye"
+    DIR_BOOTSTRAP="Debian11"
     ARCH_BOOTSTRAP="amd64"
     debootstrap_release
     ;;

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -658,6 +658,10 @@ if [ -n "${LINUX_JAIL}" ]; then
         ## check for FreeBSD releases name
         NAME_VERIFY=buster
         ;;
+    debian_bullseye|bullseye|debian-bullseye)
+        ## check for FreeBSD releases name
+        NAME_VERIFY=bullseye
+        ;;
     *)
         error_notify "Unknown Linux."
         usage
@@ -724,6 +728,10 @@ if [ -z "${EMPTY_JAIL}" ]; then
         ;;
     debian_buster|buster|debian-buster)
         NAME_VERIFY=Debian10
+        validate_release
+        ;;
+    debian_bullseye|bullseye|debian-bullseye)
+        NAME_VERIFY=Debian11
         validate_release
         ;;
     *)

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -231,13 +231,13 @@ current-build-latest|current-BUILD-LATEST|CURRENT-BUILD-LATEST)
     destroy_rel
     ;;
 Ubuntu_1804|Ubuntu_2004|UBUNTU_1804|UBUNTU_2004)
-     ## check for Linux releases
+    ## check for Linux releases
     NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Ubuntu_1804)$|(Ubuntu_2004)$' | sed 's/UBUNTU/Ubuntu/g;s/ubuntu/Ubuntu/g')
     destroy_rel
     ;;
-Debian9|Debian10|DEBIAN9|DEBIAN10)
-     ## check for Linux releases
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Debian9)$|(Debian10)$' | sed 's/DEBIAN/Debian/g')
+Debian9|Debian10|Debian11|DEBIAN9|DEBIAN10|DEBIAN11)
+    ## check for Linux releases
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Debian9)$|(Debian10)$|(Debian11)$' | sed 's/DEBIAN/Debian/g')
     destroy_rel
     ;;
 *)


### PR DESCRIPTION
Adding support for Debian 11 'bullseye'.