### PR TITLE
jls path fix + support using host package manager

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -147,14 +147,24 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rename|service|st
         shift
 
         if [ "${TARGET}" = 'ALL' ]; then
-            _JAILS=$(jls name)
+            _JAILS=$(/usr/sbin/jls name)
             JAILS=""
             for _jail in ${_JAILS}; do
-                _JAILPATH=$(jls -j "${_jail}" path)
+                _JAILPATH=$(/usr/sbin/jls -j "${_jail}" path)
                 if [ -z ${_JAILPATH##${bastille_jailsdir}*} ]; then
                     JAILS="${JAILS} ${_jail}"
                 fi
             done
+        elif [ "${CMD}" = "pkg" ] && [ "${TARGET}" = '-P' ] || [ "${TARGET}" = '--pkg' ]; then
+            TARGET="${1}"
+            USE_HOST_PKG=1
+            JAILS="${TARGET}"
+            shift
+
+            # Require the target to be running
+            if [ ! "$(/usr/sbin/jls | awk "/^${TARGET}$/")" ]; then
+                error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
+            fi
         elif [ "${CMD}" = 'template' ] && [ "${TARGET}" = '--convert' ]; then
             # This command does not act on a jail, so we are temporarily bypassing the presence/started
             # checks. The command will simply convert a template from hooks to a Bastillefile. -- cwells
@@ -169,13 +179,13 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rename|service|st
             case "${CMD}" in
             cmd|console|htop|pkg|service|stop|sysrc|template|top)
                 # Require the target to be running. -- cwells
-                if [ ! "$(jls name | awk "/^${TARGET}$/")" ]; then
+                if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
                     error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
                 fi
                 ;;
             convert|rename)
                 # Require the target to be stopped. -- cwells
-                if [ "$(jls name | awk "/^${TARGET}$/")" ]; then
+                if [ "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
                     error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
                 fi
                 ;;

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -31,7 +31,7 @@
 . /usr/local/share/bastille/common.sh
 
 usage() {
-    error_exit "Usage: bastille pkg TARGET command [args]"
+    error_exit "Usage: bastille pkg [-P|--pkg] TARGET command [args]"
 }
 
 # Handle special-case commands first.
@@ -52,6 +52,8 @@ for _jail in ${JAILS}; do
         jexec -l -U root "${_jail}" /usr/sbin/mport "$@"
     elif [ -f "${bastille_jail_path}/usr/bin/apt" ]; then
         jexec -l "${_jail}" /usr/bin/apt "$@"
+    elif [ "${USE_HOST_PKG}" = 1 ]; then
+        /usr/sbin/pkg -j "${_jail}" "$@"
     else
         jexec -l -U root "${_jail}" /usr/sbin/pkg "$@"
     fi


### PR DESCRIPTION
This patch completes a previous attempt at defining full path to jls binary.

Also included is new support for host package manager using the `pkg -P` or `pkg --pkg` options.