### PR TITLE
change new PKG option from -P to -H

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -155,7 +155,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rename|service|st
                     JAILS="${JAILS} ${_jail}"
                 fi
             done
-        elif [ "${CMD}" = "pkg" ] && [ "${TARGET}" = '-P' ] || [ "${TARGET}" = '--pkg' ]; then
+        elif [ "${CMD}" = "pkg" ] && [ "${TARGET}" = '-H' ] || [ "${TARGET}" = '--host' ]; then
             TARGET="${1}"
             USE_HOST_PKG=1
             JAILS="${TARGET}"
@@ -191,6 +191,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rename|service|st
                 ;;
             esac
         fi
+        export USE_HOST_PKG
         export TARGET
         export JAILS
     fi

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -31,7 +31,7 @@
 . /usr/local/share/bastille/common.sh
 
 usage() {
-    error_exit "Usage: bastille pkg [-P|--pkg] TARGET command [args]"
+    error_exit "Usage: bastille pkg [-H|--host] TARGET command [args]"
 }
 
 # Handle special-case commands first.


### PR DESCRIPTION
Initially lifted the options `-P` and `--pkg` from #444 but decided that `-H` and `--host` were more accurate descriptions of the action.