### PR TITLE
prepare for 0.9.20211225 release

### DIFF
--- a/docs/chapters/installation.rst
+++ b/docs/chapters/installation.rst
@@ -4,7 +4,7 @@ Bastille is available in the official FreeBSD ports tree at
 `sysutils/bastille`. Binary packages available in `quarterly` and `latest`
 repositories.
 
-Current version is `0.9.20210714`.
+Current version is `0.9.20211225`.
 
 To install from the FreeBSD package repository:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ copyright = '2018-2021, Christer Edwards'
 author = 'Christer Edwards'
 
 # The short X.Y version
-version = '0.9.20210714'
+version = '0.9.20211225'
 # The full version, including alpha/beta/rc tags
-release = '0.8.20210714-beta'
+release = '0.9.20211225-beta'
 
 
 # -- General configuration ---------------------------------------------------

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -70,7 +70,7 @@ bastille_perms_check() {
 bastille_perms_check
 
 ## version
-BASTILLE_VERSION="0.9.20210714"
+BASTILLE_VERSION="0.9.20211225"
 
 usage() {
     cat << EOF


### PR DESCRIPTION
This patch increments the version string to 0.9.20211225.