### PR TITLE
Fix create vnet jails

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -193,7 +193,7 @@ generate_vnet_jail_conf() {
         local list_jails_num=$(echo "${jail_list}" | wc -l | awk '{print $1}')
         local num_range=$((list_jails_num + 1))
         for _num in $(seq 0 "${num_range}"); do
-            if ! grep -q "e${_num}b" "${bastille_jailsdir}"/*/jail.conf; then
+            if ! grep -q "e[0-9]b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
                 uniq_epair="bastille${_num}"
                 uniq_epair_bridge="${_num}"
                 break

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -195,7 +195,7 @@ generate_vnet_jail_conf() {
         for _num in $(seq 0 "${num_range}"); do
             if ! grep -q "e${_num}b" "${bastille_jailsdir}"/*/jail.conf; then
                 uniq_epair="bastille${_num}"
-		uniq_epair_bridge="${_num}"
+                uniq_epair_bridge="${_num}"
                 break
             fi
         done

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -191,7 +191,7 @@ generate_vnet_jail_conf() {
     local jail_list=$(bastille list jails)
     if [ -n "${jail_list}" ]; then
         local list_jails_num=$(echo "${jail_list}" | wc -l | awk '{print $1}')
-        local num_range=$(expr "${list_jails_num}" + 1)
+        local num_range=$((list_jails_num + 1))
         for _num in $(seq 0 "${num_range}"); do
             if ! grep -q "e${_num}b" "${bastille_jailsdir}"/*/jail.conf; then
                 uniq_epair="bastille${_num}"


### PR DESCRIPTION
Creating vnet jails with the -V option worked only for the first two. This is what was happening before the fix when creating a third vnet jail:

```shell
root@generic:~ # bastille list -a
 JID         State  IP Address  Published Ports      Hostname    Release          Path
 adguard     Up     10.1.1.53   -                    adguard     13.0-RELEASE-p5  /usr/local/bastille/jails/adguard/root
 prometheus  Up     10.1.1.2    -                    prometheus  13.0-RELEASE-p5  /usr/local/bastille/jails/prometheus/root
root@generic:~ # bastille create -V dashboard 13.0-RELEASE 10.1.1.3 re0
Valid: (10.1.1.3).
Valid: (re0).

[dashboard]:
dashboard: created
ifconfig: interface e0b_bastille1 does not exist
jail: dashboard: /sbin/ifconfig e0b_bastille1 vnet dashboard: failed
dashboard: removed

[dashboard]: Not started. See 'bastille start dashboard'.
[dashboard]: Not started. See 'bastille start dashboard'.
[dashboard]:
dashboard: created
ifconfig: interface e0b_bastille1 does not exist
jail: dashboard: /sbin/ifconfig e0b_bastille1 vnet dashboard: failed
dashboard: removed

root@generic:~ # bastille list -a
grep: /usr/local/bastille/jails/dashboard/root/etc/rc.conf: No such file or directory
 JID         State  IP Address  Published Ports      Hostname    Release          Path
 adguard     Up     10.1.1.53   -                    adguard     13.0-RELEASE-p5  /usr/local/bastille/jails/adguard/root
sed: /usr/local/bastille/jails/dashboard/root/etc/rc.conf: No such file or directory
 dashboard   Down   -           -                    dashboard   13.0-RELEASE-p5  /usr/local/bastille/jails/dashboard/root
 prometheus  Up     10.1.1.2    -                    prometheus  13.0-RELEASE-p5  /usr/local/bastille/jails/prometheus/root
```
This is because the search pattern was looking in the wrong place (see the diff).

I've tested this fix with this:

Created 5 jails: OK
`for i in $(seq 1 5); do sudo bastille create -V jail${i} 13.0-RELEASE 10.0.0.${i} wlan0; done`

Created 6 different jails: OK
`for i in $(seq 50 55); do sudo bastille create -V jail${i} 13.0-RELEASE 10.0.0.${i} wlan0; done`

Deleted 3 jails: OK
`for i in $(seq 1 3); do bastille destroy -f jail${i}; done`

Created extra 3 jails: OK
`for i in $(seq 60 62); do sudo bastille create -V jail${i} 13.0-RELEASE 10.0.0.${i} wlan0; done`

End result:

```shell
# bastille list -a
JID       State  IP Address    Published Ports  Hostname  Release       Path
 jail4     Up     10.0.0.4      -                jail4     13.0-RELEASE  /usr/local/bastille/jails/jail4/root
 jail5     Up     10.0.0.5      -                jail5     13.0-RELEASE  /usr/local/bastille/jails/jail5/root
 jail50    Up     10.0.0.50     -                jail50    13.0-RELEASE  /usr/local/bastille/jails/jail50/root
 jail51    Up     10.0.0.51     -                jail51    13.0-RELEASE  /usr/local/bastille/jails/jail51/root
 jail52    Up     10.0.0.52     -                jail52    13.0-RELEASE  /usr/local/bastille/jails/jail52/root
 jail53    Up     10.0.0.53     -                jail53    13.0-RELEASE  /usr/local/bastille/jails/jail53/root
 jail54    Up     10.0.0.54     -                jail54    13.0-RELEASE  /usr/local/bastille/jails/jail54/root
 jail55    Up     10.0.0.55     -                jail55    13.0-RELEASE  /usr/local/bastille/jails/jail55/root
 jail60    Up     10.0.0.60     -                jail60    13.0-RELEASE  /usr/local/bastille/jails/jail60/root
 jail61    Up     10.0.0.61     -                jail61    13.0-RELEASE  /usr/local/bastille/jails/jail61/root
 jail62    Up     10.0.0.62     -                jail62    13.0-RELEASE  /usr/local/bastille/jails/jail62/root
```

List of bridges:

```shell 
# ifconfig -g bridge
wlan0bridge
```
List of epairs:
```shell
# ifconfig -g epair 
e0a_bastille3
e0a_bastille4
e0a_bastille5
e0a_bastille6
e0a_bastille7
e0a_bastille8
e0a_bastille9
e0a_bastille10
e0a_bastille0
e0a_bastille2
e0a_bastille11
```