### PR TITLE
bootstrap aarch64/arm64 Debian/Ubuntu support

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -436,6 +436,15 @@ bootstrap_template() {
 
 HW_MACHINE=$(sysctl hw.machine | awk '{ print $2 }')
 HW_MACHINE_ARCH=$(sysctl hw.machine_arch | awk '{ print $2 }')
+
+# bootstrapping from aarch64/arm64 Debian or Ubuntu require a different value for ARCH
+# create a new variable
+if [ "${HW_MACHINE_ARCH}" == "aarch64" ]; then
+    HW_MACHINE_ARCH_LINUX="arm64"
+else
+    HW_MACHINE_ARCH_LINUX=${HW_MACHINE_ARCH}
+fi
+
 RELEASE="${1}"
 OPTION="${2}"
 
@@ -527,35 +536,35 @@ ubuntu_bionic|bionic|ubuntu-bionic)
     PLATFORM_OS="Ubuntu/Linux"
     LINUX_FLAVOR="bionic"
     DIR_BOOTSTRAP="Ubuntu_1804"
-    ARCH_BOOTSTRAP="amd64"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
 ubuntu_focal|focal|ubuntu-focal)
     PLATFORM_OS="Ubuntu/Linux"
     LINUX_FLAVOR="focal"
     DIR_BOOTSTRAP="Ubuntu_2004"
-    ARCH_BOOTSTRAP="amd64"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
 debian_stretch|stretch|debian-stretch)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="stretch"
     DIR_BOOTSTRAP="Debian9"
-    ARCH_BOOTSTRAP="amd64"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
 debian_buster|buster|debian-buster)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="buster"
     DIR_BOOTSTRAP="Debian10"
-    ARCH_BOOTSTRAP="amd64"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
 debian_bullseye|bullseye|debian-bullseye)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="bullseye"
     DIR_BOOTSTRAP="Debian11"
-    ARCH_BOOTSTRAP="amd64"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
 *)


### PR DESCRIPTION
added support to bootstrap aarch64/arm64 Debian or Ubuntu for ARM64 hosts

```
beastie:~ # find /usr/local/bastille/releases/*/debootstrap/arch -exec grep -H "arm64" {} \;
/usr/local/bastille/releases/Debian10/debootstrap/arch:arm64
/usr/local/bastille/releases/Debian11/debootstrap/arch:arm64
/usr/local/bastille/releases/Debian9/debootstrap/arch:arm64
/usr/local/bastille/releases/Ubuntu_1804/debootstrap/arch:arm64
/usr/local/bastille/releases/Ubuntu_2004/debootstrap/arch:arm64
```

```
beastie:~ # bastille list -a
 JID           State  IP Address    Published Ports           Hostname      Release                Path
 arkham        Up     172.16.20.5   -                         arkham        buster (Debian 10)     /usr/local/bastille/jails/arkham/root
 hohenasperg   Up     172.16.20.1   -                         hohenasperg   bullseye (Debian 11)   /usr/local/bastille/jails/hohenasperg/root
 litchfield    Up     172.16.20.3   -                         litchfield    stretch (Debian 9)     /usr/local/bastille/jails/litchfield/root
 stammheim     Up     172.16.20.2   -                         stammheim     bionic (Ubuntu 18.04)  /usr/local/bastille/jails/stammheim/root
 wandsworth    Up     172.16.20.4   -                         wandsworth    focal (Ubuntu 20.04)   /usr/local/bastille/jails/wandsworth/root
```

```
beastie:~ # bastille console arkham
[arkham]:
Last login: Sun Jan 16 18:40:33 UTC 2022 on pts/0
Linux arkham 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@arkham:~# uname -a
Linux arkham 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64 GNU/Linux
root@arkham:~#
```

```
beastie:~ # bastille console hohenasperg
[hohenasperg]:
Linux hohenasperg 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@hohenasperg:~# uname -a
Linux hohenasperg 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64 GNU/Linux
root@hohenasperg:~#
```

```
beastie:~ # bastille console litchfield
[litchfield]:
Last login: Sun Jan 16 18:43:55 UTC 2022 on pts/0
Linux litchfield 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@litchfield:~# uname -a
Linux litchfield 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64 GNU/Linux
root@litchfield:~#
```

```
beastie:~ # bastille console stammheim
[stammheim]:
login: PAM Failure, aborting: Critical error - immediate abort
```

```
beastie:~ # bastille console wandsworth
[wandsworth]:
Welcome to Ubuntu 20.04 LTS (GNU/Linux 3.17.0 arm64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

Last login: Sun Jan 16 18:46:05 UTC 2022 on pts/0
root@wandsworth:~# uname -a
Linux wandsworth 3.17.0 FreeBSD 13.0-RELEASE-p6 #0: Mon Jan 10 06:33:27 UTC 2022 arm64 arm64 arm64 GNU/Linux
root@wandsworth:~#
```