### PR TITLE
CLONE.SH::FIXED:: update fstab paths with new jail path

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -130,7 +130,7 @@ update_fstab() {
     # Update fstab to use the new name
     FSTAB_CONFIG="${bastille_jailsdir}/${NEWNAME}/fstab"
     if [ -f "${FSTAB_CONFIG}" ]; then
-        FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-2])|([0-9]{1,2}-stable-build-[0-9]{1,3})|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)' "${FSTAB_CONFIG}" | uniq)
+        FSTAB_RELEASE=$(grep -owE '([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-5]|-BETA[1-5]|-CURRENT)|([0-9]{1,2}(-stable-build-[0-9]{1,3}|-stable-LAST))|(current-build)-([0-9]{1,3})|(current-BUILD-LATEST)|([0-9]{1,2}-stable-BUILD-LATEST)' "${FSTAB_CONFIG}" | uniq)
         FSTAB_CURRENT=$(grep -w ".*/releases/.*/jails/${TARGET}/root/.bastille" "${FSTAB_CONFIG}")
         FSTAB_NEWCONF="${bastille_releasesdir}/${FSTAB_RELEASE} ${bastille_jailsdir}/${NEWNAME}/root/.bastille nullfs ro 0 0"
         if [ -n "${FSTAB_CURRENT}" ] && [ -n "${FSTAB_NEWCONF}" ]; then

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -139,6 +139,8 @@ update_fstab() {
                 sed -i '' "s|${FSTAB_CURRENT}|${FSTAB_NEWCONF}|" "${FSTAB_CONFIG}"
             fi
         fi
+        # Update additional fstab paths with new jail path
+        sed -i '' "s|${bastille_jailsdir}/${TARGET}/root/|${bastille_jailsdir}/${NEWNAME}/root/|" "${FSTAB_CONFIG}"
     fi
 }
 


### PR DESCRIPTION
## Description
When cloning an existing jail with additional fstab entries, base entries are updated but not the additional paths, resulting in invalid destination mount points.

## How to reproduce
- create a new jail `bastille create test 12.3-RELEASE 127.0.1.1`
- add a custom mount to the jail `bastille mount test /tmp var/custom_tmp nullfs ro 0 0`
- stop the jail `bastille stop test`
- clone the jail `bastille clone test test2 127.0.1.2`
- look at the new jail's fstab (by default in `/usr/local/bastille/jails/test2/fstab`, the /var/custom_tmp should still point to the first jail's path

## Other fixes
Completed the FSTAB_RELEASE in clone.sh's `update_fstab()`, the grep didn't take into account some release names, such as [1-9]{1,2}-CURRENT