### PR TITLE
Allow Linux jails to see their mount points

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -170,6 +170,7 @@ ${NAME} {
   mount.fstab = ${bastille_jail_fstab};
   path = ${bastille_jail_path};
   devfs_ruleset = 4;
+  enforce_statfs = 1;
 
   exec.start = '/bin/true';
   exec.stop = '/bin/true';


### PR DESCRIPTION
Some Linux packages (shakes fist angrily at Java) look to see if `/proc` is mounted as a part of the installation by running
   `mountpoint /proc`
While the Linux jail can see the contents of its `/proc` directory, the linprocfs driver will not generate the correct contents for `/proc/mounts` or `/proc/self/mountinfo` as `kern_getfsstat()` will, by default, filter all mount points other than the jail's chroot directory.

Fix is to set `enforce_statfs` to allow mount points below the jail's chroot directory to be visible.