### PR TITLE
fix non-unique epair creation when using vnet

### DIFF
--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -74,9 +74,11 @@ generate_vnet_jail_netblock() {
         local num_range=$((list_jails_num + 1))
         for _num in $(seq 0 "${num_range}"); do
             if ! grep -q "e[0-9]b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                local uniq_epair="bastille${_num}"
-                local uniq_epair_bridge="${_num}"
-                break
+                if ! grep -q "epair${_num}" "${bastille_jailsdir}"/*/jail.conf; then
+                    local uniq_epair="bastille${_num}"
+                    local uniq_epair_bridge="${_num}"
+                    break
+                fi
             fi
         done
     else


### PR DESCRIPTION
`generate_vnet_jail_netblock()` will now correctly identify pre-existing `epair`s on other jails to prevent creation of conflicting duplicates.