### PR TITLE
Enable colour only when writing to a tty

### DIFF
--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -38,7 +38,7 @@ enable_color() {
 }
 
 # If "NO_COLOR" environment variable is present, disable output colors.
-if [ -z "${NO_COLOR}" ]; then
+if [ -z "${NO_COLOR}" -a -t 1 ]; then
     enable_color
 fi
 


### PR DESCRIPTION
The escape codes can confuse other scripts and things in pipes.

For example I have a jail with ip4 set to inherit (see also https://github.com/BastilleBSD/bastille/issues/369) and when I try `bastille start jail_name` I get:

```
grep: brackets ([ ]) not balanced
Error: not set interface does not exist.
```

This patch fixes the first error message.