### PR TITLE
Updated "export" sub-command docs (0.9.20220216)

### DIFF
--- a/docs/chapters/subcommands/export.rst
+++ b/docs/chapters/subcommands/export.rst
@@ -16,4 +16,14 @@ can be exported only when the jail is not running.
 
 .. code-block:: shell
 
-  Usage: bastille export TARGET
+  Usage:  bastille export | option(s) | TARGET | PATH
+
+Available options are:
+
+         --gz       -- Export a ZFS jail using GZIP(.gz) compressed image.
+    -r | --raw      -- Export a ZFS jail to an uncompressed RAW image.
+    -s | --safe     -- Safely stop and start a ZFS jail before the exporting process.
+         --tgz      -- Export a jail using simple .tgz compressed archive instead.
+         --txz      -- Export a jail using simple .txz compressed archive instead.
+    -v | --verbose  -- Be more verbose during the ZFS send operation.
+         --xz       -- Export a ZFS jail using XZ(.xz) compressed image.

--- a/docs/chapters/subcommands/export.rst
+++ b/docs/chapters/subcommands/export.rst
@@ -20,6 +20,8 @@ can be exported only when the jail is not running.
 
 Available options are:
 
+.. code-block:: shell
+
          --gz       -- Export a ZFS jail using GZIP(.gz) compressed image.
     -r | --raw      -- Export a ZFS jail to an uncompressed RAW image.
     -s | --safe     -- Safely stop and start a ZFS jail before the exporting process.


### PR DESCRIPTION
"Updated with syntax on 0.9.20220216 as if running just bastille export TARGET it errors with:

"Error: Stream can not be written to a terminal.
You must redirect standard output.

Error: An export option is required, see 'bastille export, otherwise the user must redirect to standard output."