### PR TITLE
print available linux releases

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -164,7 +164,7 @@ if [ $# -gt 0 ]; then
                 fi
             done
         echo "Available Linux releases are:"
-        echo "(ubuntu_)bionic, (ubuntu_)focal,(debian_)stretch,(debian_),(debian_)bullseye"
+        echo "(ubuntu_)bionic, (ubuntu_)focal, (debian_)stretch, (debian_), (debian_)bullseye"
         fi
         ;;
     template|templates)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -164,7 +164,7 @@ if [ $# -gt 0 ]; then
                 fi
             done
         echo "Available Linux releases are:"
-        echo "(ubuntu_)bionic, (ubuntu_)focal, (debian_)stretch, (debian_), (debian_)bullseye"
+        echo "(ubuntu_)bionic, (ubuntu_)focal, (debian_)stretch, (debian_)buster, (debian_)bullseye"
         fi
         ;;
     template|templates)

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -163,6 +163,8 @@ if [ $# -gt 0 ]; then
                     fi
                 fi
             done
+        echo "Available Linux releases are:"
+        echo "(ubuntu_)bionic, (ubuntu_)focal,(debian_)stretch,(debian_),(debian_)bullseye"
         fi
         ;;
     template|templates)


### PR DESCRIPTION
This enhancement will print all available Linux releases when using `bastille list release`

```
bastille list release
12.1-RELEASE
12.2-RELEASE
13.0-RELEASE
13.1-RC1
13.1-RELEASE
Available Linux releases are:
(ubuntu_)bionic, (ubuntu_)focal,(debian_)stretch,(debian_),(debian_)bullseye
```