### PR TITLE
Advanced Mount Types Support

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -65,8 +65,10 @@ if [ -z "${_hostpath}" ] || [ -z "${_jailpath}" ] || [ -z "${_type}" ] || [ -z "
     exit 1
 fi
 
-## if host path doesn't exist or type is not "nullfs"
-if [ ! -d "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
+## if host path doesn't exist, type is not "nullfs" or are using advanced mount type "tmpfs,linprocfs,linsysfs, fdescfs, procfs"	
+if [ "${_hostpath}" == "tmpfs" -a "$_type" == "tmpfs" ] || [ "${_hostpath}" == "linprocfs" -a "${_type}" == "linprocfs" ] || [ "${_hostpath}" == "linsysfs" -a "${_type}" == "linsysfs" ] || [ "${_hostpath}" == "proc" -a "${_type}" == "procfs" ] || [ "${_hostpath}" == "fdesc" -a "${_type}" == "fdescfs" ]  ;  then
+    warn "Detected advanced mount type ${_hostpath}"
+elif [ ! -d "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     error_notify "Detected invalid host path or incorrect mount type in FSTAB."
     warn "Format: /host/path jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"


### PR DESCRIPTION
Working on BastilleApps, I realized that it was not possible to mount linprocfs and linsysfs because it gave mount errors due to its type, since only nullfs are allowed and if the hostpath exists, I have added the so-called "advanced mount types", which launch a warning when they are detected/used. Different mount types can now be used both in Bastillefile and via bastille mount, it also checks that the mount type is supported before giving an error.

Example:
`bastille mount TARGET linsysfs compat/linux/sys linsysfs rw 0 0`