### PR TITLE
fixing regression in create.sh for Linux containers

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -204,7 +204,7 @@ ${NAME} {
   allow.mount.devfs;
 
   interface = ${bastille_jail_conf_interface};
-  ${IPX_ADDR} = ${IP};
+  ${ipx_addr} = ${IP};
   ip6 = ${IP6_MODE};
 }
 EOF


### PR DESCRIPTION
At some point the IPX_ADDR variable went from uppercase to lowercase. This one was missed.