### PR TITLE
Use "bastille config" to get ipv4.addr.

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -77,7 +77,7 @@ for _jail in ${JAILS}; do
         fi
 
         ## warn if matching configured (but not online) ip4.addr, ignore if there's no ip4.addr entry
-        ip=$(grep 'ip4.addr' "${bastille_jailsdir}/${_jail}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
+        ip=$(bastille config "${_jail}" get ip4.addr)
         if [ -n "${ip}" ]; then
             if ifconfig | grep -w "${ip}" >/dev/null; then
                 error_notify "Error: IP address (${ip}) already in use."


### PR DESCRIPTION
Hi. :)

Fixes issue with jails not being added to pf table. Likely also fixes #343, but I can't confirm because I'm not using VNET.

I'm setting up a new desktop. The Bastille version on my old desktop had set "ipv4.addr = 127.x.x.x;" with spaces, but the current code excludes the spaces. That lack of spaces causes the grep to fail, which means jails do not get added to the pf table.