### PR TITLE
Fix bug in ip-in-use test

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -68,7 +68,7 @@ validate_ip() {
                     error_exit "Invalid: (${TEST_IP})"
                 fi
             done
-            if ifconfig | grep -qw "${TEST_IP}"; then
+            if ifconfig | grep -qwF "${TEST_IP}"; then
                 warn "Warning: IP address already in use (${TEST_IP})."
             else
                 info "Valid: (${IP})."

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -91,7 +91,7 @@ validate_ip() {
                         exit 1
                     fi
                 done
-                if ifconfig | grep -qw "${TEST_IP}"; then
+                if ifconfig | grep -qwF "${TEST_IP}"; then
                     warn "Warning: IP address already in use (${TEST_IP})."
                 else
                     info "Valid: (${ip})."

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -79,7 +79,7 @@ for _jail in ${JAILS}; do
         ## warn if matching configured (but not online) ip4.addr, ignore if there's no ip4.addr entry
         ip=$(grep 'ip4.addr' "${bastille_jailsdir}/${_jail}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
         if [ -n "${ip}" ]; then
-            if ifconfig | grep -w "${ip}" >/dev/null; then
+            if ifconfig | grep -wF "${ip}" >/dev/null; then
                 error_notify "Error: IP address (${ip}) already in use."
                 continue
             fi


### PR DESCRIPTION
Need grep -wF instead of grep -w for IP test to avoid spurious match against broadcast address in ifconfig output.

```
echo 172.16.255.255 | grep -w 172.16.2.5

echo 172.16.255.255 | grep -wF 172.16.2.5
```