### PR TITLE
Accept ssh git addresses in bootstrap

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -425,7 +425,7 @@ bootstrap_template() {
     ## define basic variables
     _url=${BASTILLE_TEMPLATE_URL}
     _user=${BASTILLE_TEMPLATE_USER}
-    _repo=${BASTILLE_TEMPLATE_REPO}
+    _repo=${BASTILLE_TEMPLATE_REPO%.*} # Remove the trailing ".git"
     _template=${bastille_templatesdir}/${_user}/${_repo}
 
     ## support for non-git

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -543,6 +543,13 @@ http?://*/*/*)
     BASTILLE_TEMPLATE_REPO=$(echo "${1}" | awk -F / '{ print $5 }')
     bootstrap_template
     ;;
+git@*:*/*)
+    BASTILLE_TEMPLATE_URL=${1}
+    git_repository=$(echo "${1}" | awk -F : '{ print $2 }')
+    BASTILLE_TEMPLATE_USER=$(echo "${git_repository}" | awk -F / '{ print $1 }')
+    BASTILLE_TEMPLATE_REPO=$(echo "${git_repository}" | awk -F / '{ print $2 }')
+    bootstrap_template
+    ;;
 #adding Ubuntu Bionic as valid "RELEASE" for POC @hackacad
 ubuntu_bionic|bionic|ubuntu-bionic)
     PLATFORM_OS="Ubuntu/Linux"


### PR DESCRIPTION
1st commit:
Added a case for bootstrap where the git URL is an ssh based directory.
( i.e. git@github.com:OwnerName/RepoName )

2nd commit:
Also noticed that when using http and git@ the ".git" gets preserved in the filesystem name.  A simple substitution removing everything after the dot fixes this.  This could, I guess, potentially cause problems if people use `.` in their repo names but I don't recall ever seeing this or imagine it'd be common