### PR TITLE
Add missing spaces for consistency

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -104,10 +104,10 @@ validate_ip() {
     if echo "${ip}" | grep -qvE '(SLAAC|DHCP|0[.]0[.]0[.]0)'; then
         if [ "${ipx_addr}" = "ip4.addr" ]; then
                 IP4_ADDR="${ip}"
-                IP4_DEFINITION="${ipx_addr}=${ip};"
+                IP4_DEFINITION="${ipx_addr} = ${ip};"
         else
                 IP6_ADDR="${ip}"
-                IP6_DEFINITION="${ipx_addr}=${ip};"
+                IP6_DEFINITION="${ipx_addr} = ${ip};"
         fi
     fi
 }


### PR DESCRIPTION
Add missing spaces for jail.conf  content consistency and readability.

**Current:**
```
jail1 {
  ......
  securelevel = 2;
  interface = em0;
  ip4.addr=10.0.0.100;
  
  ip6 = disable;
}
```
**Fixed:**
```
jail1 {
  ......
  securelevel = 2;
  interface = em0;
  ip4.addr = 10.0.0.100;
  
  ip6 = disable;
}
```