### PR TITLE
fix rdr issue detecting IP6 when disabled or not set

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -76,10 +76,11 @@ check_jail_validity() {
     fi
     # Check if jail ip6 address (ip6.addr) is valid (non-VNET only)
     if [ "$(bastille config $TARGET get vnet)" != 'enabled' ]; then
-	  if [ "$(bastille config $TARGET get ip6)" != 'disabled' ]; then
-        JAIL_IP6=$(/usr/sbin/jls -j "${TARGET}" ip6.addr 2>/dev/null)
-	  fi
+        if [ "$(bastille config $TARGET get ip6)" != 'disabled' ] && [ "$(bastille config $TARGET get ip6)" != 'not set' ]; then
+            JAIL_IP6=$(/usr/sbin/jls -j "${TARGET}" ip6.addr 2>/dev/null)
+        fi
     fi
+
 
     # Check if rdr-anchor is defined in pf.conf
     if ! (pfctl -sn | grep rdr-anchor | grep 'rdr/\*' >/dev/null); then


### PR DESCRIPTION
this fixes an issue I discovered when using `rdr` to add redirects. if ip6 is 'not set' the detection fails and the PF rule chokes because the ip6 address is the string "not set".