### PR TITLE
Updated supported Linux releases

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -399,7 +399,7 @@ debootstrap_release() {
     fi
 
     case "${LINUX_FLAVOR}" in
-        bionic|stretch|buster|bullseye)
+        bionic|buster|bullseye|bookworm)
         info "Increasing APT::Cache-Start"
         echo "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/${DIR_BOOTSTRAP}/etc/apt/apt.conf.d/00aptitude
         ;;
@@ -567,13 +567,6 @@ ubuntu_focal|focal|ubuntu-focal)
     ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
-debian_stretch|stretch|debian-stretch)
-    PLATFORM_OS="Debian/Linux"
-    LINUX_FLAVOR="stretch"
-    DIR_BOOTSTRAP="Debian9"
-    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
-    debootstrap_release
-    ;;
 debian_buster|buster|debian-buster)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="buster"
@@ -585,6 +578,13 @@ debian_bullseye|bullseye|debian-bullseye)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="bullseye"
     DIR_BOOTSTRAP="Debian11"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
+    debootstrap_release
+    ;;
+debian_bookworm|bookworm|debian-bookworm)
+    PLATFORM_OS="Debian/Linux"
+    LINUX_FLAVOR="bookworm"
+    DIR_BOOTSTRAP="Debian12"
     ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -567,6 +567,13 @@ ubuntu_focal|focal|ubuntu-focal)
     ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
     debootstrap_release
     ;;
+ubuntu_jammy|jammy|ubuntu-jammy)
+    PLATFORM_OS="Ubuntu/Linux"
+    LINUX_FLAVOR="jammy"
+    DIR_BOOTSTRAP="Ubuntu_2204"
+    ARCH_BOOTSTRAP=${HW_MACHINE_ARCH_LINUX}
+    debootstrap_release
+    ;;
 debian_buster|buster|debian-buster)
     PLATFORM_OS="Debian/Linux"
     LINUX_FLAVOR="buster"

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -399,7 +399,7 @@ debootstrap_release() {
     fi
 
     case "${LINUX_FLAVOR}" in
-        bionic|buster|bullseye|bookworm)
+        bionic|focal|jammy|buster|bullseye|bookworm)
         info "Increasing APT::Cache-Start"
         echo "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/${DIR_BOOTSTRAP}/etc/apt/apt.conf.d/00aptitude
         ;;

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -759,16 +759,16 @@ if [ -z "${EMPTY_JAIL}" ]; then
         NAME_VERIFY=Ubuntu_2004
         validate_release
         ;;
-    debian_stretch|stretch|debian-stretch)
-        NAME_VERIFY=Debian9
-        validate_release
-        ;;
     debian_buster|buster|debian-buster)
         NAME_VERIFY=Debian10
         validate_release
         ;;
     debian_bullseye|bullseye|debian-bullseye)
         NAME_VERIFY=Debian11
+        validate_release
+        ;;
+    debian_bookworm|bookworm|debian-bookworm)
+        NAME_VERIFY=Debian12
         validate_release
         ;;
     *)

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -759,6 +759,11 @@ if [ -z "${EMPTY_JAIL}" ]; then
         NAME_VERIFY=Ubuntu_2004
         validate_release
         ;;
+    ubuntu_jammy|jammy|ubuntu-jammy)
+        UBUNTU="1"
+        NAME_VERIFY=Ubuntu_2204
+        validate_release
+        ;;
     debian_buster|buster|debian-buster)
         NAME_VERIFY=Debian10
         validate_release

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -683,9 +683,9 @@ if [ -n "${LINUX_JAIL}" ]; then
         ## check for FreeBSD releases name
         NAME_VERIFY=ubuntu_focal
         ;;
-    debian_stretch|stretch|debian-stretch)
+    jammy|ubuntu_jammy|ubuntu-jammy)
         ## check for FreeBSD releases name
-        NAME_VERIFY=stretch
+        NAME_VERIFY=ubuntu_jammy
         ;;
     debian_buster|buster|debian-buster)
         ## check for FreeBSD releases name
@@ -694,6 +694,10 @@ if [ -n "${LINUX_JAIL}" ]; then
     debian_bullseye|bullseye|debian-bullseye)
         ## check for FreeBSD releases name
         NAME_VERIFY=bullseye
+        ;;
+    debian_bookworm|bookworm|debian-bookworm)
+        ## check for FreeBSD releases name
+        NAME_VERIFY=bookworm
         ;;
     *)
         error_notify "Unknown Linux."

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -249,14 +249,14 @@ current-build-latest|current-BUILD-LATEST|CURRENT-BUILD-LATEST)
     NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(current-build-latest)$' | sed 's/CURRENT/current/;s/build/BUILD/g;s/latest/LATEST/g')
     destroy_rel
     ;;
-Ubuntu_1804|Ubuntu_2004|UBUNTU_1804|UBUNTU_2004)
+Ubuntu_1804|Ubuntu_2004|Ubuntu_2204|UBUNTU_1804|UBUNTU_2004|UBUNTU_2204)
     ## check for Linux releases
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Ubuntu_1804)$|(Ubuntu_2004)$' | sed 's/UBUNTU/Ubuntu/g;s/ubuntu/Ubuntu/g')
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Ubuntu_1804)$|(Ubuntu_2004)$|(Ubuntu_2204)$' | sed 's/UBUNTU/Ubuntu/g;s/ubuntu/Ubuntu/g')
     destroy_rel
     ;;
-Debian9|Debian10|Debian11|DEBIAN9|DEBIAN10|DEBIAN11)
+Debian10|Debian11|Debian12|DEBIAN10|DEBIAN11|DEBIAN12)
     ## check for Linux releases
-    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Debian9)$|(Debian10)$|(Debian11)$' | sed 's/DEBIAN/Debian/g')
+    NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '(Debian10)$|(Debian11)$|(Debian12)$' | sed 's/DEBIAN/Debian/g')
     destroy_rel
     ;;
 *)


### PR DESCRIPTION
Added:
- Ubuntu Jammy 22.04 LTS
- Debian 12 Bookworm

Removed:
- Debian 9 Stretch