### PR TITLE
/etc/pf.conf path for rdr.sh set by a variable in bastille configuration

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -11,6 +11,9 @@ bastille_releasesdir="${bastille_prefix}/releases"                    ## default
 bastille_templatesdir="${bastille_prefix}/templates"                  ## default: "${bastille_prefix}/templates"
 bastille_logsdir="/var/log/bastille"                                  ## default: "/var/log/bastille"
 
+## pf configuration path
+bastille_pf_conf="/etc/pf.conf"                                       ## default: "/etc/pf.conf"
+
 ## bastille scripts directory (assumed by bastille pkg)
 bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"
 

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -88,7 +88,7 @@ check_jail_validity() {
     fi
 
     # Check if ext_if is defined in pf.conf
-    EXT_IF=$(grep "^[[:space:]]*${bastille_network_pf_ext_if}[[:space:]]*=" /etc/pf.conf)
+    EXT_IF=$(grep "^[[:space:]]*${bastille_network_pf_ext_if}[[:space:]]*=" ${bastille_pf_conf})
     if [ -z "${EXT_IF}" ]; then
         error_exit "bastille_network_pf_ext_if (${bastille_network_pf_ext_if}) not defined in pf.conf"
     fi


### PR DESCRIPTION
Changed the occurence of path /etc/pf.conf in the rdr.sh script for reading it as a variable from the bastille configuration.

This fix issues on systems where the /etc folder is not persistent and configuration files are stored elsewhere.