### PR TITLE
Permit jail upgrades to use BETA and RC branches

### DIFF
--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -89,7 +89,7 @@ jail_check() {
 
 release_check() {
     # Validate the release
-    if ! echo "${NEWRELEASE}" | grep -q "[0-9]\{2\}.[0-9]-RELEASE"; then
+    if ! echo "${NEWRELEASE}" | grep -q "[0-9]\{2\}.[0-9]-[RELEASE,BETA,RC]"; then
         error_exit "${NEWRELEASE} is not a valid release."
     fi
 }


### PR DESCRIPTION
Allow the uplift of jails to test BETA and RC branches before release.

Currently to can bootstrap these branches with bastille but you cannot upgrade during the release cycle.