### PR TITLE
fix for JID instead of jail name in list printout

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -42,7 +42,7 @@ fi
 bastille_root_check
 
 if [ $# -eq 0 ]; then
-   /usr/sbin/jls -N
+   /usr/sbin/jls
 fi
 
 if [ "${1}" == "-j" ]; then


### PR DESCRIPTION
line 45 of list.sh was changed from jls -N to jls.

Per enhancement ticket 193 from 2020.