### PR TITLE
CIDR documentation on create command

### DIFF
--- a/docs/chapters/subcommands/create.rst
+++ b/docs/chapters/subcommands/create.rst
@@ -24,11 +24,11 @@ address to the new system.
 
 .. code-block:: shell
 
-   ishmael ~ # bastille create alcatraz 13.2-RELEASE 10.17.89.113/27
+   ishmael ~ # bastille create alcatraz 13.2-RELEASE 10.17.89.113/24
 
 
-The above code will create a jail with a /27 mask.  At the time of this documentation you 
-can only use CIDR notation, and not use a netmask 255.255.255.224 to accomplish this.
+The above code will create a jail with a /24 mask.  At the time of this documentation you 
+can only use CIDR notation, and not use a netmask 255.255.255.0 to accomplish this.
 
 
 I recommend using private (rfc1918) ip address ranges for your container.  These

--- a/docs/chapters/subcommands/create.rst
+++ b/docs/chapters/subcommands/create.rst
@@ -22,6 +22,15 @@ bootstrapped release and a private (rfc1918) IP address.
 This command will create a 11.3-RELEASE container assigning the 10.17.89.10 ip
 address to the new system.
 
+.. code-block:: shell
+
+   ishmael ~ # bastille create alcatraz 13.2-RELEASE 10.17.89.113/27
+
+
+The above code will create a jail with a /27 mask.  At the time of this documentation you 
+can only use CIDR notation, and not use a netmask 255.255.255.224 to accomplish this.
+
+
 I recommend using private (rfc1918) ip address ranges for your container.  These
 ranges include:
 


### PR DESCRIPTION
documented that ONLY CIDR notation currently works for creating a jail instead of using  a netmask statement.