### PR TITLE
fix configure_zfs() to properly return status of zfs module.

### DIFF
--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -93,7 +93,7 @@ fi
 
 # Configure ZFS
 configure_zfs() {
-    if [ ! "$(kldstat -q -m zfs)" ]; then
+    if [ ! "$(kldstat -m zfs)" ]; then
         info "ZFS module not loaded; skipping..."
     else
         ## attempt to determine bastille_zroot from `zpool list`


### PR DESCRIPTION
Tested on FreeBSD 14-RC2

Removed -q from kldstat in the function "configure_zfs()". on FreeBSD 14 (maybe earlier) this caused kldstat to return in such a way that BastilleBSD assumes zfs is not loaded when it actually is.
