### PR TITLE
Fix generated interface name in rc.conf for vnet jail

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -499,7 +499,7 @@ create_jail() {
     if [ -n "${VNET_JAIL}" ]; then
         if [ -n "${bastille_template_vnet}" ]; then
             ## rename interface to generic vnet0
-            uniq_epair=$(grep vnet.interface "${bastille_jailsdir}/${NAME}/jail.conf" | awk '{print $3}' | sed 's/;//')
+            uniq_epair=$(grep vnet.interface "${bastille_jailsdir}/${NAME}/jail.conf" | awk '{print $3}' | sed 's/;//; s/-/_/g')
 
             _gateway=''
             _gateway6=''


### PR DESCRIPTION
Hi,

this fix is replacing dash with underscore in interface name. It is required if creating a jail with the name contains dash. For rc.conf the interface name must using underscore, so without this fix, renaming interface to vnet0 is not working. 
With this fix it works like a charm.

Tested on FreeBSD 13.2