### PR TITLE
Enhancement: optional ext_if6 macro in pf.conf to enable rdr for non-VNET dual-stack jails  

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -45,6 +45,7 @@ bastille_conf_check
 . /usr/local/etc/bastille/bastille.conf
 # Set default values for config properties added during the current major version:
 : "${bastille_network_pf_ext_if:=ext_if}"
+: "${bastille_network_pf_ext_if:=ext_if6}"
 : "${bastille_network_pf_table:=jails}"
 
 ## bastille_prefix should be 0750
@@ -62,7 +63,7 @@ bastille_perms_check() {
 bastille_perms_check
 
 ## version
-BASTILLE_VERSION="0.10.20231013"
+BASTILLE_VERSION=b7d741b5cd3b0c758f0983fd9546e88fba0354d7
 
 usage() {
     cat << EOF

--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -54,6 +54,7 @@ bastille_export_options=""                                            ## default
 ## Networking
 bastille_network_loopback="bastille0"                                 ## default: "bastille0"
 bastille_network_pf_ext_if="ext_if"                                   ## default: "ext_if"
+bastille_network_pf_ext_if6="ext_if6"                                 ## default: "ext_if6"
 bastille_network_pf_table="jails"                                     ## default: "jails"
 bastille_network_shared=""                                            ## default: ""
 bastille_network_gateway=""                                           ## default: ""


### PR DESCRIPTION
1. Added an optional parameter `ext_if6` for an IPv6 interface in `pf.conf` interface next to the default `ext_if` (for IPv4) in `bastille.conf`.
2. Adjusted `rdr.sh` so that rdr rules are also added and persisted for the `ext_if6` interface.

This makes it possible to have a non-VNET jail that can deal with packets coming from a Wireguard interface (IPv4) and from an Yggdrasil (IPv6) interface.

For example, I am running caddy in a non-VNET dual-stack jail, and this way I can have it reverse-proxy to other jails.

Prior to this change, if I didn't want to deal with VNET, I would have to have a separate non-VNET IPv6-only jail running caddy to deal with requests coming from the Yggdrasil interface.

This doesn't affect the creation of an IPv4-only jail.

I have not changed anything in `create.sh`. After creating an IPv4-only jail, I edit its `jail.conf` and add `ip6.addr = fd80:...` (in this case, a link-local address) and delete the line `ip6 = new;`

For an IPv6-only jail, an improvement to this would be to make `create.sh` set `ip4 = disabled;` (for which other scripts might need to be adjusted).

The changes to the "standard" `pf.conf` look like this:

```
ext_if=wg0
ext_if6=ygg0

set block-policy return
scrub in on { $ext_if, $ext_if6 } all fragment reassemble
set skip on lo

table <jails> persist
nat on $ext_if from <jails> to any -> ($ext_if:0)
nat on $ext_if6 from <jails> to any -> ($ext_if6:0)
rdr-anchor "rdr/*"

block in all
pass out quick keep state
antispoof for $ext_if inet
antispoof for $ext_if6 inet6
pass in inet proto tcp from any to any port ssh flags S/SA modulate state
pass in inet6 proto tcp from any to any port ssh flags S/SA modulate state
```



