### PR TITLE
initial support & docs to bootstrap EOL releases

### DIFF
--- a/docs/chapters/subcommands/bootstrap.rst
+++ b/docs/chapters/subcommands/bootstrap.rst
@@ -27,7 +27,7 @@ release version as the argument.
 
 .. code-block:: shell
 
-  ishmael ~ # bastille bootstrap 12.4-RELEASE [update]
+  ishmael ~ # bastille bootstrap 14.0-RELEASE [update]
   ishmael ~ # bastille bootstrap 13.2-RELEASE [update]
 
 To `bootstrap` a HardenedBSD release, run the bootstrap sub-command with the
@@ -42,6 +42,21 @@ This command will ensure the required directory structures are in place and
 download the requested release. For each requested release, `bootstrap` will
 download the base.txz. These files are verified (sha256 via MANIFEST file)
 before they are extracted for use.
+
+EOL Releases
+------------
+
+It is sometimes necessary to run end-of-life releases for testing or legacy
+application support. Dy default Bastille will only install supported releases
+but you can bootstrap EOL / unsupported releases with a simple trick.
+
+.. code-block:: shell
+
+   ishmael ~ # export BASTILLE_URL_FREEBSD=http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/
+   ishmael ~ # bastille bootstrap 11.2-RELEASE
+
+By overriding the BASTILLE_URL_FREEBSD variable you can now bootstrap archived
+releases from the FTP archive.
 
 Tips
 ----

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -473,6 +473,11 @@ if [ -n "${OPTION}" ] && [ "${OPTION}" != "${HW_MACHINE}" ] && [ "${OPTION}" != 
     fi
 fi
 
+## allow override bootstrap URLs via environment variables
+[ -n ${BASTILLE_URL_FREEBSD} ] && bastille_url_freebsd="${BASTILLE_URL_FREEBSD}"
+[ -n ${BASTILLE_URL_HARDENEDBSD} ] && bastille_url_hardenedbsd="${BASTILLE_URL_HARDENEDBSD}"
+[ -n ${BASTILLE_URL_MIDNIGHTBSD} ] && bastille_url_midnightbsd="${BASTILLE_URL_MIDNIGHTBSD}"
+
 ## Filter sane release names
 case "${1}" in
 2.[0-9]*)
@@ -491,7 +496,7 @@ case "${1}" in
     ;;
 *-RELEASE|*-release|*-RC[1-9]|*-rc[1-9]|*-BETA[1-9])
     ## check for FreeBSD releases name
-    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RC[1-9]|-BETA[1-9])$' | tr '[:lower:]' '[:upper:]')
+    NAME_VERIFY=$(echo "${RELEASE}" | grep -iwE '^([0-9]{1,2})\.[0-9](-RELEASE|-RC[1-9]|-BETA[1-9])$' | tr '[:lower:]' '[:upper:]')
     UPSTREAM_URL="${bastille_url_freebsd}${HW_MACHINE}/${HW_MACHINE_ARCH}/${NAME_VERIFY}"
     PLATFORM_OS="FreeBSD"
     validate_release_url


### PR DESCRIPTION
This patch adds initial support to bootstrap EOL releases from ftp-archive.freebsd.org. I've also included documentation on how to override the bootstrap URL in order to do so. This manual step is included as a simple barrier to unknowingly installing unsupported versions of FreeBSD.

Note: Due to a difference in release format prior to FreeBSD 9.0 we are presently unable to bootstrap releases older than that. As a point of reference, FreeBSD 9.0 was released Jan 2012. 

**Please use caution when using EOL releases for anything other than testing and experimentation as they no longer receive security updates and may be prone to a range of vulnerabilities.**

This also adds support to override the HardenedBSD and MidnightBSD URLs in the same fashion, to maintain feature parity across platforms.