### PR TITLE
update documentation for 14.0-RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make install
 **enable at boot**
 ```shell
 sysrc bastille_enable=YES
-sysrc bastille_list="azkaban alcatraz" # (optional whitelist of jails to start at boot; default: ALL)
+sysrc bastille_rcorder=YES
 ```
 
 Upgrading from a previous version
@@ -40,7 +40,7 @@ When upgrading from a previous version of bastille (e.g. 0.10.20230714 to
 
 ```shell
 cd /usr/local/etc/bastille
-vimdiff bastille.conf bastille.conf.sample
+diff -u bastille.conf bastille.conf.sample
 ```
 
 Merge the lines that are present in the new bastille.conf.sample into
@@ -75,6 +75,7 @@ Available Commands:
   mount       Mount a volume inside the targeted container(s).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   rdr         Redirect host port to container port.
+  rcp         reverse cp(1) files from a single container to the host.
   rename      Rename a container.
   restart     Restart a running container.
   service     Manage services within targeted container(s).
@@ -131,7 +132,7 @@ Example (create, start, console)
 This example creates, starts and consoles into the container.
 
 ```shell
-ishmael ~ # bastille create alcatraz 13.2-RELEASE 10.17.89.10
+ishmael ~ # bastille create alcatraz 14.0-RELEASE 10.17.89.10/24
 ```
 
 ```shell
@@ -143,7 +144,7 @@ alcatraz: created
 ```shell
 ishmael ~ # bastille console alcatraz
 [alcatraz]:
-FreeBSD 13.2-RELEASE-p4 GENERIC
+FreeBSD 14.0-RELEASE GENERIC
 
 Welcome to FreeBSD!
 

--- a/docs/chapters/installation.rst
+++ b/docs/chapters/installation.rst
@@ -4,7 +4,7 @@ Bastille is available in the official FreeBSD ports tree at
 `sysutils/bastille`. Binary packages available in `quarterly` and `latest`
 repositories.
 
-Current version is `0.10.20231013`.
+Current version is `0.10.20231125`.
 
 To install from the FreeBSD package repository:
 
@@ -19,6 +19,7 @@ PKG
 
   pkg install bastille
   sysrc bastille_enable=YES
+  sysrc bastille_rcorder=YES
 
 
 To install from source (don't worry, no compiling):
@@ -30,6 +31,7 @@ ports
 
   make -C /usr/ports/sysutils/bastille install clean
   sysrc bastille_enable=YES
+  sysrc bastille_rcorder=YES
 
 
 GIT
@@ -41,6 +43,7 @@ GIT
   cd bastille
   make install
   sysrc bastille_enable=YES
+  sysrc bastille_rcorder=YES
 
 This method will install the latest files from GitHub directly onto your
 system. It is verbose about the files it installs (for later removal), and also

--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -128,6 +128,11 @@ host system:
   ## /etc/devfs.rules (NOT .conf)
   
   [bastille_vnet=13]
+  add include $devfsrules_hide_all
+  add include $devfsrules_unhide_basic
+  add include $devfsrules_unhide_login
+  add include $devfsrules_jail
+  add include $devfsrules_jail_vnet
   add path 'bpf*' unhide
 
 Lastly, you may want to consider these three `sysctl` values:
@@ -155,8 +160,6 @@ Below is the definition of what these three parameters are used for and mean:
 				    interface, set to 0	to disable it.
 
   
-
-
 **Regarding Routes**
 
 Bastille will attempt to auto-detect the default route from the host system and

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -62,7 +62,7 @@ bastille_perms_check() {
 bastille_perms_check
 
 ## version
-BASTILLE_VERSION="0.10.20231013"
+BASTILLE_VERSION="0.10.20231125"
 
 usage() {
     cat << EOF


### PR DESCRIPTION
A collection of misc documentation fixes related to 14.0-RELEASE, the new `bastille_rcorder` rc.conf value, updating VNET documentation regarding `devfs.rules`, etc. 