### PR TITLE
support upper & lowercase values in bastille.conf

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -45,7 +45,7 @@ esac
 bastille_root_check
 
 #Validate if ZFS is enabled in rc.conf and bastille.conf.
-if [ "$(sysrc -n zfs_enable)" = "YES" ] && [ ! "${bastille_zfs_enable}" = "YES" ]; then
+if [ "$(sysrc -n zfs_enable)" = "YES" ] && checkyesno bastille_zfs_enable; then
     warn "ZFS is enabled in rc.conf but not bastille.conf. Do you want to continue? (N|y)"
     read answer
     case $answer in
@@ -57,7 +57,7 @@ if [ "$(sysrc -n zfs_enable)" = "YES" ] && [ ! "${bastille_zfs_enable}" = "YES" 
 fi
 
 # Validate ZFS parameters.
-if [ "${bastille_zfs_enable}" = "YES" ]; then
+if checkyesno bastille_zfs_enable; then
     ## check for the ZFS pool and bastille prefix
     if [ -z "${bastille_zfs_zpool}" ]; then
         error_exit "ERROR: Missing ZFS parameters. See bastille_zfs_zpool."
@@ -102,7 +102,7 @@ bootstrap_directories() {
 
     ## ${bastille_prefix}
     if [ ! -d "${bastille_prefix}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ];then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_prefix}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
             fi
@@ -114,7 +114,7 @@ bootstrap_directories() {
 
     ## ${bastille_backupsdir}
     if [ ! -d "${bastille_backupsdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ];then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_backupsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/backups"
             fi
@@ -126,7 +126,7 @@ bootstrap_directories() {
 
     ## ${bastille_cachedir}
     if [ ! -d "${bastille_cachedir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache"
                 # Don't create unused/stale cache/RELEASE directory on Linux jails creation.
@@ -145,7 +145,7 @@ bootstrap_directories() {
     elif [ ! -d "${bastille_cachedir}/${RELEASE}" ]; then
         # Don't create unused/stale cache/RELEASE directory on Linux jails creation.
         if [ -z "${NOCACHEDIR}" ]; then
-            if [ "${bastille_zfs_enable}" = "YES" ]; then
+            if checkyesno bastille_zfs_enable; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
                 fi
@@ -157,7 +157,7 @@ bootstrap_directories() {
 
     ## ${bastille_jailsdir}
     if [ ! -d "${bastille_jailsdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_jailsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails"
             fi
@@ -168,7 +168,7 @@ bootstrap_directories() {
 
     ## ${bastille_logsdir}
     if [ ! -d "${bastille_logsdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_logsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/logs"
             fi
@@ -179,7 +179,7 @@ bootstrap_directories() {
 
     ## ${bastille_templatesdir}
     if [ ! -d "${bastille_templatesdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
             fi
@@ -190,7 +190,7 @@ bootstrap_directories() {
 
     ## ${bastille_releasesdir}
     if [ ! -d "${bastille_releasesdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases"
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
@@ -201,7 +201,7 @@ bootstrap_directories() {
 
     ## create subsequent releases/XX.X-RELEASE datasets
     elif [ ! -d "${bastille_releasesdir}/${RELEASE}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
             fi
@@ -249,7 +249,7 @@ bootstrap_release() {
 
             if [ "${FETCH_VALIDATION}" -ne "0" ]; then
                 ## perform cleanup only for stale/empty directories on failure
-                if [ "${bastille_zfs_enable}" = "YES" ]; then
+                if checkyesno bastille_zfs_enable; then
                     if [ -n "${bastille_zfs_zpool}" ]; then
                         if [ ! "$(ls -A "${bastille_cachedir}/${RELEASE}")" ]; then
                             zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
@@ -383,7 +383,7 @@ debootstrap_release() {
     info "Bootstrapping ${PLATFORM_OS} distfiles..."
     if ! debootstrap --foreign --arch=${ARCH_BOOTSTRAP} --no-check-gpg ${LINUX_FLAVOR} "${bastille_releasesdir}"/${DIR_BOOTSTRAP}; then
         ## perform cleanup only for stale/empty directories on failure
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 if [ ! "$(ls -A "${bastille_releasesdir}/${DIR_BOOTSTRAP}")" ]; then
                     zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${DIR_BOOTSTRAP}"
@@ -414,7 +414,7 @@ bootstrap_template() {
 
     ## ${bastille_templatesdir}
     if [ ! -d "${bastille_templatesdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
             fi

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -154,7 +154,7 @@ clone_jail() {
     # Attempt container clone
     info "Attempting to clone '${TARGET}' to ${NEWNAME}..."
     if ! [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 # Replicate the existing container
                 DATE=$(date +%F-%H%M%S)

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -117,3 +117,24 @@ EOF
 EOF
     fi
 }
+
+checkyesno() {
+    ## copied from /etc/rc.subr -- cedwards (20231125)
+    ## issue #368 (lowercase values should be parsed)
+    ## now used for all bastille_zfs_enable=YES|NO tests
+    ## example: if checkyesno bastille_zfs_enable; then ...
+    ## returns 0 for enabled; returns 1 for disabled
+    eval _value=\$${1}
+    case $_value in
+    [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn]|1)
+        return 0
+        ;;
+    [Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]|0)
+        return 1
+        ;;
+    *)
+        warn "\$${1} is not set properly - see rc.conf(5)."
+        return 1
+        ;;
+    esac
+}

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -281,7 +281,7 @@ create_jail() {
     bastille_jail_resolv_conf="${bastille_jailsdir}/${NAME}/root/etc/resolv.conf" ## file
 
     if [ ! -d "${bastille_jailsdir}/${NAME}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 ## create required zfs datasets, mountpoint inherited from system
                 if [ -z "${CLONE_JAIL}" ]; then
@@ -388,7 +388,7 @@ create_jail() {
                 fi
             done
         else
-            if [ "${bastille_zfs_enable}" = "YES" ]; then
+            if checkyesno bastille_zfs_enable; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     if [ -n "${CLONE_JAIL}" ]; then
                         info "Creating a clonejail...\n"

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -55,7 +55,7 @@ destroy_jail() {
 
     if [ -d "${bastille_jail_base}" ]; then
         info "Deleting Jail: ${TARGET}."
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 if [ -n "${TARGET}" ]; then
                     OPTIONS="-r"
@@ -118,7 +118,7 @@ destroy_rel() {
             if grep -qwo "${TARGET}" "${bastille_jailsdir}/${_jail}/fstab" 2>/dev/null; then
                 error_notify "Notice: (${_jail}) depends on ${TARGET} base."
                 BASE_HASCHILD="1"
-            elif [ "${bastille_zfs_enable}" = "YES" ]; then
+            elif checkyesno bastille_zfs_enable; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     ## check if this release have child clones
                     if zfs list -H -t snapshot -r "${bastille_rel_base}" > /dev/null 2>&1; then
@@ -144,7 +144,7 @@ destroy_rel() {
     else
         if [ "${BASE_HASCHILD}" -eq "0" ]; then
             info "Deleting base: ${TARGET}"
-            if [ "${bastille_zfs_enable}" = "YES" ]; then
+            if checkyesno bastille_zfs_enable; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
                     if [ -n "${TARGET}" ]; then
                         OPTIONS="-r"

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -75,7 +75,7 @@ bastille_root_check
 
 zfs_enable_check() {
     # Temporarily disable ZFS so we can create a standard backup archive
-    if [ "${bastille_zfs_enable}" = "YES" ]; then
+    if checkyesno bastille_zfs_enable; then
         bastille_zfs_enable="NO"
     fi
 }
@@ -212,7 +212,7 @@ if [ -n "${TXZ_EXPORT}" -o -n "${TGZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
     error_exit "Error: Simple archive modes with safe ZFS export can't be used together."
 fi
 
-if [ -z "${bastille_zfs_enable}" ]; then
+if checkyesno bastille_zfs_enable; then
     if [ -n "${GZIP_EXPORT}" -o -n "${RAW_EXPORT}" -o -n "${SAFE_EXPORT}" -o "${OPT_ZSEND}" = "-Rv" ]; then
         error_exit "Options --gz, --raw, --safe, --verbose are valid for ZFS configured systems only."
     fi
@@ -294,7 +294,7 @@ export_check() {
         create_zfs_snap
     fi
 
-    if [ "${bastille_zfs_enable}" = "YES" ]; then
+    if checkyesno bastille_zfs_enable; then
         if [ -z "${USER_EXPORT}" ]; then
             info "Sending ZFS data stream..."
         fi
@@ -304,7 +304,7 @@ export_check() {
 jail_export() {
     # Attempt to export the container
     DATE=$(date +%F-%H%M%S)
-    if [ "${bastille_zfs_enable}" = "YES" ]; then
+    if checkyesno bastille_zfs_enable; then
         if [ -n "${bastille_zfs_zpool}" ]; then
             if [ -n "${RAW_EXPORT}" ]; then
                 FILE_EXT=""
@@ -384,7 +384,7 @@ if [ -n "${TARGET}" ]; then
     fi
 
     # Check if is a ZFS system
-    if [ "${bastille_zfs_enable}" != "YES" ]; then
+    if ! checkyesno bastille_zfs_enable; then
         # Check if container is running and ask for stop in non ZFS systems
         if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
             error_exit "${TARGET} is running. See 'bastille stop'."

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -410,7 +410,7 @@ jail_import() {
     FILE_TRIM=$(echo "${TARGET}" | sed 's/\.xz//g;s/\.gz//g;s/\.tgz//g;s/\.txz//g;s/\.zip//g;s/\.tar\.gz//g;s/\.tar//g')
     FILE_EXT=$(echo "${TARGET}" | sed "s/${FILE_TRIM}//g")
     if [ -d "${bastille_jailsdir}" ]; then
-        if [ "${bastille_zfs_enable}" = "YES" ]; then
+        if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
                 if [ "${FILE_EXT}" = ".xz" ]; then
                     validate_archive

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -105,7 +105,7 @@ update_fstab() {
 change_name() {
     # Attempt container name change
     info "Attempting to rename '${TARGET}' to ${NEWNAME}..."
-    if [ "${bastille_zfs_enable}" = "YES" ]; then
+    if checkyesno bastille_zfs_enable; then
         if [ -n "${bastille_zfs_zpool}" ] && [ -n "${bastille_zfs_prefix}" ]; then
             # Check and rename container ZFS dataset accordingly
             # Perform additional checks in case of non-ZFS existing containers

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -85,7 +85,7 @@ esac
 bastille_root_check
 
 ## check ZFS enabled
-if [ ! "${bastille_zfs_enable}" = "YES" ]; then
+if ! checkyesno bastille_zfs_enable; then
     error_exit "ZFS not enabled."
 fi
 


### PR DESCRIPTION
This patch replaces a hard-coded test for "YES" with a check for "[Yy][Ee][Ss]..."

Technically, this now supports upper and lowercase versions of YES, TRUE, ON and 1 for enabled and recognizes NO, FALSE, OFF, and 0 as disabled. Anything else is reported as not set properly.

References #368 and #377 .
```
[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn]|1)
    return 0
[Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]|0)
    return 1
```