### PR TITLE
Adjust devfs_ruleset for hierarchical jails compatibility

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -165,10 +165,15 @@ EOF
 }
 
 generate_jail_conf() {
+    if [ "$(sysctl -n security.jail.jailed)" -eq 1 ]; then
+        devfs_ruleset_value=0
+    else
+        devfs_ruleset_value=4
+    fi
     cat << EOF > "${bastille_jail_conf}"
 ${NAME} {
-  devfs_ruleset = 4;
   enforce_statfs = 2;
+  devfs_ruleset = ${devfs_ruleset_value};
   exec.clean;
   exec.consolelog = ${bastille_jail_log};
   exec.start = '/bin/sh /etc/rc';
@@ -189,12 +194,17 @@ EOF
 }
 
 generate_linux_jail_conf() {
+    if [ "$(sysctl -n security.jail.jailed)" -eq 1 ]; then
+        devfs_ruleset_value=0
+    else
+        devfs_ruleset_value=4
+    fi
     cat << EOF > "${bastille_jail_conf}"
 ${NAME} {
   host.hostname = ${NAME};
   mount.fstab = ${bastille_jail_fstab};
   path = ${bastille_jail_path};
-  devfs_ruleset = 4;
+  devfs_ruleset = ${devfs_ruleset_value};
   enforce_statfs = 1;
 
   exec.start = '/bin/true';
@@ -212,11 +222,16 @@ EOF
 }
 
 generate_vnet_jail_conf() {
+    if [ "$(sysctl -n security.jail.jailed)" -eq 1 ]; then
+        devfs_ruleset_value=0
+    else
+        devfs_ruleset_value=13
+    fi
     NETBLOCK=$(generate_vnet_jail_netblock "$NAME" "${VNET_JAIL_BRIDGE}" "${bastille_jail_conf_interface}")
     cat << EOF > "${bastille_jail_conf}"
 ${NAME} {
-  devfs_ruleset = 13;
   enforce_statfs = 2;
+  devfs_ruleset = ${devfs_ruleset_value};
   exec.clean;
   exec.consolelog = ${bastille_jail_log};
   exec.start = '/bin/sh /etc/rc';


### PR DESCRIPTION
Hierarchical jails inherit the parent jail's permissions and don't support setting devfs_ruleset to a non-zero value. This update adds a check to determine if the script is running inside a jail. If so, it sets devfs_ruleset to 0 to comply with this constraint.

This will fix the problem described here: https://it-notes.dragas.net/2023/11/27/migrating-from-vm-to-hierarchical-jails-freebsd/