### PR TITLE
restore check_fib() call

### DIFF
--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -82,6 +82,7 @@ for _jail in ${JAILS}; do
     if [ -n "${USER}" ]; then
         validate_user
     else
+        check_fib
         LOGIN="$(jexec -l "${_jail}" which login)"
         ${_setfib} jexec -l "${_jail}" $LOGIN -f root
     fi


### PR DESCRIPTION
This is needed to restore the behavior which respects the "exec.fib" parameter in bastille "console" command, which was removed by commit b997be5