### PR TITLE
Refuse to destroy a jail with mounted filesystems

### DIFF
--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -69,6 +69,11 @@ destroy_jail() {
         fi
 
         if [ -d "${bastille_jail_base}" ]; then
+            ## make sure no filesystem is currently mounted in the jail directory
+            mount_points=$(mount | cut -d ' ' -f 3 | grep "${bastille_jail_base}")
+            if [ $? -eq 0 ]; then
+                error_exit "Jail has mounted filesystems:\n$mount_points"
+            fi
             ## removing all flags
             chflags -R noschg "${bastille_jail_base}"
 


### PR DESCRIPTION
```
# bastille create temp 14.0-RELEASE 192.168.1.10 lo1
...
# mkdir test
# cp /usr/bin/less test/
# mkdir /usr/local/bastille/jails/temp/root/test
# bastille mount temp $(realpath test) test
[temp]:
Added: /root/admin/bastille/test /usr/local/bastille/jails/temp/root/test nullfs ro 0 0
# /usr/local/bastille/jails/temp/root/test/less -f /dev/stdin &
# bastille destroy force temp
rdr-anchor not found in pf.conf
[temp]:
temp: removed
umount: unmount of /usr/local/bastille/jails/temp/root/test failed: Device busy
jail: temp: /sbin/umount -t nullfs /usr/local/bastille/jails/temp/root/test: failed

Deleting Jail: temp.
Jail has mounted filesystems:
/usr/local/bastille/jails/temp/root/test
```

Fixes #662 