### PR TITLE
rcp: fix -q option handling

### DIFF
--- a/usr/local/share/bastille/rcp.sh
+++ b/usr/local/share/bastille/rcp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018-2022, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2024, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,6 @@ usage() {
     error_exit "Usage: bastille rcp [OPTION] TARGET CONTAINER_PATH HOST_PATH"
 }
 
-CPSOURCE="${1}"
-CPDEST="${2}"
-
 # Handle special-case commands first.
 case "$1" in
 help|-h|--help)
@@ -45,14 +42,16 @@ help|-h|--help)
     ;;
 -q|--quiet)
     OPTION="${1}"
-    CPSOURCE="${2}"
-    CPDEST="${3}"
+    shift
     ;;
 esac
 
 if [ $# -ne 2 ]; then
     usage
 fi
+
+CPSOURCE="${1}"
+CPDEST="${2}"
 
 if [ "${TARGET}" = "ALL" ]; then
     usage


### PR DESCRIPTION
Using the `-q` option for rcp does not work.

Testing done after the fix:

```
❯ bastille rcp adguard /etc/hosts .

[adguard]:
/usr/local/bastille/jails/adguard/root//etc/hosts -> ./hosts


❯ bastille rcp adguard -q /etc/hosts .

[adguard]:

```
