### PR TITLE
A couple of RDR enhancements

### DIFF
--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -7,6 +7,9 @@ without modifying pf.conf (assuming you are using the `bastille0` interface
 for a private network and have enabled `rdr-anchor 'rdr/*'` in /etc/pf.conf
 as described in the Networking section).
 
+When using `dev` modifier you need to make sure the proper nat configuration is
+active for specified network device (`nat on DEV from <jails> to any -> (DEV:0)`).
+
 Note: you need to be careful if host services are configured to run
 on all interfaces as this will include the jail interface - you should
 specify the interface they run on in rc.conf (or other config files)
@@ -14,13 +17,25 @@ specify the interface they run on in rc.conf (or other config files)
 .. code-block:: shell
 
     # bastille rdr --help
-    Usage: bastille rdr TARGET [clear] | [list] | [tcp <host_port> <jail_port>] | [udp <host_port> <jail_port>]
+    Usage: bastille rdr TARGET [(dev <net_device>)|(ip <destination_ip>)] (clear [persistent])|(list [persistent])|(tcp|udp <host_port> <jail_port> [log ['(' logopts ')'] ] )
     # bastille rdr dev1 tcp 2001 22
     # bastille rdr dev1 list
     rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
+    # bastille rdr dev1 list persistent
+    tcp 2001 22
     # bastille rdr dev1 udp 2053 53
     # bastille rdr dev1 list
     rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
     rdr on em0 inet proto udp from any to any port = 2053 -> 10.17.89.1 port 53
+    # bastille rdr dev1 dev lo0 ip 10.0.0.2 tcp 8080 80
+    # bastille rdr dev1 list
+    rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
+    rdr on em0 inet proto udp from any to any port = 2053 -> 10.17.89.1 port 53
+    rdr on lo0 inet proto tcp from any to 10.0.0.2 port = 8080 -> 10.17.89.1 port 80
     # bastille rdr dev1 clear
+    Clearing dev1 redirects.
     nat cleared
+    # bastille rdr dev1 clear persistent
+    Clearing dev1 redirects.
+    nat cleared
+    Clearing dev1 rdr.conf.


### PR DESCRIPTION
This PR adds two enhancements:

1) RDR list and RDR clear for persistent rules file `rdr.conf`.
The major rationale behind this was, that the `rdr clear` does not clear the `rdr.conf` and only clears the applied pf rules. I didn't want to change the current default behavior (it may be useful in some cases).  


2) RDR ip and dev commands. It allows changing the globally configured ext_if device and defining specific host target ip address. Even this change extends the rdr.conf format it is consistent with the current format and no migration is needed.

Now a following format of `rdr.conf` is allowed:
```
tcp 22 22
udp 53 53 log (all, to pflog1)
ip 192.168.1.1 tcp 22 22
dev wg0 tcp 22 22
ip 192.168.1.1 dev wg0 udp 53 53
ip 192.168.1.1 dev wg0 tcp 23 22 log
```
It allows bigger flexibility of redirection and fix some issues. 
For example when the system is a gateway and the ext_if is the device being a gateway, the former redirection (from any to any) cause a redirect of all the packets heading to that port on this device even if the destination ip was different.
Another possible example of use case is having a two outgoing interfaces (in all my cases an ethernet port and a wireguard tunnel) with a possibility to selectively redirect from.

Then there are two extra commits. One is for the overall rdr.sh cleanup (deduplication, consistent formating, and generalization). And the last commit is update to the rdr documentation, which was not updated for a while.