### PR TITLE
[BUGFIX] Fixed rcorder startup

### DIFF
--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -41,7 +41,7 @@ restart_cmd="bastille_stop && bastille_start"
 rcordered_list() {
     local _jailsdir
     _jailsdir=$(. $bastille_conf; echo $bastille_jailsdir)
-    bastille_ordered_list=$(rcorder -s nostart ${_jailsdir}/*/jail.conf | xargs dirname | xargs basename | tr "\n" " ")
+    bastille_ordered_list=$(rcorder -s nostart ${_jailsdir}/*/jail.conf | xargs dirname | xargs basename -a | tr "\n" " ")
 }
 
 bastille_start()


### PR DESCRIPTION
Adding `bastille_rcorder="YES"` to `/etc/rc.conf` doesn't start all jails on bootup. The culprit seems to be `xargs basename`. Without the `-a` flag, this command will only output one match (the first one found).

This fix hasn't been thoroughly tested, although it works in all of my personal usecases.

This should also fix issue https://github.com/BastilleBSD/bastille/issues/678