### PR TITLE
Fix to correctly check ZFS on/off

### DIFF
--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -212,7 +212,7 @@ if [ -n "${TXZ_EXPORT}" -o -n "${TGZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
     error_exit "Error: Simple archive modes with safe ZFS export can't be used together."
 fi
 
-if checkyesno bastille_zfs_enable; then
+if ! checkyesno bastille_zfs_enable; then
     if [ -n "${GZIP_EXPORT}" -o -n "${RAW_EXPORT}" -o -n "${SAFE_EXPORT}" -o "${OPT_ZSEND}" = "-Rv" ]; then
         error_exit "Options --gz, --raw, --safe, --verbose are valid for ZFS configured systems only."
     fi


### PR DESCRIPTION
This PR corrects the test for argument compatibility with zfs when exporting jails.
