### PR TITLE
Fix alignment when listing jails with more than one IP address

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -150,7 +150,22 @@ list_all(){
                         JAIL_HOSTNAME=${JAIL_HOSTNAME:-${DEFAULT_VALUE}}
                         JAIL_RELEASE=${JAIL_RELEASE:-${DEFAULT_VALUE}}
                         JAIL_PATH=${JAIL_PATH:-${DEFAULT_VALUE}}
-                        printf " ${JAIL_NAME}%*s${JAIL_STATE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_RELEASE}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#JAIL_NAME} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_RELEASE} - ${#JAIL_RELEASE} + ${SPACER}))" ""
+                        JAIL_IP_COUNT=$(echo "${JAIL_IP}" | wc -l)
+                        if [ ${JAIL_IP_COUNT} -gt 1 ]; then
+                            # vnet0 has more than one IPs assigned.
+                            # Put each IP in its own line below the jails first address. For instance:
+                            #  JID     State  IP Address       Published Ports  Hostname  Release          Path
+                            #  foo     Up     10.10.10.10      -                foo       14.0-RELEASE-p5  /usr/local/bastille/jails/foo/root
+                            #                 10.10.10.11
+                            #                 10.10.10.12
+                            FIRST_IP="$(echo "${JAIL_IP}" | head -n 1)"
+                            printf " ${JAIL_NAME}%*s${JAIL_STATE}%*s${FIRST_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_RELEASE}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#JAIL_NAME} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#FIRST_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_RELEASE} - ${#JAIL_RELEASE} + ${SPACER}))" ""
+                            for IP in $(echo "${JAIL_IP}" | tail -n +2); do
+                                printf "%*s %*s${IP}\n" "$((${MAX_LENGTH_JAIL_NAME} + ${SPACER}))" "" "$((5 + ${SPACER}))" ""
+                            done
+                        else
+                            printf " ${JAIL_NAME}%*s${JAIL_STATE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_HOSTNAME}%*s${JAIL_RELEASE}%*s${JAIL_PATH}\n" "$((${MAX_LENGTH_JAIL_NAME} - ${#JAIL_NAME} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_HOSTNAME} - ${#JAIL_HOSTNAME} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_RELEASE} - ${#JAIL_RELEASE} + ${SPACER}))" ""
+                        fi
                 fi
             done
         else


### PR DESCRIPTION
When a VNET jail has more than IP address configured on its primary interface, invoking `bastille list -a` will now display all addresses vertically aligned. This is to address a misalignment issue where the fields following the ip addresses were no longer in the same line as the jail name.

For instance:

```
 JID     State  IP Address       Published Ports  Hostname  Release          Path
 foo     Up     10.10.10.10
10.10.10.11   -                foo              14.0-RELEASE-p5  /usr/local/bastille/jails/foo/root
 hello1  Up     10.10.10.13      -                hello1                 14.0-RELEASE-p5  /usr/local/bastille/jails/hello1/root
 hello   Up     10.10.10.12      -                hello                14.0-RELEASE-p5  /usr/local/bastille/jails/hello/root
 test    Up     10.10.10.14      -                test               14.0-RELEASE-p5  /usr/local/bastille/jails/test/root
```

With this change, all additional IPs for a given jail are aligned vertically, and the fields following the IP (ports, hostname, release, path) are all in the same line as the jail name:

```
 JID     State  IP Address       Published Ports  Hostname  Release          Path
 foo     Up     10.10.10.10      -                foo              14.0-RELEASE-p5  /usr/local/bastille/jails/foo/root
                10.10.10.11
 hello1  Up     10.10.10.13      -                hello1                 14.0-RELEASE-p5  /usr/local/bastille/jails/hello1/root
 hello   Up     10.10.10.12      -                hello                14.0-RELEASE-p5  /usr/local/bastille/jails/hello/root
 test    Up     10.10.10.14      -                test               14.0-RELEASE-p5  /usr/local/bastille/jails/test/root
```

### Considerations
#### Grouping of IPs
Initially I attempted to use line-drawing characters to visualize the fact that all addresses belong to the same jail:

```
 JID     State  IP Address       Published Ports  Hostname  Release          Path
 foo     Up     ┬ 10.10.10.10    -                foo              14.0-RELEASE-p5  /usr/local/bastille/jails/foo/root
                └ 10.10.10.11
 hello1  Up     10.10.10.13      -                hello1                 14.0-RELEASE-p5  /usr/local/bastille/jails/hello1/root
 hello   Up     10.10.10.12      -                hello                14.0-RELEASE-p5  /usr/local/bastille/jails/hello/root
 test    Up     10.10.10.14      -                test               14.0-RELEASE-p5  /usr/local/bastille/jails/test/root
```

While the result was making it clear to the user where the extra line comes from, the implementation became unnecessarily complex. More importantly, it meant that if anyone parses the output of `bastille list -a` in their script, would have to account for the fact that the "primary" IP address would be in either the third or fourth field of the line.

This highlights the fact that with this, the first and second/third/etc addresses will still be on different fields. The first address will be on field number 3, while the following addresses will be on field number 1. I could potentially modify the output to put some dummy characters in the first two columns, although I'm not sure that I like the result. Let me know if something like the following is preferable.

```
 JID     State  IP Address       Published Ports  Hostname  Release          Path
 foo     Up     10.10.10.10      -                foo              14.0-RELEASE-p5  /usr/local/bastille/jails/foo/root
 └─────  ─────  10.10.10.11
 hello1  Up     10.10.10.13      -                hello1                 14.0-RELEASE-p5  /usr/local/bastille/jails/hello1/root
 hello   Up     10.10.10.12      -                hello                14.0-RELEASE-p5  /usr/local/bastille/jails/hello/root
 test    Up     10.10.10.14      -                test               14.0-RELEASE-p5  /usr/local/bastille/jails/test/root
```



#### Dependencies
No new dependencies were introduced.