### PR TITLE
ZFS check for export.sh need to be inverted

### DIFF
--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -212,7 +212,7 @@ if [ -n "${TXZ_EXPORT}" -o -n "${TGZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
     error_exit "Error: Simple archive modes with safe ZFS export can't be used together."
 fi
 
-if checkyesno bastille_zfs_enable; then
+if ! checkyesno bastille_zfs_enable; then
     if [ -n "${GZIP_EXPORT}" -o -n "${RAW_EXPORT}" -o -n "${SAFE_EXPORT}" -o "${OPT_ZSEND}" = "-Rv" ]; then
         error_exit "Options --gz, --raw, --safe, --verbose are valid for ZFS configured systems only."
     fi


### PR DESCRIPTION
The checkyesno for zfs needs to be inverted. 
`checkyesno` returns 0 if true; see `common.sh:121`
if zfs_enabled=NO , then disallow GZIP etc.


