### PR TITLE
Add Support for Static MAC Address for Jails

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -86,12 +86,12 @@ update_jailconf() {
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
     if [ -f "${JAIL_CONFIG}" ]; then
         if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${JAIL_CONFIG}"; then
-            sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
-            sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
-            sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
-            sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
-            sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
-            sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
+            #sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
+            #sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
+            #sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
+            #sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
+            #sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
+            #sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
         fi
     fi
 
@@ -110,13 +110,25 @@ update_jailconf_vnet() {
     for _num in $(seq 0 "${num_range}"); do
         if [ -n "${jail_list}" ]; then
             if ! grep -q "e0b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                uniq_epair="bastille${_num}"
-                # Update the exec.* with uniq_epair when cloning jails.
-                sed -i '' "s|vnet.interface = e0b_bastille.*;|vnet.interface = e0b_${uniq_epair};|" "${JAIL_CONFIG}"
-                sed -i '' "s|exec.prestart += \"jib addm bastille[0-9]|exec.prestart += \"jib addm ${uniq_epair}|" "${JAIL_CONFIG}"
-                sed -i '' "s|exec.prestart += \"ifconfig e0a_bastille[0-9].*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
-                sed -i '' "s|exec.poststop += \"jib destroy bastille[0-9]\";|exec.poststop += \"jib destroy ${uniq_epair}\";|" "${JAIL_CONFIG}"
-                break
+                if ! grep -q "epair${_num}" "${bastille_jailsdir}"/*/jail.conf; then
+                    local uniq_epair="bastille${_num}"
+                    local uniq_epair_bridge="${_num}"
+                    local host_mac_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
+		            local jail_mac_suffix="$(echo -n ${NEWNAME} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
+		            # Update the exec.* with uniq_epair when cloning jails.
+                    #sed -i '' "s|vnet.interface = e[0-9]b_bastille.*;|vnet.interface = e0b_${uniq_epair};|" "${JAIL_CONFIG}"
+                    #sed -i '' "s|exec.prestart += \"jib addm bastille[0-9]|exec.prestart += \"jib addm ${uniq_epair};|" "${JAIL_CONFIG}"
+                    #sed -i '' "s|exec.prestart += \"ifconfig e[0-9]a_bastille[0-9] description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
+                    #sed -i '' "s|exec.poststop += \"jib destroy bastille[0-9]\";|exec.poststop += \"jib destroy ${uniq_epair}\";|" "${JAIL_CONFIG}"
+                    # for bridged jails
+		            sed -i '' "s|${TARGET}|${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|\"e\([0-9]\{1,\}\)|\"e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s| e\([0-9]\{1,\}\)| e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s| epair\([0-9]\{1,\}\)| epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|.*a_.*ether.*|exec.prestart += \"ifconfig e${uniq_epair_bridge}a_${NEWNAME} ether ${host_mac_prefix}:${jail_mac_suffix}a\";|" "${JAIL_CONFIG}"
+                    sed -i '' "s|.*b_.*ether.*|exec.prestart += \"ifconfig e${uniq_epair_bridge}b_${NEWNAME} ether ${host_mac_prefix}:${jail_mac_suffix}b\";|" "${JAIL_CONFIG}"
+                    break
+                fi
             fi
         fi
     done
@@ -208,3 +220,4 @@ else
 fi
 
 clone_jail
+

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -86,12 +86,12 @@ update_jailconf() {
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
     if [ -f "${JAIL_CONFIG}" ]; then
         if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${JAIL_CONFIG}"; then
-            #sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
-            #sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
-            #sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
-            #sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
-            #sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
-            #sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
+            sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
+            sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
+            sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
+            sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
+            sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
+            sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
         fi
     fi
 
@@ -114,14 +114,14 @@ update_jailconf_vnet() {
                     local uniq_epair="bastille${_num}"
                     local uniq_epair_bridge="${_num}"
                     local host_mac_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
-		            local jail_mac_suffix="$(echo -n ${NEWNAME} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
-		            # Update the exec.* with uniq_epair when cloning jails.
-                    #sed -i '' "s|vnet.interface = e[0-9]b_bastille.*;|vnet.interface = e0b_${uniq_epair};|" "${JAIL_CONFIG}"
-                    #sed -i '' "s|exec.prestart += \"jib addm bastille[0-9]|exec.prestart += \"jib addm ${uniq_epair};|" "${JAIL_CONFIG}"
-                    #sed -i '' "s|exec.prestart += \"ifconfig e[0-9]a_bastille[0-9] description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
-                    #sed -i '' "s|exec.poststop += \"jib destroy bastille[0-9]\";|exec.poststop += \"jib destroy ${uniq_epair}\";|" "${JAIL_CONFIG}"
-                    # for bridged jails
-		            sed -i '' "s|${TARGET}|${NEWNAME}|g" "${JAIL_CONFIG}"
+		    local jail_mac_suffix="$(echo -n ${NEWNAME} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
+		    # Update the exec.* with uniq_epair when cloning jails.
+                    sed -i '' "s|vnet.interface = e[0-9]b_bastille.*;|vnet.interface = e0b_${uniq_epair};|" "${JAIL_CONFIG}"
+                    sed -i '' "s|exec.prestart += \"jib addm bastille[0-9]|exec.prestart += \"jib addm ${uniq_epair};|" "${JAIL_CONFIG}"
+                    sed -i '' "s|exec.prestart += \"ifconfig e[0-9]a_bastille[0-9] description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
+                    sed -i '' "s|exec.poststop += \"jib destroy bastille[0-9]\";|exec.poststop += \"jib destroy ${uniq_epair}\";|" "${JAIL_CONFIG}"
+                    # for bridged VNET jails
+		    sed -i '' "s|${TARGET}|${NEWNAME}|g" "${JAIL_CONFIG}"
                     sed -i '' "s|\"e\([0-9]\{1,\}\)|\"e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
                     sed -i '' "s| e\([0-9]\{1,\}\)| e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
                     sed -i '' "s| epair\([0-9]\{1,\}\)| epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -86,11 +86,7 @@ update_jailconf() {
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
     if [ -f "${JAIL_CONFIG}" ]; then
         if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${JAIL_CONFIG}"; then
-            sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
-            sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
-            sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
-            sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
-            sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
+            sed -i '' "s|${TARGET}|${NEWNAME}|g" "${JAIL_CONFIG}"
             sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
         fi
     fi
@@ -116,17 +112,13 @@ update_jailconf_vnet() {
                     local host_mac_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
 		    local jail_mac_suffix="$(echo -n ${NEWNAME} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
 		    # Update the exec.* with uniq_epair when cloning jails.
-                    sed -i '' "s|vnet.interface = e[0-9]b_bastille.*;|vnet.interface = e0b_${uniq_epair};|" "${JAIL_CONFIG}"
-                    sed -i '' "s|exec.prestart += \"jib addm bastille[0-9]|exec.prestart += \"jib addm ${uniq_epair};|" "${JAIL_CONFIG}"
-                    sed -i '' "s|exec.prestart += \"ifconfig e[0-9]a_bastille[0-9] description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
-                    sed -i '' "s|exec.poststop += \"jib destroy bastille[0-9]\";|exec.poststop += \"jib destroy ${uniq_epair}\";|" "${JAIL_CONFIG}"
-                    # for bridged VNET jails
-		    sed -i '' "s|${TARGET}|${NEWNAME}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|\"e\([0-9]\{1,\}\)|\"e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s| e\([0-9]\{1,\}\)| e${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s| epair\([0-9]\{1,\}\)| epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|.*a_.*ether.*|exec.prestart += \"ifconfig e${uniq_epair_bridge}a_${NEWNAME} ether ${host_mac_prefix}:${jail_mac_suffix}a\";|" "${JAIL_CONFIG}"
-                    sed -i '' "s|.*b_.*ether.*|exec.prestart += \"ifconfig e${uniq_epair_bridge}b_${NEWNAME} ether ${host_mac_prefix}:${jail_mac_suffix}b\";|" "${JAIL_CONFIG}"
+                    # for VNET jails
+                    sed -i '' "s|bastille\([0-9]\{1,\}\)|${uniq_epair}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|e\([0-9]\{1,\}\)a_${NEWNAME}|e${uniq_epair_bridge}a_${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|e\([0-9]\{1,\}\)b_${NEWNAME}|e${uniq_epair_bridge}b_${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|epair\([0-9]\{1,\}\)|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*a|ether ${host_mac_prefix}:${jail_mac_suffix}a|" "${JAIL_CONFIG}"
+                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*b|ether ${host_mac_prefix}:${jail_mac_suffix}b|" "${JAIL_CONFIG}"
                     break
                 fi
             fi
@@ -135,7 +127,7 @@ update_jailconf_vnet() {
 
     # Rename interface to new uniq_epair
     sed -i '' "s|ifconfig_e0b_bastille.*_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-    sed -i '' "s|ifconfig_e.*b.*_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
+    sed -i '' "s|ifconfig_e.*b_${TARGET}_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
     
     # If 0.0.0.0 set DHCP, else set static IP address
     if [ "${IP}" == "0.0.0.0" ]; then
@@ -221,4 +213,3 @@ else
 fi
 
 clone_jail
-

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -135,7 +135,8 @@ update_jailconf_vnet() {
 
     # Rename interface to new uniq_epair
     sed -i '' "s|ifconfig_e0b_bastille.*_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-
+    sed -i '' "s|ifconfig_e.*b.*_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
+    
     # If 0.0.0.0 set DHCP, else set static IP address
     if [ "${IP}" == "0.0.0.0" ]; then
         sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -94,14 +94,13 @@ generate_vnet_jail_netblock() {
         local uniq_epair="bastille0"
         local uniq_epair_bridge="0"
     fi
-    # generate static MAC for jail using host prefix (first half of host MAC)
-    local host_mac_prefix="$(ifconfig ${external_interface} | grep ether | awk '{print $2}' | cut -d':' -f1-3)"
-    local jail_mac_suffix="$(echo -n ${jail_name} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
+	local host_mac_prefix="$(ifconfig ${external_interface} | grep ether | awk '{print $2}' | cut -d':' -f1-3)"
+	local jail_mac_suffix="$(echo -n ${jail_name} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
     if [ -n "${use_unique_bridge}" ]; then
         ## generate bridge config
         cat <<-EOF
   vnet;
-  vnet.interface = "e${uniq_epair_bridge}b_${jail_name}";
+  vnet.interface = e${uniq_epair_bridge}b_${jail_name};
   exec.prestart += "ifconfig epair${uniq_epair_bridge} create";
   exec.prestart += "ifconfig ${external_interface} addm epair${uniq_epair_bridge}a";
   exec.prestart += "ifconfig epair${uniq_epair_bridge}a up name e${uniq_epair_bridge}a_${jail_name}";
@@ -117,9 +116,9 @@ EOF
   vnet;
   vnet.interface = e0b_${uniq_epair};
   exec.prestart += "jib addm ${uniq_epair} ${external_interface}";
-  exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
   exec.prestart += "ifconfig e0a_${uniq_epair} ether ${host_mac_prefix}:${jail_mac_suffix}a";
   exec.prestart += "ifconfig e0b_${uniq_epair} ether ${host_mac_prefix}:${jail_mac_suffix}b";
+  exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
   exec.poststop += "jib destroy ${uniq_epair}";
 EOF
     fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -96,7 +96,7 @@ generate_vnet_jail_netblock() {
     fi
     # generate static MAC for jail using host prefix (first half of host MAC)
     local host_mac_prefix="$(ifconfig ${external_interface} | grep ether | awk '{print $2}' | cut -d':' -f1-3)"
-	local jail_mac_suffix="$(echo -n ${jail_name} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
+    local jail_mac_suffix="$(echo -n ${jail_name} | sha256 | tr -d '\n' | awk '{print substr($0,length($0)-5,2) ":" substr($0,length($0)-3,2) ":" substr($0,length($0)-1,1)}')"
     if [ -n "${use_unique_bridge}" ]; then
         ## generate bridge config
         cat <<-EOF

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -118,6 +118,8 @@ EOF
   vnet.interface = e0b_${uniq_epair};
   exec.prestart += "jib addm ${uniq_epair} ${external_interface}";
   exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
+  exec.prestart += "ifconfig e0a_${uniq_epair} ether ${host_mac_prefix}:${jail_mac_suffix}a";
+  exec.prestart += "ifconfig e0b_${uniq_epair} ether ${host_mac_prefix}:${jail_mac_suffix}b";
   exec.poststop += "jib destroy ${uniq_epair}";
 EOF
     fi


### PR DESCRIPTION
This PR adds support for static MAC addresses for jails. Steps outlined below.

1. It will use the first half of the hosts MAC address to prevent network problems.
2. It will hash the jail name and extract the first five characters of the hash, then append an "a" for the host side and a "b" for the jail side epair MAC address.
3. It will add these values to the jail.conf file for the jail, so it will use the same MAC address on a reboot, and if the jail is recreated, providing the same jail name is used.

I have tested this with the "-B" and "-V" options, and my testing was successful.

Edits are welcome if needed.