### PR TITLE
Update BASTILLE_VERSION string

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -62,7 +62,7 @@ bastille_perms_check() {
 bastille_perms_check
 
 ## version
-BASTILLE_VERSION="0.10.20231125"
+BASTILLE_VERSION="0.11.20241022"
 
 usage() {
     cat << EOF


### PR DESCRIPTION
Please update the version string in `usr/local/bin/bastille` from `0.10.20231125` to `0.11.20241022` so that the version reported by `bastille -v` matches the version reported by `pkg info bastille | grep Version`.

Currently, this is not the case:

```shell
admin@freebsd:~ % pkg info bastille | grep Version
Version        : 0.11.20241022
```

```shell
admin@freebsd:~ % bastille -v
0.10.20231125
```