### PR TITLE
mount.sh now accepts nullfs mounted files

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -70,7 +70,7 @@ fi
 ## if host path doesn't exist, type is not "nullfs" or are using advanced mount type "tmpfs,linprocfs,linsysfs, fdescfs, procfs"	
 if [ "${_hostpath}" == "tmpfs" -a "$_type" == "tmpfs" ] || [ "${_hostpath}" == "linprocfs" -a "${_type}" == "linprocfs" ] || [ "${_hostpath}" == "linsysfs" -a "${_type}" == "linsysfs" ] || [ "${_hostpath}" == "proc" -a "${_type}" == "procfs" ] || [ "${_hostpath}" == "fdesc" -a "${_type}" == "fdescfs" ]  ;  then
     warn "Detected advanced mount type ${_hostpath}"
-elif [ ! -d "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
+elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     error_notify "Detected invalid host path or incorrect mount type in FSTAB."
     warn "Format: /host/path jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"
@@ -101,7 +101,7 @@ for _jail in ${JAILS}; do
     _fstab_entry="${_hostpath} ${_fullpath} ${_type} ${_perms} ${_checks}"
 
     ## Create mount point if it does not exist. -- cwells
-    if [ ! -d "${_fullpath}" ]; then
+    if [ -d "${_hostpath}" ] && [ ! -d "${_fullpath}" ]; then
         if ! mkdir -p "${_fullpath}"; then
             error_exit "Failed to create mount point inside jail."
         fi


### PR DESCRIPTION
It is sometimes desirable to nullfs mount a single file into a jail, like resolv.conf, hosts, or otherwise. However, using a MOUNT in a Bastillefile with a file mount currently throws an error. The script needs a small adaptation to accept files.