### PR TITLE
changed setup.sh loopback creation

### DIFF
--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -31,10 +31,15 @@
 bastille_config="/usr/local/etc/bastille/bastille.conf"
 . /usr/local/share/bastille/common.sh
 # shellcheck source=/usr/local/etc/bastille/bastille.conf
+
+if [ ! -f "${bastille_config}" ]
+then
+  cp /usr/local/etc/bastille/bastille.conf.sample ${bastille_config}
+fi
 . ${bastille_config}
 
 usage() {
-    error_exit "Usage: bastille setup [pf|bastille0|zfs|vnet]"
+    error_exit "Usage: bastille setup [pf|network|zfs|vnet]"
 }
 
 # Check for too many args
@@ -42,13 +47,13 @@ if [ $# -gt 1 ]; then
     usage
 fi
 
-# Configure bastille0 network interface
-configure_bastille0() {
-    info "Configuring bastille0 loopback interface"
+# Configure bastille loopback network interface
+configure_network() {
+    info "Configuring ${bastille_network_loopback} loopback interface"
     sysrc cloned_interfaces+=lo1
-    sysrc ifconfig_lo1_name="bastille0"
+    sysrc ifconfig_lo1_name="${bastille_network_loopback}"
 
-    info "Bringing up new interface: bastille0"
+    info "Bringing up new interface: ${bastille_network_loopback}"
     service netif cloneup
 }
 
@@ -123,7 +128,7 @@ configure_zfs() {
 # Run all base functions (w/o vnet) if no args
 if [ $# -eq 0 ]; then
     sysrc bastille_enable=YES
-    configure_bastille0
+    configure_network
     configure_pf
     configure_zfs
 fi
@@ -136,8 +141,8 @@ help|-h|--help)
 pf|firewall)
     configure_pf
     ;;
-bastille0|loopback)
-    configure_bastille0
+network|bastille0|loopback)
+    configure_network
     ;;
 zfs|storage)
     configure_zfs


### PR DESCRIPTION
- check that bastille.conf exists or create a copy from .sample,
- changed "bastille0" loopback creation to read config value $bastille_network_loopback instead,
- changed setup.sh argument "bastille0" for loopback interface creation to a more generic "network",
- "bastille0" as a setup.sh argument is left for backwards compatibility