### PR TITLE
export: be clear that --xz is for ZFS systems

### DIFF
--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -213,8 +213,8 @@ if [ -n "${TXZ_EXPORT}" -o -n "${TGZ_EXPORT}" ] && [ -n "${SAFE_EXPORT}" ]; then
 fi
 
 if ! checkyesno bastille_zfs_enable; then
-    if [ -n "${GZIP_EXPORT}" -o -n "${RAW_EXPORT}" -o -n "${SAFE_EXPORT}" -o "${OPT_ZSEND}" = "-Rv" ]; then
-        error_exit "Options --gz, --raw, --safe, --verbose are valid for ZFS configured systems only."
+    if [ -n "${XZ_EXPORT}" -o -n "${GZIP_EXPORT}" -o -n "${RAW_EXPORT}" -o -n "${SAFE_EXPORT}" -o "${OPT_ZSEND}" = "-Rv" ]; then
+        error_exit "Options --xz, --gz, --raw, --safe, --verbose are valid for ZFS configured systems only."
     fi
 fi
 


### PR DESCRIPTION
The support for the `--xz` option is only for ZFS at the moment since the `import` command assumes that was the case. By now just show a more descriptive message if `--xz` was used on a UFS system.