### PR TITLE
Update destroy.sh - refuse to destroy jail with mounted filesystem

### DIFF
--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -56,7 +56,7 @@ destroy_jail() {
     if [ -d "${bastille_jail_base}" ]; then
         ## make sure no filesystem is currently mounted in the jail directory
         mount_points=$(mount | cut -d ' ' -f 3 | grep "${bastille_jail_base}"/root/)
-        if [ $? -eq 0 ]; then
+        if [ -n "${mount_points}" ]; then
             error_notify "Failed to destroy jail: ${TARGET}"
             error_exit "Jail has mounted filesystems:\n$mount_points"
         fi

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -54,6 +54,12 @@ destroy_jail() {
     fi
 
     if [ -d "${bastille_jail_base}" ]; then
+        ## make sure no filesystem is currently mounted in the jail directory
+        mount_points=$(mount | cut -d ' ' -f 3 | grep "${bastille_jail_base}")
+        if [ $? -eq 0 ]; then
+            error_notify "Failed to destroy jail: ${TARGET}"
+            error_exit "Jail has mounted filesystems:\n$mount_points"
+        fi
         info "Deleting Jail: ${TARGET}."
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -55,7 +55,7 @@ destroy_jail() {
 
     if [ -d "${bastille_jail_base}" ]; then
         ## make sure no filesystem is currently mounted in the jail directory
-        mount_points=$(mount | cut -d ' ' -f 3 | grep "${bastille_jail_base}")
+        mount_points=$(mount | cut -d ' ' -f 3 | grep "${bastille_jail_base}"/root/)
         if [ $? -eq 0 ]; then
             error_notify "Failed to destroy jail: ${TARGET}"
             error_exit "Jail has mounted filesystems:\n$mount_points"


### PR DESCRIPTION
This PR fixes an issue where files could be deleted when bastille attempts to destroy a jail that still has mounted filesystems when using ZFS. It will throw an error and exit if it detects a filesystem is still mounted inside the jail.

To test

```
# bastille create temp 14.0-RELEASE 192.168.1.10 lo1
...
# mkdir test
# cp /usr/bin/less test/
# mkdir /usr/local/bastille/jails/temp/root/test
# bastille mount temp $(realpath test) test
[temp]:
Added: /root/admin/bastille/test /usr/local/bastille/jails/temp/root/test nullfs ro 0 0
# /usr/local/bastille/jails/temp/root/test/less -f /dev/stdin &
# bastille destroy force temp
rdr-anchor not found in pf.conf
[temp]:
temp: removed
umount: unmount of /usr/local/bastille/jails/temp/root/test failed: Device busy
jail: temp: /sbin/umount -t nullfs /usr/local/bastille/jails/temp/root/test: failed

Deleting Jail: temp.
Jail has mounted filesystems:
/usr/local/bastille/jails/temp/root/test
```

With the PR in place, bastille will error upon finding existing mounts.