### PR TITLE
Add autocomplete jail name function

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -188,6 +188,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             if [ "${TARGET}" = 'ALL' ]; then
               target_all_jails
             else
+              jail_autocomplete
               JAILS="${TARGET}"
               check_target_is_running
             fi
@@ -197,7 +198,6 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             # checks. The command will simply convert a template from hooks to a Bastillefile. -- cwells
             :
         else
-            jail_autocomplete
             JAILS="${TARGET}"
 
             # Ensure the target exists. -- cwells

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -138,16 +138,6 @@ check_target_is_running() {
   fi
 }
 
-jail_autocomplete() {
-    AUTOTARGET=$( ls "${bastille_jailsdir}" | grep "${TARGET}" )
-    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
-        TARGET="${AUTOTARGET}"
-        return 0
-    else
-        error_exit "Multiple jails found for $TARGET:\n$AUTOTARGET"
-    fi
-}
-
 # Handle special-case commands first.
 case "${CMD}" in
 version|-v|--version)
@@ -167,7 +157,10 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
     elif [ "${1}" != 'help' ] && [ "${1}" != '-h' ] && [ "${1}" != '--help' ]; then
         TARGET="${1}"
         shift
-
+        # If TARGET is not ALL, attempt to autocomplet given jail name
+        if [ "${TARGET}" != ALL ]; then
+          jail_autocomplete
+        fi
         # This is needed to handle the special case of 'bastille rcp' and 'bastille cp' with the '-q' or '--quiet'
         # option specified before the TARGET. Also seems the cp and rcp commands does not support ALL as a target, so
         # that's why is handled here. Maybe this behaviour needs an improvement later. -- yaazkal
@@ -188,7 +181,6 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             if [ "${TARGET}" = 'ALL' ]; then
               target_all_jails
             else
-              jail_autocomplete
               JAILS="${TARGET}"
               check_target_is_running
             fi

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -138,6 +138,16 @@ check_target_is_running() {
   fi
 }
 
+jail_autocomplete() {
+    AUTOTARGET=$( ls "${bastille_jailsdir}" | grep "${TARGET}" )
+    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
+        TARGET="${AUTOTARGET}"
+        return 0
+    else
+        error_exit "Multiple jails found for $TARGET:\n$AUTOTARGET"
+    fi
+}
+
 # Handle special-case commands first.
 case "${CMD}" in
 version|-v|--version)
@@ -187,6 +197,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             # checks. The command will simply convert a template from hooks to a Bastillefile. -- cwells
             :
         else
+            jail_autocomplete
             JAILS="${TARGET}"
 
             # Ensure the target exists. -- cwells

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -70,6 +70,16 @@ warn() {
     echo -e "${COLOR_YELLOW}$*${COLOR_RESET}"
 }
 
+jail_autocomplete() {
+    AUTOTARGET=$( ls "${bastille_jailsdir}" | grep "${TARGET}" )
+    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
+        TARGET="${AUTOTARGET}"
+        return 0
+    else
+        error_exit "Multiple jails found for $TARGET:\n$AUTOTARGET"
+    fi
+}
+
 generate_vnet_jail_netblock() {
     local jail_name="$1"
     local use_unique_bridge="$2"

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -211,6 +211,7 @@ if [ $# -gt 1 ] || [ $# -lt 1 ]; then
 fi
 
 bastille_root_check
+jail_autocomplete
 
 ## check what should we clean
 case "${TARGET}" in

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -72,8 +72,6 @@ if [ $# -gt 5 ] || [ $# -lt 1 ]; then
 fi
 
 bastille_root_check
-
-# Attempt to autocomplete jail name
 jail_autocomplete
 
 zfs_enable_check() {

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -73,6 +73,9 @@ fi
 
 bastille_root_check
 
+# Attempt to autocomplete jail name
+jail_autocomplete
+
 zfs_enable_check() {
     # Temporarily disable ZFS so we can create a standard backup archive
     if checkyesno bastille_zfs_enable; then

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -55,6 +55,7 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(bastille list jails)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
+    jail_autocomplete
     JAILS=$(bastille list jails | awk "/^${TARGET}$/")
     ## check if exist
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -82,6 +82,9 @@ arch_check() {
     fi
 }
 
+# Attempt to autocomplete jail name
+jail_autocomplete
+
 jail_check() {
     # Check if the jail is thick and is running
     if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -76,6 +76,9 @@ case "${OPTION}" in
         ;;
 esac
 
+# Attempt to autocomplete jail name
+jail_autocomplete
+
 jail_check() {
     # Check if the jail is thick and is running
     if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then


### PR DESCRIPTION
This will allow a user to simple begin typing a jail name. If bastille finds more than one jail starting with what is typed, it will error. If it only find one jail, it will set that jail as the $TARGET

```
root@webmin:~ # bastille list all
 JID   State  IP Address  Published Ports  Hostname  Release       Path
 teer  Up     10.0.0.3    -                teer      14.0-RELEASE  /usr/local/bastille/jails/teer/root
 test  Up     10.0.0.1    -                test      14.0-RELEASE  /usr/local/bastille/jails/test/root
 tesw  Up     10.0.0.2    -                tesw      14.0-RELEASE  /usr/local/bastille/jails/tesw/root
root@webmin:~ # bastille console te
Multiple jails found for te:
teer test tesw
root@webmin:~ # bastille cmd tes
Multiple jails found for tes:
test tesw
root@webmin:~ # bastille console tee
[teer]:
root@teer:~ #
```