### PR TITLE
Update usage.rst - bastille list only shows running containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Available Commands:
   htop        Interactive process viewer (requires htop).
   import      Import a specified container.
   limits      Apply resources limits to targeted container(s). See rctl(8).
-  list        List containers (running and stopped).
+  list        List containers (running).
   mount       Mount a volume inside the targeted container(s).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   rdr         Redirect host port to container port.

--- a/docs/chapters/usage.rst
+++ b/docs/chapters/usage.rst
@@ -26,7 +26,7 @@ Usage
       htop        Interactive process viewer (requires htop).
       import      Import a specified container.
       limits      Apply resources limits to targeted container(s). See rctl(8).
-      list        List containers (running and stopped).
+      list        List containers (running).
       mount       Mount a volume inside the targeted container(s).
       pkg         Manipulate binary packages within targeted container(s). See pkg(8).
       rdr         Redirect host port to container port.

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -88,7 +88,7 @@ Available Commands:
   htop        Interactive process viewer (requires htop).
   import      Import a specified container.
   limits      Apply resources limits to targeted container(s). See rctl(8).
-  list        List containers (running and stopped).
+  list        List containers (running).
   mount       Mount a volume inside the targeted container(s).
   pkg         Manipulate binary packages within targeted container(s). See pkg(8).
   rcp         reverse cp(1) files from a single container to the host.


### PR DESCRIPTION
'bastille list' will only print running containers. '-a' or 'all' is needed to print both running and stopped.