### PR TITLE
Update setup.sh - fail setup on multiple zpool detection

### DIFF
--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -124,7 +124,7 @@ configure_zfs() {
         ## attempt to determine bastille_zroot from `zpool list`
         bastille_zroot=$(zpool list | grep -v NAME | awk '{print $1}')
         if [ $(echo "${bastille_zroot}" | wc -l) -gt 1 ]; then
-          error_notify "Error: Multiple zfs pools available:\n"${bastille_zroot}""
+          error_notify "Error: Multiple ZFS pools available:\n"${bastille_zroot}""
           error_notify "Set desired pool using \"sysrc -f "${bastille_config}" bastille_zfs_zpool=ZPOOL_NAME\""
           error_exit "Don't forget to also enable ZFS using \"sysrc -f "${bastille_config}" bastille_zfs_enable=YES\""
         fi

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -123,6 +123,10 @@ configure_zfs() {
     else
         ## attempt to determine bastille_zroot from `zpool list`
         bastille_zroot=$(zpool list | grep -v NAME | awk '{print $1}')
+        if [ $(echo "${bastille_zroot}" | wc -l) -gt 1 ]; then
+          error_notify "Error: Multiple zfs pools available:\n"${bastille_zroot}""
+          error_exit "Set desired pool using \"sysrc -f "${bastille_config}" bastille_zfs_zpool=ZPOOL_NAME\""
+        fi
         sysrc -f "${bastille_config}" bastille_zfs_enable=YES
         sysrc -f "${bastille_config}" bastille_zfs_zpool="${bastille_zroot}"
     fi

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -125,7 +125,8 @@ configure_zfs() {
         bastille_zroot=$(zpool list | grep -v NAME | awk '{print $1}')
         if [ $(echo "${bastille_zroot}" | wc -l) -gt 1 ]; then
           error_notify "Error: Multiple zfs pools available:\n"${bastille_zroot}""
-          error_exit "Set desired pool using \"sysrc -f "${bastille_config}" bastille_zfs_zpool=ZPOOL_NAME\""
+          error_notify "Set desired pool using \"sysrc -f "${bastille_config}" bastille_zfs_zpool=ZPOOL_NAME\""
+          error_exit "Don't forget to also enable ZFS using \"sysrc -f "${bastille_config}" bastille_zfs_enable=YES\""
         fi
         sysrc -f "${bastille_config}" bastille_zfs_enable=YES
         sysrc -f "${bastille_config}" bastille_zfs_zpool="${bastille_zroot}"


### PR DESCRIPTION
This will cause `bastille setup zfs` to fail when it detects multiple zfs pools. It will also show the user what to do in such a case. 