### PR TITLE
Jail autocomplete function - testing required

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -179,6 +179,12 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
               target_all_jails
             else
               JAILS="${TARGET}"
+              # Ensure the target exists
+              if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+                if ! jail_autocomplete "${TARGET}"; then
+                  error_exit "[${TARGET}]: Not found."
+                fi
+              fi
               check_target_is_running
             fi
             shift
@@ -191,7 +197,9 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
 
             # Ensure the target exists. -- cwells
             if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+              if ! jail_autocomplete "${TARGET}"; then
                 error_exit "[${TARGET}]: Not found."
+              fi
             fi
 
             case "${CMD}" in

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -178,11 +178,11 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             if [ "${TARGET}" = 'ALL' ]; then
               target_all_jails
             else
-              JAILS="${TARGET}"
               # Ensure the target exists. -- cwells
               if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
                 jail_autocomplete "${TARGET}"
               fi
+              JAILS="${TARGET}"
               check_target_is_running
             fi
             shift
@@ -191,12 +191,11 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
             # checks. The command will simply convert a template from hooks to a Bastillefile. -- cwells
             :
         else
-            JAILS="${TARGET}"
-
             # Ensure the target exists. -- cwells
             if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
                 jail_autocomplete "${TARGET}"
             fi
+            JAILS="${TARGET}"
 
             case "${CMD}" in
             cmd|console|htop|pkg|service|stop|sysrc|template|top)

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -148,7 +148,12 @@ help|-h|--help)
     usage
     ;;
 bootstrap|create|destroy|export|import|list|rdr|restart|setup|start|update|upgrade|verify)
-    # Nothing "extra" to do for these commands. -- cwells
+    # Ensure the target exists
+    if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+      if ! jail_autocomplete "${TARGET}"; then
+        error_exit "[${TARGET}]: Not found."
+      fi
+    fi
     ;;
 clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|service|stop|sysrc|tags|template|top|umount|zfs)
     # Parse the target and ensure it exists. -- cwells

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -148,10 +148,7 @@ help|-h|--help)
     usage
     ;;
 bootstrap|create|destroy|export|import|list|rdr|restart|setup|start|update|upgrade|verify)
-    # Ensure the target exists
-    if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-      jail_autocomplete "${TARGET}"
-    fi
+    # Nothing "extra" to do for these commands. -- cwells
     ;;
 clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|service|stop|sysrc|tags|template|top|umount|zfs)
     # Parse the target and ensure it exists. -- cwells

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -179,7 +179,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
               target_all_jails
             else
               JAILS="${TARGET}"
-              # Ensure the target exists
+              # Ensure the target exists. -- cwells
               if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
                 jail_autocomplete "${TARGET}"
               fi
@@ -195,7 +195,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
 
             # Ensure the target exists. -- cwells
             if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-              jail_autocomplete "${TARGET}"
+                jail_autocomplete "${TARGET}"
             fi
 
             case "${CMD}" in

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -150,9 +150,7 @@ help|-h|--help)
 bootstrap|create|destroy|export|import|list|rdr|restart|setup|start|update|upgrade|verify)
     # Ensure the target exists
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-      if ! jail_autocomplete "${TARGET}"; then
-        error_exit "[${TARGET}]: Not found."
-      fi
+      jail_autocomplete "${TARGET}"
     fi
     ;;
 clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|service|stop|sysrc|tags|template|top|umount|zfs)
@@ -186,9 +184,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
               JAILS="${TARGET}"
               # Ensure the target exists
               if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-                if ! jail_autocomplete "${TARGET}"; then
-                  error_exit "[${TARGET}]: Not found."
-                fi
+                jail_autocomplete "${TARGET}"
               fi
               check_target_is_running
             fi
@@ -202,9 +198,7 @@ clone|config|cmd|console|convert|cp|edit|htop|limits|mount|pkg|rcp|rename|servic
 
             # Ensure the target exists. -- cwells
             if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-              if ! jail_autocomplete "${TARGET}"; then
-                error_exit "[${TARGET}]: Not found."
-              fi
+              jail_autocomplete "${TARGET}"
             fi
 
             case "${CMD}" in

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -72,16 +72,19 @@ warn() {
 
 jail_autocomplete() {
     local jail_name="${1}"
-    local AUTOTARGET="$( ls "${bastille_jailsdir}" | grep "${jail_name}" )"
-    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
-        TARGET="${AUTOTARGET}"
-        return 0
-    elif [ $( echo "${AUTOTARGET}" | wc -l ) -gt 1 ]; then
-        error_exit "Multiple jails found for $jail_name:\n$AUTOTARGET"
+    if ls "${bastille_jailsdir}" | grep "${jail_name}"; then
+        local AUTOTARGET="$( ls "${bastille_jailsdir}" | grep "${jail_name}" )"
     else
         error_exit "[${jail_name}]: Not found."
     fi
+    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
+        TARGET="${AUTOTARGET}"
+        return 0
+    else
+        error_exit "Multiple jails found for $jail_name:\n$AUTOTARGET"
+    fi
 }
+
 
 generate_vnet_jail_netblock() {
     local jail_name="$1"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -70,6 +70,16 @@ warn() {
     echo -e "${COLOR_YELLOW}$*${COLOR_RESET}"
 }
 
+jail_autocomplete() {
+    AUTOTARGET=$( ls "${bastille_jailsdir}" | grep "${TARGET}" )
+    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
+        TARGET="${AUTOTARGET}"
+        return 0
+    else
+        error_exit "Multiple jails found for $TARGET:\n$AUTOTARGET"
+    fi
+}
+
 generate_vnet_jail_netblock() {
     local jail_name="$1"
     local use_unique_bridge="$2"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -76,8 +76,10 @@ jail_autocomplete() {
     if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
         TARGET="${AUTOTARGET}"
         return 0
-    else
+    elif [ $( echo "${AUTOTARGET}" | wc -l ) -gt 1 ]; then
         error_exit "Multiple jails found for $jail_name:\n$AUTOTARGET"
+    else
+        error_exit "[${jail_name}]: Not found."
     fi
 }
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -72,12 +72,14 @@ warn() {
 
 jail_autocomplete() {
     local jail_name="${1}"
+    # shellcheck disable=SC2010
     if ls "${bastille_jailsdir}" | grep "${jail_name}"; then
         local AUTOTARGET="$( ls "${bastille_jailsdir}" | grep "${jail_name}" )"
     else
         error_exit "[${jail_name}]: Not found."
     fi
-    if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
+    # shellcheck disable=SC2034
+    if [ "$( echo "${AUTOTARGET}" | wc -l )" -eq 1 ]; then
         TARGET="${AUTOTARGET}"
         return 0
     else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -71,12 +71,13 @@ warn() {
 }
 
 jail_autocomplete() {
-    AUTOTARGET=$( ls "${bastille_jailsdir}" | grep "${TARGET}" )
+    local jail_name="${1}"
+    local AUTOTARGET="$( ls "${bastille_jailsdir}" | grep "${jail_name}" )"
     if [ $( echo "${AUTOTARGET}" | wc -l ) -eq 1 ]; then
         TARGET="${AUTOTARGET}"
         return 0
     else
-        error_exit "Multiple jails found for $TARGET:\n$AUTOTARGET"
+        error_exit "Multiple jails found for $jail_name:\n$AUTOTARGET"
     fi
 }
 

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -37,13 +37,14 @@ usage() {
 
 destroy_jail() {
     local OPTIONS
-    bastille_jail_base="${bastille_jailsdir}/${TARGET}"            ## dir
-    bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
-	
+
     # Ensure the target exists. -- cwells
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
       jail_autocomplete "${TARGET}"
     fi
+    
+    bastille_jail_base="${bastille_jailsdir}/${TARGET}"            ## dir
+    bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
     
     if [ "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         if [ "${FORCE}" = "1" ]; then

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -39,7 +39,12 @@ destroy_jail() {
     local OPTIONS
     bastille_jail_base="${bastille_jailsdir}/${TARGET}"            ## dir
     bastille_jail_log="${bastille_logsdir}/${TARGET}_console.log"  ## file
-
+	
+    # Ensure the target exists. -- cwells
+    if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+      jail_autocomplete "${TARGET}"
+    fi
+    
     if [ "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
         if [ "${FORCE}" = "1" ]; then
             bastille stop "${TARGET}"

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -92,6 +92,11 @@ TGZ_EXPORT=
 OPT_ZSEND="-R"
 COMP_OPTION="0"
 
+# Ensure the target exists. -- cwells
+if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+  jail_autocomplete "${TARGET}"
+fi
+
 opt_count() {
     COMP_OPTION=$(expr ${COMP_OPTION} + 1)
 }

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -229,8 +229,8 @@ if [ $# -gt 0 ]; then
     ;;
     *)
         # Check if we want to query all info for a specific jail instead.
-        if [ -f "${bastille_jailsdir}/${1}/jail.conf" ]; then
-            TARGET="${1}"
+        if [ ! -f "${bastille_jailsdir}/${1}/jail.conf" ]; then
+	    jail_autocomplete "${1}"
             list_all
         else
             usage

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -64,7 +64,7 @@ check_jail_validity() {
     # Check if jail name is valid
     JAIL_NAME=$(/usr/sbin/jls -j "${TARGET}" name 2>/dev/null)
     if [ -z "${JAIL_NAME}" ]; then
-        error_exit "Jail not found: ${TARGET}"
+        jail_autocomplete "${TARGET}"
     fi
 
     # Check if jail ip4 address (ip4.addr) is valid (non-VNET only)

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -65,6 +65,7 @@ check_jail_validity() {
     JAIL_NAME=$(/usr/sbin/jls -j "${TARGET}" name 2>/dev/null)
     if [ -z "${JAIL_NAME}" ]; then
         jail_autocomplete "${TARGET}"
+        JAIL_NAME="${TARGET}"
     fi
 
     # Check if jail ip4 address (ip4.addr) is valid (non-VNET only)

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -55,11 +55,11 @@ if [ "${TARGET}" = 'ALL' ]; then
     JAILS=$(bastille list jails)
 fi
 if [ "${TARGET}" != 'ALL' ]; then
-    JAILS=$(bastille list jails | awk "/^${TARGET}$/")
     ## check if exist
     if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-        error_exit "[${TARGET}]: Not found."
+        jail_autocomplete "${TARGET}"
     fi
+    JAILS=$(bastille list jails | awk "/^${TARGET}$/")
 fi
 
 for _jail in ${JAILS}; do

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -66,6 +66,11 @@ if [ "${TARGET}" = "ALL" ]; then
     error_exit "Batch upgrade is unsupported."
 fi
 
+# Ensure the target exists. -- cwells
+if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+    jail_autocomplete "${TARGET}"
+fi
+
 if [ -f "/bin/midnightbsd-version" ]; then
     echo -e "${COLOR_RED}Not yet supported on MidnightBSD.${COLOR_RESET}"
     exit 1

--- a/usr/local/share/bastille/upgrade.sh
+++ b/usr/local/share/bastille/upgrade.sh
@@ -57,6 +57,11 @@ if [ "${TARGET}" = "ALL" ]; then
     error_exit "Batch upgrade is unsupported."
 fi
 
+# Ensure the target exists. -- cwells
+if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
+    jail_autocomplete "${TARGET}"
+fi
+    
 if [ -f "/bin/midnightbsd-version" ]; then
     echo -e "${COLOR_RED}Not yet supported on MidnightBSD.${COLOR_RESET}"
     exit 1


### PR DESCRIPTION
I've rewritten the autocomplete function to be a little easier to follow.
These are the key points.

- main function is inside common.sh
- it is only run if the jail is not first found by grepping the jails directory
- it is only run inside an *.sh file that requires the TARGET=jail arg

When testing, please try to use every single command that is directed toward a jail, and let me know if it works properly or not.