### PR TITLE
Update template.sh - bugfix for cmd

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -299,7 +299,7 @@ for _jail in ${JAILS}; do
                     # Escape single-quotes in the command being executed. -- cwells
                     _args=$(echo "${_args}" | sed "s/'/'\\\\''/g")
                     # Allow redirection within the jail. -- cwells
-                    _args="sh -c '${_args}'"
+                    _args="sh -c \"${_args}\""
                     ;;
                 cp|copy)
                     _cmd='cp'


### PR DESCRIPTION
This fixes a bug where templated "`cmd`" would not working when doing some commands like `fetch`.