### PR TITLE
RDR Improvements: Allow TO/FROM+INTERACE+IP STACK

### DIFF
--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -2,7 +2,7 @@
 rdr
 ===
 
-bastille rdr allows you to configure dynamic rdr rules for your containers
+`bastille rdr` allows you to configure dynamic rdr rules for your containers
 without modifying pf.conf (assuming you are using the `bastille0` interface
 for a private network and have enabled `rdr-anchor 'rdr/*'` in /etc/pf.conf
 as described in the Networking section).
@@ -17,11 +17,11 @@ specify the interface they run on in rc.conf (or other config files)
     Usage: bastille rdr TARGET [option(s)] [clear|reset|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
     Options:
 
-    -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-    -s | --source      [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
-    -d | --destination [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
-    -t | --type        [ipv4|ipv6]      | -- Specify IP type. Must be used if -s or -d are used. Defaults to both.
-
+    -i | --interface   [interface]               Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
+    -s | --source      [source ip]               Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
+    -d | --destination [destination ip]          Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -t | --type        [ipv4|ipv6]               Specify IP type. Must be used if -s or -d are used. Defaults to both.
+    -x | --debug                                 Enable debug mode.
     
     # bastille rdr dev1 tcp 2001 22
     [jail1]:
@@ -41,11 +41,12 @@ specify the interface they run on in rc.conf (or other config files)
     # bastille rdr dev1 clear
     nat cleared
 
-The `rdr` command includes 3 additional options:
+The `rdr` command includes 4 additional options:
 
 - **-i** | Set a non-default interface on which to create the `rdr` rule.
 - **-s** | Limit the source IP on the `rdr` rule.
 - **-d** | Limit the destination IP on the `rdr` rule.
+- **-t** | Specify network type. Can be "ipv4" or "ipv6". Default is "dual".
 
 .. code-block:: shell
 
@@ -72,3 +73,6 @@ The `rdr` command includes 3 additional options:
     rdr pass on vtnet0 inet proto tcp from any to 192.168.0.45 port = 9000 -> 10.17.89.1 port 9000
 
 The options can be used together, as seen above.
+
+If you have multiple interfaces assigned to your jail, `bastille rdr` will
+only redirect using the default one.

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -43,10 +43,12 @@ specify the interface they run on in rc.conf (or other config files)
 
 The `rdr` command includes 4 additional options:
 
-- **-i** | Set a non-default interface on which to create the `rdr` rule.
-- **-s** | Limit the source IP on the `rdr` rule.
-- **-d** | Limit the destination IP on the `rdr` rule.
-- **-t** | Specify network type. Can be "ipv4" or "ipv6". Default is "dual".
+.. code-block:: shell
+
+    -i | --interface   [interface]               Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
+    -s | --source      [source ip]               Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
+    -d | --destination [destination ip]          Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -t | --type        [ipv4|ipv6]               Specify IP type. Must be used if -s or -d are used. Defaults to both.
 
 .. code-block:: shell
 

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -25,14 +25,14 @@ specify the interface they run on in rc.conf (or other config files)
     
     # bastille rdr dev1 tcp 2001 22
     [jail1]:
-    IPv4 tcp/any:2001 -> any:22 on em0
+    IPv4 tcp/2001:22  on em0
    
     # bastille rdr dev1 list
     rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
     
     # bastille rdr dev1 udp 2053 53
     [jail1]:
-    IPv4 udp/any:2001 -> any:22 on em0
+    IPv4 udp/2053:53 on em0
     
     # bastille rdr dev1 list
     rdr pass on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
@@ -52,21 +52,21 @@ The `rdr` command includes 4 additional options:
 
 .. code-block:: shell
 
-    # bastille rdr dev1 -i vtnet0 udp 2001 22
+    # bastille rdr dev1 -i vtnet0 udp 8000 80
     [jail1]:
-    IPv4 tcp/any:8000 -> any:80 on vtnet0
+    IPv4 tcp/8000:80 on vtnet0
     
     # bastille rdr dev1 -s 192.168.0.1 tcp 8080 81
     [jail1]:
-    IPv4 tcp/192.168.0.1:8080 -> any:81 on em0
+    IPv4 tcp/8080:81 on em0
 
     # bastille rdr dev1 -d 192.168.0.84 tcp 8082 82
     [jail1]:
-    IPv4 tcp/any:8082 -> 192.168.0.84:82 on em0
+    IPv4 tcp/8082:82 on em0
 
     # bastille rdr dev1 -i vtnet0 -d 192.168.0.45 tcp 9000 9000
     [jail1]:
-    IPv4 tcp/any:9000 -> 192.168.0.45:9000 on vtnet0
+    IPv4 tcp/9000:9000 on vtnet0
 
     # bastille rdr dev1 list
     rdr pass on vtnet0 inet proto udp from any to any port = 2001 -> 10.17.89.1 port 22

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -24,7 +24,7 @@ specify the interface they run on in rc.conf (or other config files)
     # bastille rdr dev1 tcp 2001 22
     [jail1]:
     Redirecting IPv4:
-    tcp any:2001 -> any:22 on em0
+    tcp/any:2001 -> any:22 on em0
    
     # bastille rdr dev1 list
     rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
@@ -32,7 +32,7 @@ specify the interface they run on in rc.conf (or other config files)
     # bastille rdr dev1 udp 2053 53
     [jail1]:
     Redirecting:
-    udp any:2001 -> any:22 on em0
+    udp/any:2001 -> any:22 on em0
     
     # bastille rdr dev1 list
     rdr pass on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
@@ -52,22 +52,22 @@ The `rdr` command includes 3 additional options:
     # bastille rdr dev1 -i vtnet0 udp 2001 22
     [jail1]:
     Redirecting IPv4:
-    tcp any:8000 -> any:80 on vtnet0
+    tcp/any:8000 -> any:80 on vtnet0
     
     # bastille rdr dev1 -s 192.168.0.1 tcp 8080 81
     [jail1]:
     Redirecting IPv4:
-    tcp 192.168.0.1:8080 -> any:81 on em0
+    tcp/192.168.0.1:8080 -> any:81 on em0
 
     # bastille rdr dev1 -d 192.168.0.84 tcp 8082 82
     [jail1]:
     Redirecting IPv4:
-    tcp any:8082 -> 192.168.0.84:82 on em0
+    tcp/any:8082 -> 192.168.0.84:82 on em0
 
     # bastille rdr dev1 -i vtnet0 -d 192.168.0.45 tcp 9000 9000
     [jail1]:
     Redirecting IPv4:
-    tcp any:9000 -> 192.168.0.45:9000 on vtnet0
+    tcp/any:9000 -> 192.168.0.45:9000 on vtnet0
 
     # bastille rdr dev1 list
     rdr pass on vtnet0 inet proto udp from any to any port = 2001 -> 10.17.89.1 port 22

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -23,7 +23,7 @@ specify the interface they run on in rc.conf (or other config files)
     
     # bastille rdr dev1 tcp 2001 22
     [jail1]:
-    Redirecting:
+    Redirecting IPv4:
     tcp any:2001 -> any:22 on em0
    
     # bastille rdr dev1 list
@@ -51,22 +51,22 @@ The `rdr` command includes 3 additional options:
 
     # bastille rdr dev1 -i vtnet0 udp 2001 22
     [jail1]:
-    Redirecting:
+    Redirecting IPv4:
     tcp any:8000 -> any:80 on vtnet0
     
     # bastille rdr dev1 -s 192.168.0.1 tcp 8080 81
     [jail1]:
-    Redirecting:
+    Redirecting IPv4:
     tcp 192.168.0.1:8080 -> any:81 on em0
 
     # bastille rdr dev1 -d 192.168.0.84 tcp 8082 82
     [jail1]:
-    Redirecting:
+    Redirecting IPv4:
     tcp any:8082 -> 192.168.0.84:82 on em0
 
     # bastille rdr dev1 -i vtnet0 -d 192.168.0.45 tcp 9000 9000
     [jail1]:
-    Redirecting:
+    Redirecting IPv4:
     tcp any:9000 -> 192.168.0.45:9000 on vtnet0
 
     # bastille rdr dev1 list

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -14,7 +14,7 @@ specify the interface they run on in rc.conf (or other config files)
 .. code-block:: shell
 
     # bastille rdr --help
-    Usage: bastille rdr TARGET [options(s)] [clear|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
+    Usage: bastille rdr TARGET [options(s)] [clear|reset|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
     Options:
 
     -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -14,7 +14,7 @@ specify the interface they run on in rc.conf (or other config files)
 .. code-block:: shell
 
     # bastille rdr --help
-    Usage: bastille rdr TARGET [options(s)] [clear|reset|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
+    Usage: bastille rdr TARGET [option(s)] [clear|reset|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
     Options:
 
     -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -20,19 +20,19 @@ specify the interface they run on in rc.conf (or other config files)
     -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
     -s | --source      [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
     -d | --destination [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -t | --type        [ipv4|ipv6]      | -- Specify IP type. Must be used if -s or -d are used. Defaults to both.
+
     
     # bastille rdr dev1 tcp 2001 22
     [jail1]:
-    Redirecting IPv4:
-    tcp/any:2001 -> any:22 on em0
+    IPv4 tcp/any:2001 -> any:22 on em0
    
     # bastille rdr dev1 list
     rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
     
     # bastille rdr dev1 udp 2053 53
     [jail1]:
-    Redirecting:
-    udp/any:2001 -> any:22 on em0
+    IPv4 udp/any:2001 -> any:22 on em0
     
     # bastille rdr dev1 list
     rdr pass on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
@@ -51,23 +51,19 @@ The `rdr` command includes 3 additional options:
 
     # bastille rdr dev1 -i vtnet0 udp 2001 22
     [jail1]:
-    Redirecting IPv4:
-    tcp/any:8000 -> any:80 on vtnet0
+    IPv4 tcp/any:8000 -> any:80 on vtnet0
     
     # bastille rdr dev1 -s 192.168.0.1 tcp 8080 81
     [jail1]:
-    Redirecting IPv4:
-    tcp/192.168.0.1:8080 -> any:81 on em0
+    IPv4 tcp/192.168.0.1:8080 -> any:81 on em0
 
     # bastille rdr dev1 -d 192.168.0.84 tcp 8082 82
     [jail1]:
-    Redirecting IPv4:
-    tcp/any:8082 -> 192.168.0.84:82 on em0
+    IPv4 tcp/any:8082 -> 192.168.0.84:82 on em0
 
     # bastille rdr dev1 -i vtnet0 -d 192.168.0.45 tcp 9000 9000
     [jail1]:
-    Redirecting IPv4:
-    tcp/any:9000 -> 192.168.0.45:9000 on vtnet0
+    IPv4 tcp/any:9000 -> 192.168.0.45:9000 on vtnet0
 
     # bastille rdr dev1 list
     rdr pass on vtnet0 inet proto udp from any to any port = 2001 -> 10.17.89.1 port 22

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -17,9 +17,9 @@ specify the interface they run on in rc.conf (or other config files)
     Usage: bastille rdr TARGET [options(s)] [clear|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]
     Options:
 
-    -i [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-    -s [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
-    -d [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
+    -s | --source      [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
+    -d | --destination [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
     
     # bastille rdr dev1 tcp 2001 22
     [jail1]:

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -207,7 +207,7 @@ list_ports(){
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
-                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1":"$4"/"$2":"$5" -> "$3":"$6}')"
+                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1 $2":"$5"/"$3":"$6" -> "$4":"$7}')"
                 info "[${_JAIL}]:"
 		echo "${_PORTS}"
 	    fi

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille list [-j|-a] [release [-p]|template|(jail|container)|log|limit|(import|export|backup)]"
+    error_exit "Usage: bastille list [-j|-a] [release [-p]|template|(jail|container)|log|limit|ports|(import|export|backup)]"
 }
 
 if [ "${1}" = help -o "${1}" = "-h" -o "${1}" = "--help" ]; then
@@ -202,12 +202,28 @@ list_import(){
     ls "${bastille_backupsdir}" | grep -v ".sha256$"
 }
 
+list_ports(){
+    if [ -d "${bastille_jailsdir}" ]; then
+        JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
+        for _JAIL in ${JAIL_LIST}; do
+            if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
+                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1":"$4"//"$2":"$5" -> "$3":"$6}')"
+                info "[${_JAIL}]:"
+		echo "${_PORTS}"
+	    fi
+        done
+    fi
+}
+
 if [ $# -gt 0 ]; then
     # Handle special-case commands first.
     case "${1}" in
     all|-a|--all)
         list_all
         ;;
+    port|ports)
+        list_ports
+	;;
     release|releases)
         list_release
         ;;

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -207,7 +207,7 @@ list_ports(){
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
-                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1":"$4"//"$2":"$5" -> "$3":"$6}')"
+                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1":"$4"/"$2":"$5" -> "$3":"$6}')"
                 info "[${_JAIL}]:"
 		echo "${_PORTS}"
 	    fi

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -207,7 +207,7 @@ list_ports(){
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
-                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1 $2":"$5"/"$3":"$6" -> "$4":"$7}')"
+                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1" "$2":"$5"/"$3":"$6" -> "$4":"$7}')"
                 info "[${_JAIL}]:"
 		echo "${_PORTS}"
 	    fi

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -207,7 +207,7 @@ list_ports(){
         JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
-                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf | awk '{print $1" "$2":"$5"/"$3":"$6" -> "$4":"$7}')"
+                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf)"
                 info "[${_JAIL}]:"
 		echo "${_PORTS}"
 	    fi

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -224,11 +224,11 @@ list_import(){
 
 list_ports(){
     if [ -d "${bastille_jailsdir}" ]; then
-        JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
-        for _JAIL in ${JAIL_LIST}; do
-            if [ -f "${bastille_jailsdir}/${_JAIL}/rdr.conf" ]; then
-                _PORTS="$(cat "${bastille_jailsdir}"/"${_JAIL}"/rdr.conf)"
-                info "[${_JAIL}]:"
+        JAIL_LIST="$(bastille list jails)"
+        for _jail in ${JAIL_LIST}; do
+            if [ -f "${bastille_jailsdir}/${_jail}/rdr.conf" ]; then
+                _PORTS="$(cat ${bastille_jailsdir}/${_jail}/rdr.conf)"
+                info "[${_jail}]:"
 		echo "${_PORTS}"
 	    fi
         done

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -283,7 +283,7 @@ while [ $# -gt 0 ]; do
             fi
             ;;
         *)
-            if [ $# -gt 5 ]; then
+            if [ $# -ge 6 ]; then
               check_jail_validity
               persist_rdr_rule "$@"
               load_rdr_rule "$@"

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille rdr TARGET [options(s)] [clear|reset|list|(tcp|udp)] host_port jail_port [log ['(' logopts ')'] ] )]"
+    error_notify "Usage: bastille rdr TARGET [option(s)] [clear|reset|list|(tcp|udp)] host_port jail_port [log ['(' logopts ')'] ] )]"
 
     cat << EOF
     Options:

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -34,7 +34,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille rdr [option(s)] TARGET [clear|reset|list|(tcp|udp)] HOST_PORT JAIL_PORT [log ['(' logopts ')'] ] )]"
+    error_notify "Usage: bastille rdr [option(s)] TARGET [clear|reset|list|(tcp|udp)] HOST_PORT JAIL_PORT [log ['(' logopts ')'] ]"
     cat << EOF
     Options:
 
@@ -49,7 +49,6 @@ EOF
 }
 
 check_jail_validity() {
-
     # Validate jail network type and set IP4/6
     if [ "$( bastille config ${TARGET} get vnet )" != 'enabled' ]; then
         _ip4_interfaces="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -223,41 +223,49 @@ RDR_SRC="any"
 RDR_DST="any"
 OPTION="0"
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        -i|--interface)
-            if [ -z "${2}" ]; then
-                error_exit "Must specify an interface with [-i|--interface]"
-            fi
-            if ifconfig | grep -owq "${2}:"; then
-                RDR_IF="${2}"
-		OPTION="1"
-                shift 2
-            else
-                error_exit "${2} is not a valid interface."
-            fi
-            ;;
-        -s|--source)
-            if [ -z "${2}" ]; then
-                error_exit "Must specify a source IP/subnet with [-s|--source]"
-            fi
-            check_ip_validity "${2}"
-            RDR_SRC="${2}"
+# Check for options
+case "$1" in
+    -i|--interface)
+        if [ -z "${2}" ]; then
+            error_exit "Must specify an interface with [-i|--interface]"
+        fi
+        if ifconfig | grep -owq "${2}:"; then
+            RDR_IF="${2}"
 	    OPTION="1"
             shift 2
-	        ;;
-        -d|--destination)
-            if [ -z "${2}" ]; then
-                error_exit "Must specify a destination IP with [-d|--destination]"
-            fi
-            if ifconfig | grep -owq "inet ${2}"; then
-                RDR_DST="${2}"
-		OPTION="1"
-                shift 2
-            else
-                error_exit "${2} is not an IP on this system."
-            fi
-            ;;    
+        else
+            error_exit "${2} is not a valid interface."
+        fi
+        ;;
+    -s|--source)
+        if [ -z "${2}" ]; then
+            error_exit "Must specify a source IP/subnet with [-s|--source]"
+        fi
+        check_ip_validity "${2}"
+        RDR_SRC="${2}"
+	OPTION="1"
+        shift 2
+        ;;
+    -d|--destination)
+        if [ -z "${2}" ]; then
+            error_exit "Must specify a destination IP with [-d|--destination]"
+        fi
+        if ifconfig | grep -owq "inet ${2}"; then
+            RDR_DST="${2}"
+	    OPTION="1"
+            shift 2
+        else
+            error_exit "${2} is not an IP on this system."
+        fi
+    ;;   
+esac
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
         list)
             if [ "${OPTION}" -eq 1 ];then
                 error_exit "Command \"${1}\" cannot be used with options."

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -111,7 +111,7 @@ validate_rdr_rule() {
     local jail_port="${6}"
     if grep -qs "$if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
         error_notify "Error: Ports already in use on this interface."
-        error_exit "See 'bastille list ports' or 'bastille rdr TARGET clear'."
+        error_exit "See 'bastille list ports' or 'bastille rdr TARGET reset'."
     fi
 }
 

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -162,7 +162,7 @@ load_rdr_rule() {
 if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null;
   printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
   | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-  error_notify "Failed to create IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+  error_exit "Failed to create IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
 else
   info "[${JAIL_NAME}]:"
   info "Redirecting IPv4:"
@@ -173,7 +173,7 @@ if [ -n "$JAIL_IP6" ]; then
   if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
     printf '%s\nrdr pass on $%s inet proto %s to port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
     | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-    error_notify "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+    error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
   else
     info "[${JAIL_NAME}]:"
     info "Redirecting IPv6:"
@@ -197,7 +197,7 @@ log=$@
 if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
   printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
   | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-  error_notify "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+  error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
 else
   info "[${JAIL_NAME}]:"
   info "Redirecting logged IPv4:"
@@ -208,7 +208,7 @@ if [ -n "$JAIL_IP6" ]; then
   if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
     printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
     | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-    error_notify "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+    error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
   else
     info "[${JAIL_NAME}]:"
     info "Redirecting logged IPv6:"
@@ -282,8 +282,8 @@ while [ $# -gt 0 ]; do
                 usage
             elif [ $# -eq 3 ]; then
                 check_jail_validity
-                persist_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 load_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+                persist_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 shift "$#"
             else
                 case "$4" in
@@ -298,16 +298,16 @@ while [ $# -gt 0 ]; do
                             done
                             if [ $2 == "(" ] && [ $last == ")" ] ; then
                                 check_jail_validity
-                                persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                                 load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                                persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"                                
                                 shift $#
                             else
                                 usage
                             fi
                         elif [ $# -eq 1 ]; then
                             check_jail_validity
-                            persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                             load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                            persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                             shift 1
                         else
                             usage
@@ -322,13 +322,13 @@ while [ $# -gt 0 ]; do
         *)
             if [ $# -eq 6 ]; then
               check_jail_validity
-              persist_rdr_rule "$@"
               load_rdr_rule "$@"
+              persist_rdr_rule "$@"
               shift $#
             elif [ $# -ge 7 ] && [ "${7}" = "log" ]; then
               check_jail_validity
-              persist_rdr_log_rule "$@"
               load_rdr_log_rule "$@"
+              persist_rdr_log_rule "$@"
               shift $#
             else
               usage

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -101,7 +101,7 @@ check_jail_validity() {
 # function: check if IP is valid
 check_rdr_ip_validity() {
     local ip="$1"
-    local ip6=$(echo "${ip}" | grep -E '^(([a-fA-F0-9:]+$)|([a-fA-F0-9:]+\/[0-9]{1,3}$)|SLAAC)')
+    local ip6="$(echo "${ip}" | grep -E '^(([a-fA-F0-9:]+$)|([a-fA-F0-9:]+\/[0-9]{1,3}$)|SLAAC)')"
     if [ -n "${ip6}" ]; then
         info "Valid: (${ip6})."
     else
@@ -198,7 +198,7 @@ load_rdr_log_rule() {
     shift 7;
     log=$@
     # Create IPv4 rule with log
-    if [ "${inet} = "ipv4" ] || [ "${inet} = "dual" ]; then
+    if { [ "${inet}" = "ipv4" ] || [ "${inet}" = "dual" ]; }; then
         if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
             printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
             | pfctl -a "rdr/${JAIL_NAME}" -f-; then
@@ -209,7 +209,7 @@ load_rdr_log_rule() {
         fi
     fi
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
-    if [ -n "$JAIL_IP6" ] && [ "${inet} = "ipv6" ] || [ "${inet} = "dual" ]; then 
+    if [ -n "$JAIL_IP6" ] && { [ "${inet}" = "ipv6" ] || [ "${inet}" = "dual" ]; };then 
         if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
             printf '%s\nrdr pass %s on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "rdr/${JAIL_NAME}" -f-; then

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -165,7 +165,7 @@ load_rdr_rule() {
             error_exit "Failed to create IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${TARGET}]:"
-            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
 }
@@ -190,7 +190,7 @@ load_rdr_log_rule() {
             error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${TARGET}]:"
-            echo "IPv4 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv4 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
@@ -202,7 +202,7 @@ load_rdr_log_rule() {
             error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${TARGET}]:"
-            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
 }

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille rdr TARGET [options(s)] [clear|list|(tcp|udp host_port jail_port [log ['(' logopts ')'] ] )]"
+    error_notify "Usage: bastille rdr TARGET [options(s)] [clear|list|(tcp|udp)] host_port jail_port [log ['(' logopts ')'] ] )]"
 
     cat << EOF
     Options:

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -170,7 +170,7 @@ load_rdr_rule() {
     # Create IPv6 rdr rule (if ip6.addr is enabled)
     if [ -n "$JAIL_IP6" ]; then
         if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-            printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            printf '%s\nrdr pass on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "rdr/${JAIL_NAME}" -f-; then
             error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
@@ -203,7 +203,7 @@ load_rdr_log_rule() {
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
     if [ -n "$JAIL_IP6" ]; then
         if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-            printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            printf '%s\nrdr pass %s on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "rdr/${JAIL_NAME}" -f-; then
             error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -227,7 +227,7 @@ while [ "$#" -gt 0 ]; do
                 usage
             elif ifconfig | grep -owq "${2}:"; then
                 RDR_IF="${2}"
-		        OPTION="1"
+		OPTION="1"
                 shift 2
             else
                 error_exit "${2} is not a valid interface."
@@ -239,7 +239,7 @@ while [ "$#" -gt 0 ]; do
             else
                 check_rdr_ip_validity "${2}"
                 RDR_SRC="${2}"
-	            OPTION="1"
+	        OPTION="1"
                 shift 2
             fi
             ;;
@@ -248,7 +248,7 @@ while [ "$#" -gt 0 ]; do
                 usage
             elif ifconfig | grep -owq "inet ${2}"; then
                 RDR_DST="${2}"
-	            OPTION="1"
+	        OPTION="1"
                 shift 2
             else
                 error_exit "${2} is not an IP on this system."
@@ -313,8 +313,8 @@ while [ "$#" -gt 0 ]; do
                 usage
             elif [ $# -eq 3 ]; then
                 check_jail_validity
-                load_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 persist_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+                load_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 shift "$#"
             else
                 case "$4" in
@@ -329,16 +329,16 @@ while [ "$#" -gt 0 ]; do
                             done
                             if [ $2 == "(" ] && [ $last == ")" ] ; then
                                 check_jail_validity
-                                load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
-                                persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"                                
+                                persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                                load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"                                
                                 shift $#
                             else
                                 usage
                             fi
                         elif [ $# -eq 1 ]; then
                             check_jail_validity
-                            load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                             persist_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                            load_rdr_log_rule $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                             shift 1
                         else
                             usage
@@ -355,13 +355,13 @@ while [ "$#" -gt 0 ]; do
                 usage
             elif [ $# -eq 6 ] && [ "${4}" = "tcp" ] || [ "${4}" = "udp" ]; then
                 check_jail_validity
-                load_rdr_rule "$@"
                 persist_rdr_rule "$@"
+                load_rdr_rule "$@"
                 shift $#
             elif [ $# -ge 7 ] && [ "${7}" = "log" ]; then
                 check_jail_validity
-                load_rdr_log_rule "$@"
                 persist_rdr_log_rule "$@"
+                load_rdr_log_rule "$@"
                 shift $#
             else
                 usage

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -257,7 +257,7 @@ case "$1" in
         else
             error_exit "${2} is not an IP on this system."
         fi
-    ;;   
+        ;;   
 esac
 
 if [ $# -lt 2 ]; then

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -337,6 +337,12 @@ while [ "$#" -gt 0 ]; do
                 validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 persist_rdr_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
                 load_rdr_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+		# Temp block to remove old format after new format is loaded the first time
+		while read rules; do
+                if [ "$(echo ${rules} | wc -w)" -lt 6 ]; then
+                    sed -i '' "/^${rules}$/d" "${bastille_jailsdir}/${_jail}/rdr.conf"
+                fi
+                done < "${bastille_jailsdir}/${_jail}/rdr.conf"
                 shift "$#"
             else
                 case "${4}" in

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -56,17 +56,17 @@ check_jail_validity() {
         # Check if jail ip4.addr is valid (non-VNET only)
         if [ "${_ip4_interfaces}" != "not set" ] && [ "${_ip4_interfaces}" != "disable" ]; then
             if echo "&{_ip4_interfaces}" | grep -q "|"; then
-                JAIL_IP="$(echo ${_ip4_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+                JAIL_IP="$(echo ${_ip4_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}' | sed -E 's#/[0-9]+$##g')"
             else
-                JAIL_IP="${_ip4_interfaces}"
+                JAIL_IP="$(echo ${_ip4_interfaces} | sed -E 's#/[0-9]+$##g')"
             fi
         fi
         # Check if jail ip6.addr is valid (non-VNET only)
         if [ "${_ip6_interfaces}" != "not set" ] && [ "${_ip6_interfaces}" != "disable" ]; then
             if echo "&{_ip6_interfaces}" | grep -q "|"; then
-                JAIL_IP6="$(echo ${_ip6_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+                JAIL_IP6="$(echo ${_ip6_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}' | sed -E 's#/[0-9]+$##g')"
             else
-                JAIL_IP6="${_ip6_interfaces}"
+                JAIL_IP6="$(echo ${_ip6_interfaces} | sed -E 's#/[0-9]+$##g')"
             fi
         fi
     else

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -262,7 +262,8 @@ while [ "$#" -gt 0 ]; do
         *)
 	    break
             ;;
-esac
+    esac
+done
 
 if [ $# -lt 2 ]; then
     usage

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -169,7 +169,7 @@ load_rdr_rule() {
             error_exit "Failed to create IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            echo "IPv4 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}" 
+            echo "IPv4 ${proto}/${host_port}:${jail_port} on ${if_name}" 
         fi
     fi
     # Create IPv6 rdr rule (if ip6.addr is enabled)
@@ -180,7 +180,7 @@ load_rdr_rule() {
             error_exit "Failed to create IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
 }
@@ -205,7 +205,7 @@ load_rdr_log_rule() {
             error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            echo "IPv4 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv4 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
@@ -216,7 +216,7 @@ load_rdr_log_rule() {
             error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${host_port}:${jail_port} on ${if_name}"
         fi
     fi
 }

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -170,7 +170,7 @@ load_rdr_rule() {
     # Create IPv6 rdr rule (if ip6.addr is enabled)
     if [ -n "$JAIL_IP6" ]; then
         if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-            printf '%s\nrdr pass on $%s inet proto %s to port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "rdr/${JAIL_NAME}" -f-; then
             error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -165,8 +165,7 @@ load_rdr_rule() {
         error_exit "Failed to create IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
     else
         info "[${JAIL_NAME}]:"
-        info "Redirecting IPv4:"
-        info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}" 
+        echo "IPv4 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}" 
     fi
     # Create IPv6 rdr rule (if ip6.addr is enabled)
     if [ -n "$JAIL_IP6" ]; then
@@ -176,8 +175,7 @@ load_rdr_rule() {
             error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            info "Redirecting IPv6:"
-            info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
         fi
     fi
 }
@@ -200,8 +198,7 @@ load_rdr_log_rule() {
         error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
     else
         info "[${JAIL_NAME}]:"
-        info "Redirecting logged IPv4:"
-        info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+        echo "IPv4 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
     fi
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
     if [ -n "$JAIL_IP6" ]; then
@@ -211,8 +208,7 @@ load_rdr_log_rule() {
             error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         else
             info "[${JAIL_NAME}]:"
-            info "Redirecting logged IPv6:"
-            info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+            echo "IPv6 ${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
         fi
     fi
 }

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -300,14 +300,14 @@ while [ "$#" -gt 0 ]; do
                     echo "${JAIL_NAME} redirects:"
                     pfctl -a "rdr/${JAIL_NAME}" -Fn
 		    if rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf; then
-                        info "[${JAIL_NAME}]: rdr.conf removed."
+                        info "[${JAIL_NAME}]: rdr.conf removed"
 	            fi
                 done
             else
                 check_jail_validity
                 pfctl -a "rdr/${JAIL_NAME}" -Fn
                 if rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf; then
-                    info "[${JAIL_NAME}]: rdr.conf removed."
+                    info "[${JAIL_NAME}]: rdr.conf removed"
 	        fi
             fi
             shift

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -229,7 +229,7 @@ while [ $# -gt 0 ]; do
             if [ -z "${2}" ]; then
                 error_exit "Must specify an interface with [-i|--interface]"
             fi
-            if ifconfig | grep -owq "${1}:"; then
+            if ifconfig | grep -owq "${2}:"; then
                 RDR_IF="${2}"
 		OPTION="1"
                 shift 2

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -100,7 +100,7 @@ validate_rdr_rule() {
     local jail_port="${6}"
     if grep -qs "$if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
         error_notify "Error: Ports already in use on this interface."
-        error_exit "See 'bastille list ports' or 'bastille rdr TARGET reset'."
+        error_exit "See 'bastille list ports' or 'bastille rdr TARGET clear'."
     fi
 }
 
@@ -283,11 +283,6 @@ while [ "$#" -gt 0 ]; do
                 error_exit "Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
                 usage
-            elif [ "${TARGET}" = 'ALL' ]; then
-                for _jail in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
-                    echo "${_jail} redirects:"
-                    pfctl -a "rdr/${_jail}" -Psn 2>/dev/null
-                done
             else
                 check_jail_validity
                 pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null
@@ -299,14 +294,10 @@ while [ "$#" -gt 0 ]; do
                 error_exit "Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
                 usage
-            elif [ "${TARGET}" = 'ALL' ]; then
-                for _jail in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
-                    echo "${_jail} redirects:"
-                    pfctl -a "rdr/${_jail}" -Fn
-                done
             else
                 check_jail_validity
-                pfctl -a "rdr/${TARGET}" -Fn
+                echo "${_jail} redirects:"
+                pfctl -a "rdr/${_jail}" -Fn
             fi
             shift
             ;;
@@ -315,19 +306,12 @@ while [ "$#" -gt 0 ]; do
                 error_exit "Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
                 usage
-            elif [ "${TARGET}" = 'ALL' ]; then
-                for _jail in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
-                    echo "${_jail} redirects:"
-                    pfctl -a "rdr/${_jail}" -Fn
-		    if rm -f "${bastille_jailsdir}"/"${_jail}"/rdr.conf; then
-                        info "[${_jail}]: rdr.conf removed"
-	            fi
-                done
             else
                 check_jail_validity
-                pfctl -a "rdr/${TARGET}" -Fn
-                if rm -f "${bastille_jailsdir}"/"${_jail}"/rdr.conf; then
-                    info "[${TARGET}]: rdr.conf removed"
+                echo "${_jail} redirects:"
+                pfctl -a "rdr/${_jail}" -Fn
+		if rm -f "${bastille_jailsdir}/${_jail}/rdr.conf"; then
+                    info "[${_jail}]: rdr.conf removed"
 	        fi
             fi
             shift

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -99,6 +99,29 @@ check_jail_validity() {
     fi
 }
 
+check_rdr_ip_validity() {
+    local ip="$1"
+    local ip6=$(echo "${ip}" | grep -E '^(([a-fA-F0-9:]+$)|([a-fA-F0-9:]+\/[0-9]{1,3}$)|SLAAC)')
+    if [ -n "${ip6}" ]; then
+        info "Valid: (${ip6})."
+    else
+        local IFS
+        if echo "${ip}" | grep -Eq '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$'; then
+          TEST_IP=$(echo "${ip}" | cut -d / -f1)
+          IFS=.
+          set ${TEST_IP}
+          for quad in 1 2 3 4; do
+            if eval [ \$$quad -gt 255 ]; then
+              error_exit "Invalid: (${TEST_IP})"
+            fi
+          done
+          info "Valid: (${ip})."
+        else
+          error_exit "Invalid: (${ip})."
+       fi
+    fi
+}
+
 # function: write rule to rdr.conf
 persist_rdr_rule() {
   local if="${1}"
@@ -198,15 +221,16 @@ fi
 while [ $# -gt 0 ]; do
   while getopts "i:s:d:" opt; do
     case $opt in
-        i) if ifconfig | grep -ow "${OPTARG}:"; then
+        i) if ifconfig | grep -owq "${OPTARG}:"; then
              RDR_IF="${OPTARG}"
            else
              error_exit "$OPTARG is not a valid interface on this system."
            fi 
            ;;
-        s) RDR_SRC="$OPTARG"
+        s) check_rdr_ip_validity "${OPTARG}"
+           RDR_SRC="$OPTARG"
            ;;
-        d) if ifconfig | grep -ow "inet ${OPTARG}"; then
+        d) if ifconfig | grep -owq "inet ${OPTARG}"; then
             RDR_DST="$OPTARG"
            else
              error_exit "$OPTARG is not an IP on this system."

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -53,11 +53,11 @@ check_jail_validity() {
         _ip6_interfaces="$(bastille config ${TARGET} get ip6.addr | sed 's/,/ /g')"
         # Check if jail ip4.addr is valid (non-VNET only)
         if [ "${_ip4_interfaces}" != "not set" ] && [ "${_ip4_interfaces}" != "disable" ]; then
-            JAIL_IP="$(bastille config ${TARGET} get ip4.addr | awk '{print $1}' | awk -F"|" '{print $2}')"
+            JAIL_IP="$(echo ${_ip4_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
         fi
         # Check if jail ip6.addr is valid (non-VNET only)
         if [ "${_ip6_interfaces}" != "not set" ] && [ "${_ip6_interfaces}" != "disable" ]; then
-            JAIL_IP6="$(bastille config ${TARGET} get ip6.addr | awk '{print $1}' | awk -F"|" '{print $2}')"
+            JAIL_IP6="$(echo ${_ip6_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
         fi
     else
         error_exit "VNET jails do not support rdr."

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -55,11 +55,19 @@ check_jail_validity() {
         _ip6_interfaces="$(bastille config ${TARGET} get ip6.addr | sed 's/,/ /g')"
         # Check if jail ip4.addr is valid (non-VNET only)
         if [ "${_ip4_interfaces}" != "not set" ] && [ "${_ip4_interfaces}" != "disable" ]; then
-            JAIL_IP="$(echo ${_ip4_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+            if echo "&{_ip4_interfaces}" | grep -q "|"; then
+                JAIL_IP="$(echo ${_ip4_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+            else
+                JAIL_IP="${_ip4_interfaces}"
+            fi
         fi
         # Check if jail ip6.addr is valid (non-VNET only)
         if [ "${_ip6_interfaces}" != "not set" ] && [ "${_ip6_interfaces}" != "disable" ]; then
-            JAIL_IP6="$(echo ${_ip6_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+            if echo "&{_ip6_interfaces}" | grep -q "|"; then
+                JAIL_IP6="$(echo ${_ip6_interfaces} | awk '{print $1}' | awk -F"|" '{print $2}')"
+            else
+                JAIL_IP6="${_ip6_interfaces}"
+            fi
         fi
     else
         error_exit "VNET jails do not support rdr."

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -174,7 +174,7 @@ log=$@
 if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
   printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
   | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-  error_notify "Failed to create logged IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+  error_notify "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
 else
   info "[${JAIL_NAME}]:"
   info "Redirecting logged IPv4:"
@@ -185,7 +185,7 @@ if [ -n "$JAIL_IP6" ]; then
   if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
     printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
     | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-    error_notify "Failed to create logged IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+    error_notify "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
   else
     info "[${JAIL_NAME}]:"
     info "Redirecting logged IPv6:"
@@ -296,10 +296,15 @@ while [ $# -gt 0 ]; do
             fi
             ;;
         *)
-            if [ $# -ge 6 ]; then
+            if [ $# -eq 6 ]; then
               check_jail_validity
               persist_rdr_rule "$@"
               load_rdr_rule "$@"
+              shift $#
+            elif [ $# -ge 7 ] && [ "${7}" = "log" ]; then
+              check_jail_validity
+              persist_rdr_log_rule "$@"
+              load_rdr_log_rule "$@"
               shift $#
             else
               usage

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -225,7 +225,6 @@ load_rdr_log_rule() {
 RDR_IF="$(grep "^[[:space:]]*${bastille_network_pf_ext_if}[[:space:]]*=" ${bastille_pf_conf} | awk -F'"' '{print $2}')"
 RDR_SRC="any"
 RDR_DST="any"
-OPTION="0"
 RDR_INET="dual"
 OPTION_IF=0
 OPTION_SRC=0
@@ -260,7 +259,7 @@ while [ "$#" -gt 0 ]; do
             if [ -z "${2}" ] || [ -z "${3}" ]; then
                 usage
             elif ifconfig | grep -owq "inet ${2}"; then
-	              OPTION_DST=1
+	        OPTION_DST=1
                 RDR_DST="${2}"
                 shift 2
             else
@@ -279,9 +278,9 @@ while [ "$#" -gt 0 ]; do
             fi
             ;;
         list)
-            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
+            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ]; then
                 error_exit "Command \"${1}\" cannot be used with options."
-	          elif [ -n "${2}" ]; then
+	    elif [ -n "${2}" ]; then
                 usage
             elif [ "${TARGET}" = 'ALL' ]; then
                 for JAIL_NAME in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
@@ -295,7 +294,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         clear)
-            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
+            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ]; then
                 error_exit "Command \"${1}\" cannot be used with options."
 	          elif [ -n "${2}" ]; then
                 usage
@@ -311,7 +310,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         reset)
-            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
+            if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ]; then
                 error_exit "Command \"${1}\" cannot be used with options."
 	          elif [ -n "${2}" ]; then
                 usage
@@ -335,7 +334,7 @@ while [ "$#" -gt 0 ]; do
         tcp|udp)
             if [ $# -lt 3 ]; then
                 usage
-            elif [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] && [ "${OPTION_INET_TYPE}" -ne 1 ];then
+            elif [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] && [ "${OPTION_INET_TYPE}" -ne 1 ]; then
                 error_exit "[-t|--type] must be set when using [-s|--source] or [-d|--destination]"
             elif [ $# -eq 3 ]; then
                 check_jail_validity

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -32,7 +32,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille rdr TARGET [options(s)] [clear|list|(tcp|udp)] host_port jail_port [log ['(' logopts ')'] ] )]"
+    error_notify "Usage: bastille rdr TARGET [options(s)] [clear|reset|list|(tcp|udp)] host_port jail_port [log ['(' logopts ')'] ] )]"
 
     cat << EOF
     Options:

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -100,7 +100,7 @@ validate_rdr_rule() {
     local jail_port="${6}"
     if grep -qs "$if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
         error_notify "Error: Ports already in use on this interface."
-        error_exit "See 'bastille list ports' or 'bastille rdr TARGET clear'."
+        error_exit "See 'bastille list ports' or 'bastille rdr TARGET reset'."
     fi
 }
 

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -340,9 +340,9 @@ while [ "$#" -gt 0 ]; do
 		# Temp block to remove old format after new format is loaded the first time
 		while read rules; do
                 if [ "$(echo ${rules} | wc -w)" -lt 6 ]; then
-                    sed -i '' "/^${rules}$/d" "${bastille_jailsdir}/${_jail}/rdr.conf"
+                    sed -i '' "/^${rules}$/d" "${bastille_jailsdir}/${TARGET}/rdr.conf"
                 fi
-                done < "${bastille_jailsdir}/${_jail}/rdr.conf"
+                done < "${bastille_jailsdir}/${TARGET}/rdr.conf"
                 shift "$#"
             else
                 case "${4}" in

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -37,9 +37,9 @@ usage() {
     cat << EOF
     Options:
 
-    -i [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-    -s [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
-    -d [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -i | --interface   [interface]      | -- Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
+    -s | --source      [source ip]      | -- Limit rdr to a source IP. Useful to only allow access from a certian IP or subnet.
+    -d | --destination [destination ip] | -- Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
 
 EOF
     exit 1

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -299,12 +299,16 @@ while [ "$#" -gt 0 ]; do
                 for JAIL_NAME in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
                     echo "${JAIL_NAME} redirects:"
                     pfctl -a "rdr/${JAIL_NAME}" -Fn
-		    rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf
+		    if rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf; then
+                        info "[${JAIL_NAME}]: rdr.conf removed."
+	            fi
                 done
             else
                 check_jail_validity
                 pfctl -a "rdr/${JAIL_NAME}" -Fn
-		rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf
+                if rm -f "${bastille_jailsdir}"/"${JAIL_NAME}"/rdr.conf; then
+                    info "[${JAIL_NAME}]: rdr.conf removed."
+	        fi
             fi
             shift
             ;;	    

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -107,114 +107,114 @@ check_rdr_ip_validity() {
     else
         local IFS
         if echo "${ip}" | grep -Eq '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$'; then
-          TEST_IP=$(echo "${ip}" | cut -d / -f1)
-          IFS=.
-          set ${TEST_IP}
-          for quad in 1 2 3 4; do
-            if eval [ \$$quad -gt 255 ]; then
-              error_exit "Invalid: (${TEST_IP})"
-            fi
-          done
-          info "Valid: (${ip})."
+            TEST_IP=$(echo "${ip}" | cut -d / -f1)
+            IFS=.
+            set ${TEST_IP}
+            for quad in 1 2 3 4; do
+                if eval [ \$$quad -gt 255 ]; then
+                    error_exit "Invalid: (${TEST_IP})"
+                fi
+            done
+            info "Valid: (${ip})."
         else
-          error_exit "Invalid: (${ip})."
-       fi
+            error_exit "Invalid: (${ip})."
+        fi
     fi
 }
 
 # function: write rule to rdr.conf
 persist_rdr_rule() {
-  local if="${1}"
-  local src="${2}"
-  local dst="${3}"
-  local proto="${4}"
-  local host_port="${5}"
-  local jail_port="${6}"
-if ! grep -qs "$if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"; then
-    echo "$if $src $dst $proto $host_port $jail_port" >> "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"
-fi
+    local if="${1}"
+    local src="${2}"
+    local dst="${3}"
+    local proto="${4}"
+    local host_port="${5}"
+    local jail_port="${6}"
+    if ! grep -qs "$if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"; then
+        echo "$if $src $dst $proto $host_port $jail_port" >> "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"
+    fi
 }
 
 persist_rdr_log_rule() {
-  local if="${1}"
-  local src="${2}"
-  local dst="${3}"
-  local proto="${4}"
-  local host_port="${5}"
-  local jail_port="${6}"
-shift 6;
-log=$@;
-if ! grep -qs "$if $src $dst $proto $host_port $jail_port $log" "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"; then
-    echo "$if $src $dst $proto $host_port $jail_port $log" >> "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"
-fi
+    local if="${1}"
+    local src="${2}"
+    local dst="${3}"
+    local proto="${4}"
+    local host_port="${5}"
+    local jail_port="${6}"
+    shift 6;
+    log=$@;
+    if ! grep -qs "$if $src $dst $proto $host_port $jail_port $log" "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"; then
+        echo "$if $src $dst $proto $host_port $jail_port $log" >> "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf"
+    fi
 }
 
 # function: load rdr rule via pfctl
 load_rdr_rule() {
-  local if_name="${1}"
-  local if=ext_if=\"${1}\"
-  local src="${2}"
-  local dst="${3}"
-  local proto="${4}"
-  local host_port="${5}"
-  local jail_port="${6}"
-# Create IPv4 rdr rule
-if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null;
-  printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
-  | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-  error_exit "Failed to create IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-else
-  info "[${JAIL_NAME}]:"
-  info "Redirecting IPv4:"
-  info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}" 
-fi
-# Create IPv6 rdr rule (if ip6.addr is enabled)
-if [ -n "$JAIL_IP6" ]; then
-  if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-    printf '%s\nrdr pass on $%s inet proto %s to port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
-    | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-    error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-  else
-    info "[${JAIL_NAME}]:"
-    info "Redirecting IPv6:"
-    info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
-  fi
-fi
+    local if_name="${1}"
+    local if=ext_if=\"${1}\"
+    local src="${2}"
+    local dst="${3}"
+    local proto="${4}"
+    local host_port="${5}"
+    local jail_port="${6}"
+    # Create IPv4 rdr rule
+    if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null;
+        printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
+        | pfctl -a "rdr/${JAIL_NAME}" -f-; then
+        error_exit "Failed to create IPv4 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+    else
+        info "[${JAIL_NAME}]:"
+        info "Redirecting IPv4:"
+        info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}" 
+    fi
+    # Create IPv6 rdr rule (if ip6.addr is enabled)
+    if [ -n "$JAIL_IP6" ]; then
+        if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
+            printf '%s\nrdr pass on $%s inet proto %s to port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            | pfctl -a "rdr/${JAIL_NAME}" -f-; then
+            error_exit "Failed to create IPv6 rdr rule \"${1} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        else
+            info "[${JAIL_NAME}]:"
+            info "Redirecting IPv6:"
+            info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+        fi
+    fi
 }
 
 # function: load rdr rule with log via pfctl
 load_rdr_log_rule() {
-  local if_name="${1}"
-  local if=ext_if=\"${1}\"
-  local src="${2}"
-  local dst="${3}"
-  local proto="${4}"
-  local host_port="${5}"
-  local jail_port="${6}"
-shift 6;
-log=$@
-# Create IPv4 rule with log
-if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-  printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
-  | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-  error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-else
-  info "[${JAIL_NAME}]:"
-  info "Redirecting logged IPv4:"
-  info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
-fi
-# Create IPv6 rdr rule with log (if ip6.addr is enabled)
-if [ -n "$JAIL_IP6" ]; then
-  if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
-    printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
-    | pfctl -a "rdr/${JAIL_NAME}" -f-; then
-    error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-  else
-    info "[${JAIL_NAME}]:"
-    info "Redirecting logged IPv6:"
-    info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
-  fi
-fi
+    local if_name="${1}"
+    local if=ext_if=\"${1}\"
+    local src="${2}"
+    local dst="${3}"
+    local proto="${4}"
+    local host_port="${5}"
+    local jail_port="${6}"
+    shift 6;
+    log=$@
+    # Create IPv4 rule with log
+    if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
+        printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
+        | pfctl -a "rdr/${JAIL_NAME}" -f-; then
+        error_exit "Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+    else
+        info "[${JAIL_NAME}]:"
+        info "Redirecting logged IPv4:"
+        info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+    fi
+    # Create IPv6 rdr rule with log (if ip6.addr is enabled)
+    if [ -n "$JAIL_IP6" ]; then
+        if ! ( pfctl -a "rdr/${JAIL_NAME}" -Psn;
+            printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            | pfctl -a "rdr/${JAIL_NAME}" -f-; then
+            error_exit "Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        else
+            info "[${JAIL_NAME}]:"
+            info "Redirecting logged IPv6:"
+            info "${proto}/${src}:${host_port} -> ${dst}:${jail_port} on ${if_name}"
+        fi
+    fi
 }
 
 # Set defaults
@@ -229,10 +229,9 @@ while [ "$#" -gt 0 ]; do
         -i|--interface)
             if [ -z "${2}" ] || [ -z "${3}" ]; then
                 usage
-            fi
-            if ifconfig | grep -owq "${2}:"; then
+            elif ifconfig | grep -owq "${2}:"; then
                 RDR_IF="${2}"
-		OPTION="1"
+		        OPTION="1"
                 shift 2
             else
                 error_exit "${2} is not a valid interface."
@@ -241,19 +240,19 @@ while [ "$#" -gt 0 ]; do
         -s|--source)
             if [ -z "${2}" ] || [ -z "${3}" ]; then
                 usage
+            else
+                check_rdr_ip_validity "${2}"
+                RDR_SRC="${2}"
+	            OPTION="1"
+                shift 2
             fi
-            check_rdr_ip_validity "${2}"
-            RDR_SRC="${2}"
-	    OPTION="1"
-            shift 2
             ;;
         -d|--destination)
             if [ -z "${2}" ] || [ -z "${3}" ]; then
                 usage
-            fi
-            if ifconfig | grep -owq "inet ${2}"; then
+            elif ifconfig | grep -owq "inet ${2}"; then
                 RDR_DST="${2}"
-	        OPTION="1"
+	            OPTION="1"
                 shift 2
             else
                 error_exit "${2} is not an IP on this system."
@@ -262,10 +261,9 @@ while [ "$#" -gt 0 ]; do
         list)
             if [ "${OPTION}" -eq 1 ];then
                 error_exit "Command \"${1}\" cannot be used with options."
-	    elif [ -n "${2}" ]; then
+	        elif [ -n "${2}" ]; then
                 usage
-            fi
-            if [ "${TARGET}" = 'ALL' ]; then
+            elif [ "${TARGET}" = 'ALL' ]; then
                 for JAIL_NAME in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
                     echo "${JAIL_NAME} redirects:"
                     pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null
@@ -279,10 +277,9 @@ while [ "$#" -gt 0 ]; do
         clear)
             if [ "${OPTION}" -eq 1 ];then
                 error_exit "Command \"${1}\" cannot be used with options."
-	    elif [ -n "${2}" ]; then
+	        elif [ -n "${2}" ]; then
                 usage
-            fi
-            if [ "${TARGET}" = 'ALL' ]; then
+            elif [ "${TARGET}" = 'ALL' ]; then
                 for JAIL_NAME in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
                     echo "${JAIL_NAME} redirects:"
                     pfctl -a "rdr/${JAIL_NAME}" -Fn
@@ -296,10 +293,9 @@ while [ "$#" -gt 0 ]; do
         reset)
             if [ "${OPTION}" -eq 1 ];then
                 error_exit "Command \"${1}\" cannot be used with options."
-	    elif [ -n "${2}" ]; then
+	        elif [ -n "${2}" ]; then
                 usage
-            fi
-            if [ "${TARGET}" = 'ALL' ]; then
+            elif [ "${TARGET}" = 'ALL' ]; then
                 for JAIL_NAME in $(ls "${bastille_jailsdir}" | sed "s/\n//g"); do
                     echo "${JAIL_NAME} redirects:"
                     pfctl -a "rdr/${JAIL_NAME}" -Fn
@@ -357,19 +353,18 @@ while [ "$#" -gt 0 ]; do
         *)
             if [ "${OPTION}" -eq 1 ];then
                 usage
-            fi
-            if [ $# -eq 6 ] && [ "${4}" = "tcp" ] || [ "${4}" = "udp" ]; then
-              check_jail_validity
-              load_rdr_rule "$@"
-              persist_rdr_rule "$@"
-              shift $#
+            elif [ $# -eq 6 ] && [ "${4}" = "tcp" ] || [ "${4}" = "udp" ]; then
+                check_jail_validity
+                load_rdr_rule "$@"
+                persist_rdr_rule "$@"
+                shift $#
             elif [ $# -ge 7 ] && [ "${7}" = "log" ]; then
-              check_jail_validity
-              load_rdr_log_rule "$@"
-              persist_rdr_log_rule "$@"
-              shift $#
+                check_jail_validity
+                load_rdr_log_rule "$@"
+                persist_rdr_log_rule "$@"
+                shift $#
             else
-              usage
+                usage
             fi
             ;;
     esac

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -224,40 +224,44 @@ RDR_DST="any"
 OPTION="0"
 
 # Check for options
-case "$1" in
-    -i|--interface)
-        if [ -z "${2}" ]; then
-            error_exit "Must specify an interface with [-i|--interface]"
-        fi
-        if ifconfig | grep -owq "${2}:"; then
-            RDR_IF="${2}"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -i|--interface)
+            if [ -z "${2}" ]; then
+                error_exit "Must specify an interface with [-i|--interface]"
+            fi
+            if ifconfig | grep -owq "${2}:"; then
+                RDR_IF="${2}"
+		OPTION="1"
+                shift 2
+            else
+                error_exit "${2} is not a valid interface."
+            fi
+            ;;
+        -s|--source)
+            if [ -z "${2}" ]; then
+                error_exit "Must specify a source IP/subnet with [-s|--source]"
+            fi
+            check_rdr_ip_validity "${2}"
+            RDR_SRC="${2}"
 	    OPTION="1"
             shift 2
-        else
-            error_exit "${2} is not a valid interface."
-        fi
-        ;;
-    -s|--source)
-        if [ -z "${2}" ]; then
-            error_exit "Must specify a source IP/subnet with [-s|--source]"
-        fi
-        check_ip_validity "${2}"
-        RDR_SRC="${2}"
-	OPTION="1"
-        shift 2
-        ;;
-    -d|--destination)
-        if [ -z "${2}" ]; then
-            error_exit "Must specify a destination IP with [-d|--destination]"
-        fi
-        if ifconfig | grep -owq "inet ${2}"; then
-            RDR_DST="${2}"
-	    OPTION="1"
-            shift 2
-        else
-            error_exit "${2} is not an IP on this system."
-        fi
-        ;;   
+            ;;
+        -d|--destination)
+            if [ -z "${2}" ]; then
+                error_exit "Must specify a destination IP with [-d|--destination]"
+            fi
+            if ifconfig | grep -owq "inet ${2}"; then
+                RDR_DST="${2}"
+	        OPTION="1"
+                shift 2
+            else
+                error_exit "${2} is not an IP on this system."
+            fi
+            ;;
+        *)
+	    break
+            ;;
 esac
 
 if [ $# -lt 2 ]; then


### PR DESCRIPTION

I've reconstructed much of the rdr.sh to allow users to set TO/FROM and also the interface.
Old command of `bastille rdr jail tcp 8000 80` still functions as it should and will use the default interface and any to any when creating the rules. Major differences are

- you can now set which interface the rule is created on with `-i em0` or any specified interface
- if you want to limit the rdr rule to a certain source, use `-s 134.234.67.34`
- if you have multiple IPs on an interface, you can choose to redirect to only one using `-d 192.168.1.45`
- `-t` is also available if you want to specifically load a rule doing ip4/6 `-t ipv4` or `-t ipv6`. The default will use both, or 'dual'

Error checking is also in place, and testers are welcome.
I will continue to update this PR with the docs and usage commands if users find this helpful.
