### PR TITLE
Fix pfctl being invoked when NAT is not used + change ip var to ip4 

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -79,14 +79,14 @@ for _jail in ${JAILS}; do
         fi
 
         ## warn if matching configured (but not online) ip4.addr, ignore if there's no ip4.addr entry
-        ip=$(bastille config "${_jail}" get ip4.addr)
-        if [ -n "${ip}" ]; then
-            if ifconfig | grep -wF "${ip}" >/dev/null; then
-                error_notify "Error: IP address (${ip}) already in use."
+        _ip4=$(bastille config "${_jail}" get ip4.addr)
+        if [ "${_ip4}" != "not set" ]; then
+            if ifconfig | grep -wF "${_ip4}" >/dev/null; then
+                error_notify "Error: IP address (${_ip4}) already in use."
                 continue
             fi
             ## add ip4.addr to firewall table
-            pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
+            pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
         fi
 
         ## start the container

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -52,10 +52,10 @@ for _jail in ${JAILS}; do
     ## test if running
     if [ "$(/usr/sbin/jls name | awk "/^${_jail}$/")" ]; then
         ## Capture ip4.addr address while still running
-        _ip="$(/usr/sbin/jls -j ${_jail} ip4.addr)"
+        _ip4="$( bastille config ${_jail} get ip4.addr )"
 
         # Check if pfctl is present
-        if which -s pfctl; then
+        if [ which -s pfctl ] && [ "${_ip4}" != "not set" ]; then
             if [ "$(bastille rdr ${_jail} list)" ]; then
                 bastille rdr ${_jail} clear
             fi
@@ -73,9 +73,9 @@ for _jail in ${JAILS}; do
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r "${_jail}"
 
         ## remove (captured above) ip4.addr from firewall table
-        if [ -n "${bastille_network_loopback}" -a ! -z "${_ip}" ]; then
+        if [ -n "${bastille_network_loopback}" ] && [ "${_ip4}" != "not set" ]; then
             if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-                pfctl -q -t "${bastille_network_pf_table}" -T delete "${_ip}"
+                pfctl -q -t "${bastille_network_pf_table}" -T delete "${_ip4}"
             fi
         fi
     fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -52,7 +52,7 @@ for _jail in ${JAILS}; do
     ## test if running
     if [ "$(/usr/sbin/jls name | awk "/^${_jail}$/")" ]; then
         ## Capture ip4.addr address while still running
-        _ip4="$( bastille config ${_jail} get ip4.addr )"
+        _ip4="$(bastille config ${_jail} get ip4.addr)"
 
         # Check if pfctl is present
         if [ "${_ip4}" != "not set" ]; then

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -55,7 +55,7 @@ for _jail in ${JAILS}; do
         _ip4="$( bastille config ${_jail} get ip4.addr )"
 
         # Check if pfctl is present
-        if [ which -s pfctl ] && [ "${_ip4}" != "not set" ]; then
+        if [ "${_ip4}" != "not set" ]; then
             if [ "$(bastille rdr ${_jail} list)" ]; then
                 bastille rdr ${_jail} clear
             fi


### PR DESCRIPTION
This PR fixes an issue where pfctl is invoked even when NAT is not being used. This prints unecessary error for folks using only VNET jails.

It also changes command to find ip4.addr to the bastille native config command which will return "not set" if ip4.addr is not found, instead of returning a -