### PR TITLE
Allow using template in custom directory

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -188,15 +188,17 @@ case ${TEMPLATE} in
         ;;
     */*)
         if [ ! -d "${bastille_templatesdir}/${TEMPLATE}" ]; then
-            if [ ! -d ${TEMPLATE} ]; then
                 error_exit "${TEMPLATE} not found."
-            else
+        else
                 bastille_template=${TEMPLATE}
-            fi
         fi
         ;;
     *)
-        error_exit "Template name/URL not recognized."
+        if [ ! -f ${TEMPLATE}/Bastillefile ]; then
+            error_exit "${TEMPLATE} not found."
+        else
+            bastille_template=${TEMPLATE}
+        fi
 esac
 
 if [ -z "${JAILS}" ]; then


### PR DESCRIPTION
This PR will allow users to specify any template directory to use with Bastille.
If the template is not found in the template directory, it will check the current directory and try to determine if a Bastillefile is present. If not, it will exit as normal.