### PR TITLE
Revert "Merge pull request #770 from tschettervictor/patch-7"

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -188,17 +188,15 @@ case ${TEMPLATE} in
         ;;
     */*)
         if [ ! -d "${bastille_templatesdir}/${TEMPLATE}" ]; then
+            if [ ! -d ${TEMPLATE} ]; then
                 error_exit "${TEMPLATE} not found."
-        else
+            else
                 bastille_template=${TEMPLATE}
+            fi
         fi
         ;;
     *)
-        if [ ! -f ${TEMPLATE}/Bastillefile ]; then
-            error_exit "${TEMPLATE} not found."
-        else
-            bastille_template=${TEMPLATE}
-        fi
+        error_exit "Template name/URL not recognized."
 esac
 
 if [ -z "${JAILS}" ]; then


### PR DESCRIPTION
This reverts commit 649c337055047b41d4e063febcf16a12b1f30a48, reversing changes made to 7d3ca7b21b30150f9b89fb6d5cf42c4abcdd348a in PR #770 

The reason to revert this is because that PR introduces an issue when the templates are not applied anymore.

Take this as an example:

Does not apply the base templates at the creation time nor a custom template:
![image](https://github.com/user-attachments/assets/944b8603-d47c-4501-856a-d889e5fc7d10)

After reverting the commit, the previous behavior was recovered at creation time:
![image](https://github.com/user-attachments/assets/2a98b0a5-093b-4b4c-bafc-133c695ca6b0)

After reverting the commit, the previous capability of applying an extra template was recovered:
![image](https://github.com/user-attachments/assets/0684d28d-c3b6-4e1c-b5c0-891e38af68a7)
