### PR TITLE
Improve bastille.conf handling with user prompt for creation

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,10 +32,20 @@ PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
 . /usr/local/share/bastille/common.sh
 
-## check for config existance
+## check for config existence
 bastille_conf_check() {
     if [ ! -r "/usr/local/etc/bastille/bastille.conf" ]; then
-        error_exit "Missing Configuration"
+        warn "Configuration file not found. Do yu want to create it with default values? [y/N]"
+        read  answer
+            case "${answer}" in
+                [Nn][Oo]|[Nn]|"")
+                    error_exit "No configuration file has been generated. Exiting."
+                ;;
+                [Yy][Ee][Ss]|[Yy])
+                    cp /usr/local/etc/bastille/bastille.conf.sample /usr/local/etc/bastille/bastille.conf
+                    info "Configuration file has been generated. Continuing with default values"
+                ;;
+            esac
     fi
 }
 

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -30,13 +30,6 @@
 
 bastille_config="/usr/local/etc/bastille/bastille.conf"
 . /usr/local/share/bastille/common.sh
-
-# TODO: This not going to take effect since Bastille checks the file
-# before running this subcommand. We will need to check an strategy.
-if [ ! -f "${bastille_config}" ]; then
-  cp /usr/local/etc/bastille/bastille.conf.sample ${bastille_config}
-fi
-
 # shellcheck source=/usr/local/etc/bastille/bastille.conf
 . ${bastille_config}
 


### PR DESCRIPTION
Replaced ineffective default configuration generation logic with a user-interactive prompt. Users can now choose to create the configuration file with default values if it is missing, ensuring better control and clarity. Removed redundant code from the setup script to streamline execution.