### PR TITLE
template: Error when multiple spaces in Bastillefile

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -281,7 +281,7 @@ for _jail in ${JAILS}; do
             # First word converted to lowercase is the Bastille command. -- cwells
             _cmd=$(echo "${_line}" | awk '{print tolower($1);}')
             # Rest of the line with "arg" variables replaced will be the arguments. -- cwells
-            _args=$(echo "${_line}" | awk '{$1=""; sub(/^ */, ""); print;}' | eval "sed ${ARG_REPLACEMENTS}")
+            _args=$(echo "${_line}" | sed 's/^[^ ]*//' | eval "sed ${ARG_REPLACEMENTS}")
 
             # Apply overrides for commands/aliases and arguments. -- cwells
             case $_cmd in


### PR DESCRIPTION
Replace "awk" with "sed" because awk was removing blank lines that were adjacent to other blank lines.

Sed now simply strips the uppercase first arg away from the line, which is what the awk command attempted to do in the first place.