### PR TITLE
etcupdate: beta version

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -93,6 +93,7 @@ Available Commands:
   create      Create a new thin container or a thick container if -T|--thick option specified.
   destroy     Destroy a stopped container or a FreeBSD release.
   edit        Edit container configuration files (advanced).
+  etcupdate   Update /etc directory to specified release.
   export      Exports a specified container.
   help        Help about any command.
   htop        Interactive process viewer (requires htop).
@@ -157,7 +158,7 @@ version|-v|--version)
 help|-h|--help)
     usage
     ;;
-bootstrap|create|destroy|export|htop|import|list|mount|rdr|restart|setup|start|top|umount|update|upgrade|verify)
+bootstrap|create|destroy|etcupdate|export|htop|import|list|mount|rdr|restart|setup|start|top|umount|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
 clone|config|cmd|console|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysrc|tags|template|zfs)

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -190,13 +190,28 @@ set_target_single() {
     local _TARGET="${1}"
     if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
         error_exit "[all|ALL] not supported with this command."
-    else
-        check_target_exists "${_TARGET}" || error_exit "Jail not found \"${_TARGET}\""
-        JAILS="${_TARGET}"
-        TARGET="${_TARGET}"
-        export JAILS
-        export TARGET
+    elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
+        error_exit "Error: Command only supports a single TARGET."
+    elif echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
+        if get_jail_name "${_TARGET}" > /dev/null; then
+            _TARGET="$(get_jail_name ${_TARGET})"
+        else
+            error_exit "Error: JID \"${_TARGET}\" not found. Is jail running?"
+        fi
+    elif
+        ! check_target_exists "${_TARGET}"; then
+            if jail_autocomplete "${_TARGET}" > /dev/null; then
+                _TARGET="$(jail_autocomplete ${_TARGET})"
+            elif [ $? -eq 2 ]; then
+                error_exit "Jail not found \"${_TARGET}\""
+            else
+                exit 1
+            fi
     fi
+    TARGET="${_TARGET}"
+    JAILS="${_TARGET}"
+    export TARGET
+    export JAILS
 }
 
 target_all_jails() {

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -191,6 +191,6 @@ while [ "$#" -gt 0 ]; do
                     error_exit "Unknown action: \"${ACTION}\""
                     ;;
             esac
-        ;;
+            ;;
     esac
 done

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -111,10 +111,6 @@ update_jail_etc() {
     fi
 }
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
-    usage
-fi
-
 # Handle options.
 DRY_RUN=0
 FORCE=0
@@ -152,6 +148,10 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
 # Main commands
 while [ "$#" -gt 0 ]; do
     case "${1}" in
@@ -166,31 +166,32 @@ while [ "$#" -gt 0 ]; do
             fi
             ;;
         *)
-            if [ -z "${2}" ]; then
-                usage
-            else
-                TARGET="${1}"
-                ACTION="${2}"
-                RELEASE="${3}"
-                set_target_single "${TARGET}"
-                case "${ACTION}" in
-                    diff)
-                        diff_review "${TARGET}"
-                        shift "$#"
-                        ;;
-                    resolve)
-                        resolve_conflicts "${TARGET}"
-                        shift "$#"
-                        ;;
-                    update)
+            TARGET="${1}"
+            ACTION="${2}"
+            RELEASE="${3}"
+            set_target_single "${TARGET}"
+            case "${ACTION}" in
+                diff)
+                    diff_review "${TARGET}"
+                    shift "$#"
+                    ;;
+                resolve)
+                    resolve_conflicts "${TARGET}"
+                    shift "$#"
+                    ;;
+                update)
+                    if [ -z "${RELEASE}" ]; then
+                        usage
+                    else
                         update_jail_etc "${TARGET}" "${RELEASE}"
                         shift "$#"
-                        ;;
-                    *)
-                    error_exit "Unknown action: \"${ACTION}\""
+                    fi
                     ;;
-                esac
-            fi
-            ;;
+                *)
+                error_exit "Unknown action: \"${ACTION}\""
+                ;;
+            esac
+        fi
+        ;;
     esac
 done

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Copyright (c) 2018-2024, Christer Edwards <christer.edwards@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+. /usr/local/share/bastille/common.sh
+. /usr/local/etc/bastille/bastille.conf
+
+usage() {
+    error_notify "Usage: bastille etcupdate [option(s)] [TARGET|bootstrap] RELEASE"
+    cat << EOF
+    Options:
+
+    -d | --dry-run          Show output, but do not apply.
+
+EOF
+    exit 1
+}
+
+bootstrap_etc_release() {
+    local _release="${1}"
+    local _current="$(sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives | awk -F': ' '{print $2}')"
+    if ! ls -A "${bastille_releasesdir}/${_release}/usr/src" 2>/dev/null; then
+        sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives=src
+        if ! bastille bootstrap "${_release}"; then
+            error_notify "Failed to bootstrap etcupdate \"${_release}\""
+        fi
+        sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
+    fi
+}
+
+bootstrap_etc_tarball() {
+    local _release="${1}"
+    if [ ! -f ${bastille_cachedir}/${_release}.tbz2 ]; then
+        if ! etcupdate build -d /tmp/etcupdate -s ${bastille_releasesdir}/${_release}/usr/src ${bastille_cachedir}/${_release}.tbz2; then
+            error_exit "Failed to build etcupdate tarball \"${_release}.tbz2\""
+        else
+            info "Etcupdate bootstrap complete: \"${_release}\""
+        fi
+    else
+        info "Etcupdate release has already been prepared for application: \"${_release}\""
+        exit 0
+    fi
+}
+
+update_jail_etc() {
+    local _jail="${1}"
+    local _release="${2}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        info "[_jail]: --dry-run"
+        etcupdate -n -D "${bastille_jailsdir}"/"${_jail}"/root -t ${bastille_cachedir}/${_release}.tbz2
+    else
+        info "[_jail]:"
+        etcupdate -D "${bastille_jailsdir}"/"${_jail}"/root -t ${bastille_cachedir}/${_release}.tbz2
+    fi
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+# Handle options.
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+        -h|--help|help)
+            usage
+            ;;
+        -d|--dry-run)
+            if [ -z "${2}" ] || [ -z "${3}" ]; then
+                usage
+            else
+                DRY_RUN=1
+                shift
+            fi
+            ;;
+        -*)
+            error_exit "Unknown option: \"${1}\""
+            ;;
+        bootstrap)
+            if [ -z "${2}" ]; then
+                usage
+            else
+                RELEASE="${2}"
+                bootstrap_etc_release "${RELEASE}"
+                bootstrap_etc_tarball "${RELEASE}"
+                shift $#
+            fi
+            ;;
+        *)
+            if [ -z "${2}" ]; then
+                usage
+            else
+                TARGET="${1}"
+                RELEASE="${2}"
+            fi
+            if [ -z "${DRY_RUN}" ]; then
+                DRY_RUN=0
+            fi
+            set_target_single "${TARGET}"
+            update_jail_etc "${TARGET}" "${RELEASE}"
+            shift "$#"
+            ;;
+    esac
+done

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -31,11 +31,13 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille etcupdate [option(s)] [TARGET|bootstrap] RELEASE"
+    error_notify "Usage: bastille etcupdate [option(s)] [bootstrap|TARGET] [update RELEASE|resolve]"
     cat << EOF
     Options:
 
     -d | --dry-run          Show output, but do not apply.
+    -f | --force            Force a re-bootstrap of a RELEASE.
+    -x | --debug            Enable debug mode.
 
 EOF
     exit 1
@@ -47,11 +49,9 @@ bootstrap_etc_release() {
     if ls -A "${bastille_releasesdir}/${_release}/usr/src" 2>/dev/null; then
         sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives=src
         if ! bastille bootstrap "${_release}"; then
-            sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
-            error_exit "Failed to bootstrap etcupdate \"${_release}\""
-        else
-            sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
+            error_notify "Failed to bootstrap etcupdate: ${_release}"
         fi
+        sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
     fi
 }
 
@@ -62,50 +62,88 @@ bootstrap_etc_tarball() {
         if ! etcupdate build -d /tmp/etcupdate -s ${bastille_releasesdir}/${_release}/usr/src ${bastille_cachedir}/${_release}.tbz2; then
             error_exit "Failed to build etcupdate tarball \"${_release}.tbz2\""
         else
-            info "Etcupdate bootstrap complete: \"${_release}\""
+            info "Etcupdate bootstrap complete: ${_release}"
+        fi
+    elif [ -f ${bastille_cachedir}/${_release}.tbz2 ] && [ "${FORCE}" -eq 1 ]; then
+        rm -f "${bastille_cachedir}/${_release}.tbz2"
+        echo "Building tarball, please wait..."
+        if ! etcupdate build -d /tmp/etcupdate -s ${bastille_releasesdir}/${_release}/usr/src ${bastille_cachedir}/${_release}.tbz2; then
+            error_exit "Failed to build etcupdate tarball \"${_release}.tbz2\""
+        else
+            info "Etcupdate bootstrap complete: ${_release}"
         fi
     else
-        info "Etcupdate release has already been prepared for application: \"${_release}\""
-        exit 0
+        info "Etcupdate release has already been prepared for application: ${_release}"
     fi
+}
+
+resolve_conflicts() {
+    local _jail="${1}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        info "[_jail]: --dry-run"
+        etcupdate resolve -n -D "${bastille_jailsdir}/${_jail}/root"
+    else
+        info "[_jail]:"
+        etcupdate resolve -D "${bastille_jailsdir}/${_jail}/root"
+    fi   
 }
 
 update_jail_etc() {
     local _jail="${1}"
     local _release="${2}"
-    if [ ! -f ${bastille_cachedir}/${_release}.tbz2 ]; then
-        error_exit "Error: Please run \"bastille etcupdate bootstrap RELEASE\" first."
-    fi
     if [ "${DRY_RUN}" -eq 1 ]; then
         info "[_jail]: --dry-run"
-        etcupdate -n -D "${bastille_jailsdir}"/"${_jail}"/root -t ${bastille_cachedir}/${_release}.tbz2
+        etcupdate -n -D "${bastille_jailsdir}/${_jail}/root" -t ${bastille_cachedir}/${_release}.tbz2
     else
         info "[_jail]:"
-        etcupdate -D "${bastille_jailsdir}"/"${_jail}"/root -t ${bastille_cachedir}/${_release}.tbz2
+        etcupdate -D "${bastille_jailsdir}/${_jail}/root" -t ${bastille_cachedir}/${_release}.tbz2
     fi
 }
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
     usage
 fi
 
 # Handle options.
+DRY_RUN=0
+FORCE=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
             ;;
         -d|--dry-run)
-            if [ -z "${2}" ] || [ -z "${3}" ]; then
-                usage
-            else
-                DRY_RUN=1
-                shift
-            fi
+            DRY_RUN=1
+            shift
             ;;
-        -*)
-            error_exit "Unknown option: \"${1}\""
+        -f|--force)
+            FORCE=1
+            shift
             ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*) 
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    d) DRY_RUN=1 ;;
+                    f) FORCE=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\"" ;; 
+                esac
+            done
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Main commands
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
         bootstrap)
             if [ -z "${2}" ]; then
                 usage
@@ -121,14 +159,19 @@ while [ "$#" -gt 0 ]; do
                 usage
             else
                 TARGET="${1}"
-                RELEASE="${2}"
+                ACTION="${2}"
+                RELEASE="${3}"
             fi
-            if [ -z "${DRY_RUN}" ]; then
-                DRY_RUN=0
-            fi
-            set_target_single "${TARGET}"
-            update_jail_etc "${TARGET}" "${RELEASE}"
-            shift "$#"
+            case "${ACTION}" in
+                resolve)
+                    resolve_conflicts "${TARGET}"
+                    shift "$#"
+                    ;;
+                update)
+                    update_jail_etc "${TARGET}" "${RELEASE}"
+                    shift "$#"
+                    ;;
+            esac
             ;;
     esac
 done

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -87,13 +87,8 @@ diff_review() {
 
 resolve_conflicts() {
     local _jail="${1}"
-    if [ "${DRY_RUN}" -eq 1 ]; then
-        info "[${_jail}]: etcupdate resolve --dry-run"
-        etcupdate resolve -n -D "${bastille_jailsdir}/${_jail}/root"
-    else
-        info "[${_jail}]: etcupdate resolve"
-        etcupdate resolve -D "${bastille_jailsdir}/${_jail}/root"
-    fi   
+    info "[${_jail}]: etcupdate resolve"
+    etcupdate resolve -D "${bastille_jailsdir}/${_jail}/root"  
 }
 
 update_jail_etc() {

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -47,9 +47,11 @@ bootstrap_etc_release() {
     if ls -A "${bastille_releasesdir}/${_release}/usr/src" 2>/dev/null; then
         sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives=src
         if ! bastille bootstrap "${_release}"; then
-            error_notify "Failed to bootstrap etcupdate \"${_release}\""
+            sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
+            error_exit "Failed to bootstrap etcupdate \"${_release}\""
+        else
+            sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
         fi
-        sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives="${_current}"
     fi
 }
 
@@ -71,6 +73,9 @@ bootstrap_etc_tarball() {
 update_jail_etc() {
     local _jail="${1}"
     local _release="${2}"
+    if [ ! -f ${bastille_cachedir}/${_release}.tbz2 ]; then
+        error_exit "Error: Please run \"bastille etcupdate bootstrap RELEASE\" first."
+    fi
     if [ "${DRY_RUN}" -eq 1 ]; then
         info "[_jail]: --dry-run"
         etcupdate -n -D "${bastille_jailsdir}"/"${_jail}"/root -t ${bastille_cachedir}/${_release}.tbz2

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -56,6 +56,7 @@ bootstrap_etc_release() {
 bootstrap_etc_tarball() {
     local _release="${1}"
     if [ ! -f ${bastille_cachedir}/${_release}.tbz2 ]; then
+        echo "Building tarball, please wait..."
         if ! etcupdate build -d /tmp/etcupdate -s ${bastille_releasesdir}/${_release}/usr/src ${bastille_cachedir}/${_release}.tbz2; then
             error_exit "Failed to build etcupdate tarball \"${_release}.tbz2\""
         else

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -81,12 +81,18 @@ bootstrap_etc_tarball() {
 
 diff_review() {
     local _jail="${1}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        warn "Warning: diff mode does not support [-d|--dryrun]"
+    fi
     info "[${_jail}]: etcupdate --diff mode"
     etcupdate diff -D "${bastille_jailsdir}/${_jail}/root"  
 }
 
 resolve_conflicts() {
     local _jail="${1}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        warn "Warning: resolve mode does not support [-d|--dryrun]"
+    fi
     info "[${_jail}]: etcupdate resolve"
     etcupdate resolve -D "${bastille_jailsdir}/${_jail}/root"  
 }

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -163,7 +163,7 @@ while [ "$#" -gt 0 ]; do
                 RELEASE="${2}"
                 bootstrap_etc_release "${RELEASE}"
                 bootstrap_etc_tarball "${RELEASE}"
-                shift $#
+                shift "$#"
             fi
             ;;
         *)

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -188,10 +188,9 @@ while [ "$#" -gt 0 ]; do
                     fi
                     ;;
                 *)
-                error_exit "Unknown action: \"${ACTION}\""
-                ;;
+                    error_exit "Unknown action: \"${ACTION}\""
+                    ;;
             esac
-        fi
         ;;
     esac
 done

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -31,7 +31,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille etcupdate [option(s)] [bootstrap|TARGET] [update RELEASE|resolve]"
+    error_notify "Usage: bastille etcupdate [option(s)] [bootstrap|TARGET] [diff|resolve|update RELEASE]"
     cat << EOF
     Options:
 

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -99,6 +99,9 @@ resolve_conflicts() {
 update_jail_etc() {
     local _jail="${1}"
     local _release="${2}"
+    if [ ! -f ${bastille_cachedir}/${_release}.tbz2 ]; then
+        error_exit "Error: Please run \"bastille etcupdate bootstrap RELEASE\" first."
+    fi
     if [ "${DRY_RUN}" -eq 1 ]; then
         info "[_jail]: update --dry-run"
         etcupdate -n -D "${bastille_jailsdir}/${_jail}/root" -t ${bastille_cachedir}/${_release}.tbz2

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -44,7 +44,7 @@ EOF
 bootstrap_etc_release() {
     local _release="${1}"
     local _current="$(sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives | awk -F': ' '{print $2}')"
-    if ! ls -A "${bastille_releasesdir}/${_release}/usr/src" 2>/dev/null; then
+    if ls -A "${bastille_releasesdir}/${_release}/usr/src" 2>/dev/null; then
         sysrc -f /usr/local/etc/bastille/bastille.conf bastille_bootstrap_archives=src
         if ! bastille bootstrap "${_release}"; then
             error_notify "Failed to bootstrap etcupdate \"${_release}\""

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -81,17 +81,17 @@ bootstrap_etc_tarball() {
 
 diff_review() {
     local _jail="${1}"
-    info "[_jail]: diff"
+    info "[${_jail}]: etcupdate --diff mode"
     etcupdate diff -D "${bastille_jailsdir}/${_jail}/root"  
 }
 
 resolve_conflicts() {
     local _jail="${1}"
     if [ "${DRY_RUN}" -eq 1 ]; then
-        info "[_jail]: resolve --dry-run"
+        info "[${_jail}]: etcupdate resolve --dry-run"
         etcupdate resolve -n -D "${bastille_jailsdir}/${_jail}/root"
     else
-        info "[_jail]: resolve"
+        info "[${_jail}]: etcupdate resolve"
         etcupdate resolve -D "${bastille_jailsdir}/${_jail}/root"
     fi   
 }
@@ -103,10 +103,10 @@ update_jail_etc() {
         error_exit "Error: Please run \"bastille etcupdate bootstrap RELEASE\" first."
     fi
     if [ "${DRY_RUN}" -eq 1 ]; then
-        info "[_jail]: update --dry-run"
+        info "[${_jail}]: etcupdate update --dry-run"
         etcupdate -n -D "${bastille_jailsdir}/${_jail}/root" -t ${bastille_cachedir}/${_release}.tbz2
     else
-        info "[_jail]: update"
+        info "[${_jail}]: etcupdate update"
         etcupdate -D "${bastille_jailsdir}/${_jail}/root" -t ${bastille_cachedir}/${_release}.tbz2
     fi
 }


### PR DESCRIPTION
Add subcommand "etcupdate"

This will simply use the built in "bootstrap" command to bootstrap the "src" version of a release, then create a tarball for it ONCE. This tarball is then used to update (includes dry run) a specifie jail to a specified RELEASE version of etc.

To test.

1. Install a jail with 13.4-RELEASE
2. Bootstrap an etcupdate release using "bastille etcupdate bootstrap 14.2-RELEASE
(make sure its a higher version than the jail)
3. Change the RELEASE of the jail from 13.4 to 14.0 or whichever higher version you choose
4. Do an etcupdate by "bastille etcupdate jailname update 14.0-RELEASE" -d for dry run
5. Do a "bastille etcupdate jailname resolve" to resolve conflicts

Confirm the etc files updated properly and the resolve mode works as expected.
Logs are inside the jail at /var/db/etcupdate