### PR TITLE
Update common.sh with functions for all jails+first migration "console.sh"

### DIFF
--- a/docs/chapters/subcommands/console.rst
+++ b/docs/chapters/subcommands/console.rst
@@ -2,8 +2,7 @@
 console
 =======
 
-This sub-command launches a login shell into the container. Default is password-less
-root login.
+This sub-command launches a login shell into the container. Default is password-less root login.
 
 .. code-block:: shell
 
@@ -11,6 +10,23 @@ root login.
   [folsom]:
   root@folsom:~ #
 
+TARGET can also be a running jails JID value.
+
+  ishmael ~ # bastille list
+   JID  IP Address      Hostname                      Path
+     1  10.1.2.3        ishmael                       /usr/local/bastille/jails/ishmael/root
+  ishmael ~ # bastille console 1
+  [ishmael]:
+  root@ishmael:~ #
+
 At this point you are logged in to the container and have full shell access.  The
 system is yours to use and/or abuse as you like. Any changes made inside the
 container are limited to the container.
+
+.. code-block:: shell
+
+  "Usage: bastille console [option(s)] TARGET [user]"
+  Options:
+
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.

--- a/docs/chapters/subcommands/console.rst
+++ b/docs/chapters/subcommands/console.rst
@@ -12,6 +12,8 @@ This sub-command launches a login shell into the container. Default is password-
 
 TARGET can also be a running jails JID value.
 
+.. code-block:: shell
+
   ishmael ~ # bastille list
    JID  IP Address      Hostname                      Path
      1  10.1.2.3        ishmael                       /usr/local/bastille/jails/ishmael/root

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -131,7 +131,7 @@ EOF
 CMD=$1
 shift
 
-target_all_jails() {
+target_all_jails_old() {
   _JAILS=$(/usr/sbin/jls name)
   JAILS=""
   for _jail in ${_JAILS}; do
@@ -142,7 +142,7 @@ target_all_jails() {
   done
 }
 
-check_target_is_running() {
+check_target_is_running_old() {
   if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
       error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
   fi
@@ -157,10 +157,10 @@ version|-v|--version)
 help|-h|--help)
     usage
     ;;
-bootstrap|create|destroy|export|htop|import|list|mount|rdr|restart|setup|start|top|umount|update|upgrade|verify)
+bootstrap|console|create|destroy|export|htop|import|list|mount|rdr|restart|setup|start|top|umount|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
-clone|config|cmd|console|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysrc|tags|template|zfs)
+clone|config|cmd|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysrc|tags|template|zfs)
     # Parse the target and ensure it exists. -- cwells
     if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
         PARAMS='help'
@@ -181,15 +181,15 @@ clone|config|cmd|console|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysr
         fi
 
         if [ "${TARGET}" = 'ALL' ]; then
-            target_all_jails
+            target_all_jails_old
         elif [ "${CMD}" = "pkg" ] && [ "${TARGET}" = '-H' ] || [ "${TARGET}" = '--host' ]; then
             TARGET="${1}"
             USE_HOST_PKG=1
             if [ "${TARGET}" = 'ALL' ]; then
-              target_all_jails
+              target_all_jails_old
             else
               JAILS="${TARGET}"
-              check_target_is_running
+              check_target_is_running_old
             fi
             shift
         elif [ "${CMD}" = 'template' ] && [ "${TARGET}" = '--convert' ]; then
@@ -205,8 +205,8 @@ clone|config|cmd|console|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysr
             fi
 
             case "${CMD}" in
-            cmd|console|pkg|service|stop|sysrc|template)
-                check_target_is_running
+            cmd|pkg|service|stop|sysrc|template)
+                check_target_is_running_old
                 ;;
             convert|rename)
                 # Require the target to be stopped. -- cwells

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -42,7 +42,7 @@ help|-h|--help)
     ;;
 esac
 
-if [ $# -ne 2 ]; then
+if [ "$#" -ne 2 ]; then
     usage
 fi
 
@@ -112,8 +112,8 @@ update_jailconf_vnet() {
         local bastille_num_range=$((_vnet_if_count + 1))
         if echo ${_if} | grep -Eoq 'epair[1-9]+'; then
             # Update bridged VNET config
-            for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -Eoq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+            for _num in $(seq 1 "${epair_num_range}"); do
+                if ! grep -oq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     # Update jail.conf epair name
                     local uniq_epair_bridge="${_num}"
                     local _if_epaira="$(grep "${_if}" ${JAIL_CONFIG} | grep -Eo -m 1 "epair[1-9]+a")"
@@ -144,10 +144,10 @@ update_jailconf_vnet() {
                     break
                 fi
             done
-        elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
+        elif echo ${_if} | grep -Eoq 'bastille[1-9]+'; then
             # Update VNET config
-            for _num in $(seq 0 "${bastille_num_range}"); do
-                if ! grep -Eoq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
+            for _num in $(seq 1 "${bastille_num_range}"); do
+                if ! grep -oq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -122,7 +122,7 @@ update_jailconf_vnet() {
                     sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
                     # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
                     # we also do not use the main generate_static_mac function here
-                    if grep -Eo "${_if}" ${JAIL_CONFIG} | grep -oq ether; then
+                    if grep -oq "${_if}" ${JAIL_CONFIG} | grep -oq ether; then
                         local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
                         local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
                         local macaddr="${macaddr_prefix}:${macaddr_suffix}"
@@ -154,7 +154,7 @@ update_jailconf_vnet() {
                     sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
                     # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
                     # we also do not use the main generate_static_mac function here
-                    if grep -Eo ${_if} ${JAIL_CONFIG} | grep -oq ether; then
+                    if grep -oq ${_if} ${JAIL_CONFIG} | grep -oq ether; then
                         local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
                         local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
                         local macaddr="${macaddr_prefix}:${macaddr_suffix}"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -103,47 +103,81 @@ update_jailconf() {
 
 update_jailconf_vnet() {
     bastille_jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
-
-    # Determine number of containers and define an uniq_epair
-    local list_jails_num="$(bastille list jails | wc -l | awk '{print $1}')"
-    local num_range="$(expr "${list_jails_num}" + 1)"
-    jail_list=$(bastille list jail)
-    for _num in $(seq 0 "${num_range}"); do
-        if [ -n "${jail_list}" ]; then
-            if ! grep -q "e0b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                if ! grep -q "epair${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                    local uniq_epair="bastille${_num}"
+    # Determine number of interfaces and define a uniq_epair
+    local _if_list="$(grep -Eo 'epair[1-9]+|bastille[1-9]+' ${JAIL_CONFIG} | sort -u)"
+    for _if in ${_if_list}; do
+        local _epair_if_count="$(grep -Eo 'epair[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+        local _bastille_if_count="$(grep -Eo 'bastille[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+        local epair_num_range=$((_epair_if_count + 1))
+        local bastille_num_range=$((_vnet_if_count + 1))
+        if echo ${_if} | grep -Eoq 'epair[1-9]+'; then
+            # Update bridged VNET config
+            for _num in $(seq 0 "${epair_num_range}"); do
+                if ! grep -Eoq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                    # Update jail.conf epair name
                     local uniq_epair_bridge="${_num}"
-	            # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
+                    local _if_epaira="$(grep "${_if}" ${JAIL_CONFIG} | grep -Eo -m 1 "epair[1-9]+a")"
+                    local _if_epairb="$(grep "${_if}" ${JAIL_CONFIG} | grep -Eo -m 1 "epair[1-9]+b")"
+                    local _if_vnet="$(grep ${_if_epairb} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[1-9]+")"
+                    sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
                     # we also do not use the main generate_static_mac function here
-                    local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
-    	            local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
-                    local macaddr="${macaddr_prefix}:${macaddr_suffix}"
-	            # Update the exec.* with uniq_epair when cloning jails.
-                    # for VNET jails
-                    sed -i '' "s|bastille\([0-9]\{1,\}\)|${uniq_epair}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|e\([0-9]\{1,\}\)a_${NEWNAME}|e${uniq_epair_bridge}a_${NEWNAME}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|e\([0-9]\{1,\}\)b_${NEWNAME}|e${uniq_epair_bridge}b_${NEWNAME}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|epair\([0-9]\{1,\}\)|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-		    sed -i '' "s|exec.prestart += \"ifconfig e0a_bastille\([0-9]\{1,\}\).*description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
-                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*a\";|ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*b\";|ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                    if grep -Eo "${_if}" ${JAIL_CONFIG} | grep -oq ether; then
+                        local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
+                        local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
+                        local macaddr="${macaddr_prefix}:${macaddr_suffix}"
+                        sed -i '' "s|epair${uniq_epair}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|epair${uniq_epair}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                    fi
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    # Update /etc/rc.conf
+                    sed -i '' "s|${_if_epairb}_name|epair${uniq_epair_bridge}b_name|" "${bastille_jail_rc_conf}"
+                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q "epair${uniq_epair_bridge}b_name"; then
+                        if [ "${IP}" = "0.0.0.0" ]; then
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                        else
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
+                        fi
+                    else
+                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                    fi
                     break
                 fi
-            fi
+            done
+        elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
+            # Update VNET config
+            for _num in $(seq 0 "${bastille_num_range}"); do
+                if ! grep -Eoq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                    # Update jail.conf epair name
+                    local uniq_epair="bastille${_num}"
+                    local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
+                    sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
+                    # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
+                    # we also do not use the main generate_static_mac function here
+                    if grep -Eo ${_if} ${JAIL_CONFIG} | grep -oq ether; then
+                        local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
+                        local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
+                        local macaddr="${macaddr_prefix}:${macaddr_suffix}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*b\";|${uniq_epair} ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                    fi
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    # Update /etc/rc.conf
+                    sed -i '' "s|ifconfig_e0b_${_if}_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
+                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q ${uniq_epair}; then
+                        if [ "${IP}" = "0.0.0.0" ]; then
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                        else
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0=" inet ${IP} "
+                        fi
+                    else
+                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                    fi
+                    break
+                fi
+            done
         fi
     done
-
-    # Rename interface to new uniq_epair
-    sed -i '' "s|ifconfig_e0b_bastille.*_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-    sed -i '' "s|ifconfig_e.*b_${TARGET}_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
-    
-    # If 0.0.0.0 set DHCP, else set static IP address
-    if [ "${IP}" = "0.0.0.0" ]; then
-        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
-    else
-        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
-    fi
 }
 
 update_fstab() {

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -42,7 +42,7 @@ help|-h|--help)
     ;;
 esac
 
-if [ "$#" -ne 2 ]; then
+if [ $# -ne 2 ]; then
     usage
 fi
 
@@ -103,81 +103,47 @@ update_jailconf() {
 
 update_jailconf_vnet() {
     bastille_jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
-    # Determine number of interfaces and define a uniq_epair
-    local _if_list="$(grep -Eo 'epair[1-9]+|bastille[1-9]+' ${JAIL_CONFIG} | sort -u)"
-    for _if in ${_if_list}; do
-        local _epair_if_count="$(grep -Eo 'epair[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-        local _bastille_if_count="$(grep -Eo 'bastille[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-        local epair_num_range=$((_epair_if_count + 1))
-        local bastille_num_range=$((_vnet_if_count + 1))
-        if echo ${_if} | grep -Eoq 'epair[1-9]+'; then
-            # Update bridged VNET config
-            for _num in $(seq 1 "${epair_num_range}"); do
-                if ! grep -oq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
-                    # Update jail.conf epair name
-                    local uniq_epair_bridge="${_num}"
-                    local _if_epaira="$(grep "${_if}" ${JAIL_CONFIG} | grep -Eo -m 1 "epair[1-9]+a")"
-                    local _if_epairb="$(grep "${_if}" ${JAIL_CONFIG} | grep -Eo -m 1 "epair[1-9]+b")"
-                    local _if_vnet="$(grep ${_if_epairb} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[1-9]+")"
-                    sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-                    # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
-                    # we also do not use the main generate_static_mac function here
-                    if grep -oq "${_if}" ${JAIL_CONFIG} | grep -oq ether; then
-                        local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
-                        local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
-                        local macaddr="${macaddr_prefix}:${macaddr_suffix}"
-                        sed -i '' "s|epair${uniq_epair}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|epair${uniq_epair}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
-                    fi
-                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
-                    # Update /etc/rc.conf
-                    sed -i '' "s|${_if_epairb}_name|epair${uniq_epair_bridge}b_name|" "${bastille_jail_rc_conf}"
-                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q "epair${uniq_epair_bridge}b_name"; then
-                        if [ "${IP}" = "0.0.0.0" ]; then
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
-                        else
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
-                        fi
-                    else
-                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
-                    fi
-                    break
-                fi
-            done
-        elif echo ${_if} | grep -Eoq 'bastille[1-9]+'; then
-            # Update VNET config
-            for _num in $(seq 1 "${bastille_num_range}"); do
-                if ! grep -oq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
-                    # Update jail.conf epair name
+
+    # Determine number of containers and define an uniq_epair
+    local list_jails_num="$(bastille list jails | wc -l | awk '{print $1}')"
+    local num_range="$(expr "${list_jails_num}" + 1)"
+    jail_list=$(bastille list jail)
+    for _num in $(seq 0 "${num_range}"); do
+        if [ -n "${jail_list}" ]; then
+            if ! grep -q "e0b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
+                if ! grep -q "epair${_num}" "${bastille_jailsdir}"/*/jail.conf; then
                     local uniq_epair="bastille${_num}"
-                    local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
-                    sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
-                    # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
+                    local uniq_epair_bridge="${_num}"
+	            # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
                     # we also do not use the main generate_static_mac function here
-                    if grep -oq ${_if} ${JAIL_CONFIG} | grep -oq ether; then
-                        local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep ${_if} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
-                        local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
-                        local macaddr="${macaddr_prefix}:${macaddr_suffix}"
-                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*b\";|${uniq_epair} ether ${macaddr}b\";|" "${JAIL_CONFIG}"
-                    fi
-                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
-                    # Update /etc/rc.conf
-                    sed -i '' "s|ifconfig_e0b_${_if}_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q ${uniq_epair}; then
-                        if [ "${IP}" = "0.0.0.0" ]; then
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
-                        else
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0=" inet ${IP} "
-                        fi
-                    else
-                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
-                    fi
+                    local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
+    	            local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
+                    local macaddr="${macaddr_prefix}:${macaddr_suffix}"
+	            # Update the exec.* with uniq_epair when cloning jails.
+                    # for VNET jails
+                    sed -i '' "s|bastille\([0-9]\{1,\}\)|${uniq_epair}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|e\([0-9]\{1,\}\)a_${NEWNAME}|e${uniq_epair_bridge}a_${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|e\([0-9]\{1,\}\)b_${NEWNAME}|e${uniq_epair_bridge}b_${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|epair\([0-9]\{1,\}\)|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+		    sed -i '' "s|exec.prestart += \"ifconfig e0a_bastille\([0-9]\{1,\}\).*description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
+                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*a\";|ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                    sed -i '' "s|ether.*:.*:.*:.*:.*:.*b\";|ether ${macaddr}b\";|" "${JAIL_CONFIG}"
                     break
                 fi
-            done
+            fi
         fi
     done
+
+    # Rename interface to new uniq_epair
+    sed -i '' "s|ifconfig_e0b_bastille.*_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
+    sed -i '' "s|ifconfig_e.*b_${TARGET}_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
+    
+    # If 0.0.0.0 set DHCP, else set static IP address
+    if [ "${IP}" = "0.0.0.0" ]; then
+        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+    else
+        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
+    fi
 }
 
 update_fstab() {

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -230,8 +230,8 @@ generate_vnet_jail_netblock() {
     ## determine number of interfaces + 1
     ## iterate num and grep all jail configs
     ## define uniq_epair
-    local _epair_if_count="$(grep -Eos 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-    local _vnet_if_count="$(grep -Eos 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+    local _epair_if_count="$(grep -Eos 'epair[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+    local _vnet_if_count="$(grep -Eos 'bastille[1-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
     local epair_num_range=$((_epair_if_count + 1))
     local vnet_num_range=$((_vnet_if_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
@@ -243,7 +243,7 @@ generate_vnet_jail_netblock() {
                 fi
             done
         else
-            local uniq_epair_bridge="0"
+            local uniq_epair_bridge="1"
         fi
     else
         if [ "${_vnet_if_count}" -gt 0 ]; then  
@@ -254,7 +254,7 @@ generate_vnet_jail_netblock() {
                 fi
             done
         else
-            local uniq_epair="bastille0"
+            local uniq_epair="bastille1"
         fi
     fi
     ## If BRIDGE is enabled, generate bridge config, else generate VNET config

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -190,12 +190,11 @@ set_target_single() {
             else
                 exit 1
             fi
-    else
-        TARGET="${_TARGET}"
-        JAILS="${_TARGET}"
-        export TARGET
-        export JAILS
     fi
+    TARGET="${_TARGET}"
+    JAILS="${_TARGET}"
+    export TARGET
+    export JAILS
 }
 
 target_all_jails() {

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -175,7 +175,7 @@ set_target_single() {
     local _status=0
     if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
         error_exit "[all|ALL] not supported with this command."
-    elif echo "${_TARGET}" > /dev/null | grep -Eq '^[0-9]+$'; then
+    elif echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
         if get_jail_name "${_TARGET}" > /dev/null; then
             _TARGET="$(get_jail_name ${_TARGET})"
         else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -147,7 +147,7 @@ set_target() {
         target_all_jails
     else
         for _jail in ${_TARGET}; do
-            if echo "${_jail}" | grep -Eq '^[0-9]+$'; then
+            if [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && [ echo "${_jail}" | grep -Eq '^[0-9]+$' ]; then
                 if get_jail_name "${_jail}" > /dev/null; then
                     _jail="$(get_jail_name ${_jail})"
                 else
@@ -172,12 +172,11 @@ set_target() {
 
 set_target_single() {
     local _TARGET="${1}"
-    local _status=0
     if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
         error_exit "[all|ALL] not supported with this command."
     elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
         error_exit "Error: Command only supports a single TARGET."
-    elif echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
+    elif [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && [ echo "${_TARGET}" | grep -Eq '^[0-9]+$' ]; then
         if get_jail_name "${_TARGET}" > /dev/null; then
             _TARGET="$(get_jail_name ${_TARGET})"
         else
@@ -188,7 +187,7 @@ set_target_single() {
             if jail_autocomplete "${_TARGET}" > /dev/null; then
                 _TARGET="$(jail_autocomplete ${_TARGET})"
             elif [ $? -eq 2 ]; then
-                error_exit "Jail not found \"${_jail}\""
+                error_exit "Jail not found \"${_TARGET}\""
             else
                 exit 1
             fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -230,7 +230,9 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
+    # Use FreeBSD vendor MAC prefix (58:9c:fc) for jail MAC prefix
     local macaddr_prefix="58:9c:fc"
+    # Use hash of interface+jailname for jail MAC suffix
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -164,9 +164,9 @@ set_target() {
             fi
             TARGET="${TARGET} ${_jail}"
             JAILS="${JAILS} ${_jail}"
-            export TARGET
-            export JAILS
         done
+        export TARGET
+        export JAILS
     fi
 }
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -147,7 +147,7 @@ set_target() {
         target_all_jails
     else
         for _jail in ${_TARGET}; do
-            if [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && [ echo "${_jail}" | grep -Eq '^[0-9]+$' ]; then
+            if [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_jail}" | grep -Eq '^[0-9]+$'; then
                 if get_jail_name "${_jail}" > /dev/null; then
                     _jail="$(get_jail_name ${_jail})"
                 else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -49,7 +49,7 @@ enable_color() {
 
 enable_debug() {
     # Enable debug mode.
-    warn "***DEBUG MODE START***"
+    warn "***DEBUG MODE***"
     set -x
 } 
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -176,7 +176,7 @@ set_target_single() {
         error_exit "[all|ALL] not supported with this command."
     elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
         error_exit "Error: Command only supports a single TARGET."
-    elif [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && [ echo "${_TARGET}" | grep -Eq '^[0-9]+$' ]; then
+    elif [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
         if get_jail_name "${_TARGET}" > /dev/null; then
             _TARGET="$(get_jail_name ${_TARGET})"
         else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -213,7 +213,9 @@ target_all_jails() {
     export JAILS
 }
 
-update_fstab() {
+# Moving fstab function to common.sh
+# Not in use yet, so keeping the name different
+update_fstab_new() {
     local _oldname="${1}"
     local _newname="${2}"
     local _fstab="${bastille_jailsdir}/${_newname}/fstab"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -30,7 +30,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-. /usr/local/etc/bastille/bastille.conf
+# Source config file
+if [ -f /usr/local/etc/bastille/bastille.conf ]; then
+    . /usr/local/etc/bastille/bastille.conf
+fi
 
 COLOR_RED=
 COLOR_GREEN=
@@ -90,7 +93,7 @@ warn() {
 check_target_exists() {
     local _TARGET="${1}"
     local _jaillist="$(bastille list jails)"
-    if ! echo "${_jaillist}" | grep -Eoq "^${_TARGET}$"; then
+    if ! echo "${_jaillist}" | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -99,7 +102,7 @@ check_target_exists() {
 
 check_target_is_running() {
     local _TARGET="${1}"
-    if ! jls name | grep -Eoq "^${_TARGET}$"; then
+    if ! jls name | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -108,7 +111,7 @@ check_target_is_running() {
 
 check_target_is_stopped() {
     local _TARGET="${1}"
-    if jls name | grep -Eoq "^${_TARGET}$"; then
+    if jls name | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -184,8 +187,7 @@ set_target_single() {
         else
             error_exit "Error: JID \"${_TARGET}\" not found. Is jail running?"
         fi
-    elif
-        ! check_target_exists "${_TARGET}"; then
+    elif ! check_target_exists "${_TARGET}"; then
             if jail_autocomplete "${_TARGET}" > /dev/null; then
                 _TARGET="$(jail_autocomplete ${_TARGET})"
             elif [ $? -eq 2 ]; then
@@ -211,6 +213,30 @@ target_all_jails() {
     export JAILS
 }
 
+update_fstab() {
+    local _oldname="${1}"
+    local _newname="${2}"
+    local _fstab="${bastille_jailsdir}/${_newname}/fstab"
+    if [ -f "${_fstab}" ]; then
+        sed -i '' "s|${bastille_jailsdir}/${_oldname}/root/|${bastille_jailsdir}/${_newname}/root/|" "${_fstab}"
+    else
+        error_notify "Error: Failed to update fstab: ${_newmane}"
+    fi
+}
+
+generate_static_mac() {
+    local jail_name="${1}"
+    local external_interface="${2}"
+    local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
+    local macaddr_prefix="58:9c:fc"
+    local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
+    if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
+        error_notify "Failed to generate MAC address."
+    fi
+    macaddr="${macaddr_prefix}:${macaddr_suffix}"
+    export macaddr
+}
+
 generate_vnet_jail_netblock() {
     local jail_name="${1}"
     local use_unique_bridge="${2}"
@@ -220,23 +246,37 @@ generate_vnet_jail_netblock() {
     ## iterate num and grep all jail configs
     ## define uniq_epair
     local _epair_if_count="$(grep -Eos 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-    local _vnet_if_count="$(grep -Eos 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+    local _bastille_if_count="$(grep -Eos 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
     local epair_num_range=$((_epair_if_count + 1))
-    local vnet_num_range=$((_vnet_if_count + 1))
+    local bastille_num_range=$((_bastille_if_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_if_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${epair_num_range}"); do
                 if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
-                    local uniq_epair_bridge="${_num}"
+                    if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                        local host_epair=e${_num}a_${jail_name}
+                        local jail_epair=e${_num}b_${jail_name}
+                    else
+                        local host_epair=epair${_num}a
+                        local jail_epair=epair${_num}b
+                    fi
                     break
                 fi
             done
         else
-            local uniq_epair_bridge="0"
+            if [ "$(echo -n "e0a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                local _num=0
+                local host_epair=e${_num}a_${jail_name}
+                local jail_epair=e${_num}b_${jail_name}
+            else
+                local _num=0
+                local host_epair=epair${_num}a
+                local jail_epair=epair${_num}b
+            fi
         fi
     else
-        if [ "${_vnet_if_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${vnet_num_range}"); do
+        if [ "${_bastille_if_count}" -gt 0 ]; then  
+            for _num in $(seq 0 "${bastille_num_range}"); do
                 if ! grep -Eosq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     local uniq_epair="bastille${_num}"
                     break
@@ -253,25 +293,29 @@ generate_vnet_jail_netblock() {
             generate_static_mac "${jail_name}" "${external_interface}"
             cat <<-EOF
   vnet;
-  vnet.interface = epair${uniq_epair_bridge}b;
-  exec.prestart += "ifconfig epair${uniq_epair_bridge} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${uniq_epair_bridge}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a ether ${macaddr}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}b ether ${macaddr}b";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a description \"vnet host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "ifconfig ${external_interface} deletem epair${uniq_epair_bridge}a";
-  exec.poststop += "ifconfig epair${uniq_epair_bridge}a destroy";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "ifconfig epair${_num} create";
+  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
+  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
+  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
+  exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "ifconfig ${external_interface} deletem ${host_epair}";
+  exec.poststop += "ifconfig ${host_epair} destroy";
 EOF
         else
             ## Generate bridged VNET config without static MAC address
             cat <<-EOF
   vnet;
-  vnet.interface = epair${uniq_epair_bridge}b;
-  exec.prestart += "ifconfig epair${uniq_epair_bridge} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${uniq_epair_bridge}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a description \"vnet host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "ifconfig ${external_interface} deletem epair${uniq_epair_bridge}a";
-  exec.poststop += "ifconfig epair${uniq_epair_bridge}a destroy";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "ifconfig epair${_num} create";
+  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
+  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
+  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "ifconfig ${external_interface} deletem ${host_epair}";
+  exec.poststop += "ifconfig ${host_epair} destroy";
 EOF
         fi
     else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -88,7 +88,7 @@ warn() {
 check_target_exists() {
     local _TARGET="${1}"
     local _jaillist="$(bastille list jails)"
-    if ! echo "${_jaillist}" | grep -Eq "^${_TARGET}$"; then
+    if ! echo "${_jaillist}" | grep -Eoq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -97,7 +97,7 @@ check_target_exists() {
 
 check_target_is_running() {
     local _TARGET="${1}"
-    if ! jls name | grep -Eq "^${_TARGET}$"; then
+    if ! jls name | grep -Eoq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -106,7 +106,7 @@ check_target_is_running() {
 
 check_target_is_stopped() {
     local _TARGET="${1}"
-    if jls name | grep -Eq "^${_TARGET}$"; then
+    if jls name | grep -Eoq "^${_TARGET}$"; then
         return 1
     else
         return 0

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -175,6 +175,8 @@ set_target_single() {
     local _status=0
     if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
         error_exit "[all|ALL] not supported with this command."
+    elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
+        error_exit "Error: Command only supports a single TARGET."
     elif echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
         if get_jail_name "${_TARGET}" > /dev/null; then
             _TARGET="$(get_jail_name ${_TARGET})"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -236,8 +236,8 @@ generate_vnet_jail_netblock() {
     local vnet_num_range=$((_vnet_if_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_if_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+            for _num in $(seq 1 "${epair_num_range}"); do
+                if ! grep -osq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     local uniq_epair_bridge="${_num}"
                     break
                 fi
@@ -247,8 +247,8 @@ generate_vnet_jail_netblock() {
         fi
     else
         if [ "${_vnet_if_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${vnet_num_range}"); do
-                if ! grep -Eosq "bastillle${_num}" ${bastille_jailsdir}/*/jail.conf; then
+            for _num in $(seq 1 "${vnet_num_range}"); do
+                if ! grep -osq "bastillle${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -108,7 +108,7 @@ validate_user() {
 }
 
 check_fib() {
-    fib=$(grep 'exec.fib' "${bastille_jailsdir}/${_jail}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
+    fib=$(grep 'exec.fib' "${bastille_jailsdir}/${TARGET}/jail.conf" | awk '{print $3}' | sed 's/\;//g')
         if [ -n "${fib}" ]; then
             _setfib="setfib -F ${fib}"
         else

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -121,6 +121,7 @@ LOGIN="$(jexec -l "${TARGET}" which login)"
 if [ -n "${USER}" ]; then
     validate_user
 else
+    check_fib
     LOGIN="$(jexec -l "${TARGET}" which login)"
     ${_setfib} jexec -l "${TARGET}" $LOGIN -f root
 fi

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -36,7 +36,7 @@ usage() {
     cat << EOF
     Options:
 
-    -a | --auto           Auto mode. Start/stop jail if required.
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
     -x | --debug          Enable debug mode.
 
 EOF

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -36,7 +36,7 @@ usage() {
     cat << EOF
     Options:
 
-    -f | --force          Start the jail if it is stopped.
+    -s | --start          Start the jail if it is stopped.
     -x | --debug          Enable debug mode.
 
 EOF
@@ -44,14 +44,14 @@ EOF
 }
 
 # Handle options.
-FORCE=0
+START=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
             ;;
-        -f|--force)
-            FORCE=1
+        -s|--start)
+            START=1
             shift
             ;;
         -x|--debug)
@@ -59,8 +59,14 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -*)
-            error_notify "Unknown Option: \"${1}\""
-            usage
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    x) enable_debug ;;
+                    s) START=1 ;;
+                    *) error_exit "Unknown Option: \"${1}\"" ;; 
+                esac
+            done
+            shift
             ;;
         *)
             break
@@ -77,11 +83,11 @@ USER="${2}"
 
 bastille_root_check
 set_target_single "${TARGET}"
-check_target_is_running "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+check_target_is_running "${TARGET}" || if [ "${START}" -eq 1 ]; then
     bastille start "${TARGET}"
 else
     error_notify "Jail is not running."
-    error_exit "Use [-f|--force] to force start the jail."
+    error_exit "Use [-s|--start] to force start the jail."
 fi
 
 validate_user() {

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -36,7 +36,7 @@ usage() {
     cat << EOF
     Options:
 
-    -s | --start          Start the jail if it is stopped.
+    -a | --auto           Auto mode. Start/stop jail if required.
     -x | --debug          Enable debug mode.
 
 EOF
@@ -44,14 +44,14 @@ EOF
 }
 
 # Handle options.
-START=0
+AUTO=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
             ;;
-        -s|--start)
-            START=1
+        -a|--auto)
+            AUTO=1
             shift
             ;;
         -x|--debug)
@@ -62,7 +62,7 @@ while [ "$#" -gt 0 ]; do
             for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
                 case ${_opt} in
                     x) enable_debug ;;
-                    s) START=1 ;;
+                    a) AUTO=1 ;;
                     *) error_exit "Unknown Option: \"${1}\"" ;; 
                 esac
             done
@@ -83,11 +83,11 @@ USER="${2}"
 
 bastille_root_check
 set_target_single "${TARGET}"
-check_target_is_running "${TARGET}" || if [ "${START}" -eq 1 ]; then
+check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
     bastille start "${TARGET}"
 else
     error_notify "Jail is not running."
-    error_exit "Use [-s|--start] to force start the jail."
+    error_exit "Use [-a|--auto] to auto-start the jail."
 fi
 
 validate_user() {

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -68,6 +68,8 @@ validate_name() {
         error_exit "Container names may not begin with (-|_) characters!"
     elif [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
         error_exit "Container names may not contain special characters!"
+    elif echo "${NAME_VERIFY}" | grep -qE '^[0-9]+$'; then
+        error_exit "Container names may not contain only numbers."
     fi
 }
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -69,7 +69,7 @@ validate_name() {
     elif [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
         error_exit "Container names may not contain special characters!"
     elif echo "${NAME_VERIFY}" | grep -qE '^[0-9]+$'; then
-        error_exit "Container names may not contain only digits/numerals."
+        error_exit "Container names may not contain only digits."
     fi
 }
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -69,7 +69,7 @@ validate_name() {
     elif [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
         error_exit "Container names may not contain special characters!"
     elif echo "${NAME_VERIFY}" | grep -qE '^[0-9]+$'; then
-        error_exit "Container names may not contain only numbers."
+        error_exit "Container names may not contain only digits/numerals."
     fi
 }
 


### PR DESCRIPTION
This PR does 3 things.

1. Rename two functions inside the main executable to have the suffix _old
- this is because the new functions inside commons.sh are named the same, and since the old ones are only ever called inside the main executable, it is best to rename them for now, for future removal

2. Update common.sh with the new functions which include "set_target_single" "set_target" and others that will be used in the future.

3. Update console command to allow use with JID and jailname autocomplete

And as a treat, adds the "debug mode" function.

@JRGTH can you go over this and see if it will fit current code structure?
@bmac2 

To test
- use the console command with JID or (next for nextcloud) etc...
- if you have more than one jail with next as the prefix, you should get an error, if not, it should simply let you into the jail

Just a quick note. This PR should affect nothing except the console command. Everything else will still use the standard methods of validating jail names, check if running/stopped etc... so shouldn't be too hard to test.