### PR TITLE
config: Correctly match valueless parameters. Fixes #693

### DIFF
--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -136,7 +136,7 @@ for _jail in ${JAILS}; do
         awk -F= -v line="${LINE}" -v property="${PROPERTY}" '
             BEGIN {
                 # build RE as string as we can not expand vars in RE literals
-                prop_re = "^[[:space:]]*" property "[[:space:]]*$";
+                prop_re = "^[[:space:]]*" property "[[:space:]]*;?$";
             }
             $1 ~ prop_re && !found {
                 # we already have an entry in the config for this property so


### PR DESCRIPTION
The current RE does not match valueless parameters properly. For instance, if the jail config file has a single line with `allow.mount;` the field in the AWK program will have the value `allow.mount;`. This is currently not matched due to the trailing `;`. This PR allows for zero or one trailing `;` in the field.

This resolves #693 and https://github.com/BastilleBSD/bastille/pull/702#issuecomment-2230339823