### PR TITLE
mount: allow [ro|rw|rq|sw|xx] as available mount options

### DIFF
--- a/docs/chapters/subcommands/mount.rst
+++ b/docs/chapters/subcommands/mount.rst
@@ -10,7 +10,7 @@ Syntax follows standard `/etc/fstab` format:
 
   Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]
 
-The 'options' string can include a comma-separated list of mount options, but must include at least one of (rw,ro,rq,sw,xx) according to fstab documentation.
+The 'options' string can include a comma-separated list of mount options, but must start with one of (rw,ro,rq,sw,xx) according to fstab documentation.
 
 Example: Mount a tmpfs filesystem with options.
 .. code-block:: shell

--- a/docs/chapters/subcommands/mount.rst
+++ b/docs/chapters/subcommands/mount.rst
@@ -10,7 +10,7 @@ Syntax follows standard `/etc/fstab` format:
 
   Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]
 
-The 'options' string can include a comma-separated list of mount options, but must include at least one of (rw,ro,rq.sw,xx) according to fstab documentation.
+The 'options' string can include a comma-separated list of mount options, but must include at least one of (rw,ro,rq,sw,xx) according to fstab documentation.
 
 Example: Mount a tmpfs filesystem with options.
 .. code-block:: shell

--- a/docs/chapters/subcommands/mount.rst
+++ b/docs/chapters/subcommands/mount.rst
@@ -10,7 +10,7 @@ Syntax follows standard `/etc/fstab` format:
 
   Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]
 
-The 'options' string can include a comma-separated list of mount options, but must start with 'ro' or 'rw'.
+The 'options' string can include a comma-separated list of mount options, but must include at least one of (rw,ro,rq.sw,xx) according to fstab documentation.
 
 Example: Mount a tmpfs filesystem with options.
 .. code-block:: shell

--- a/docs/chapters/subcommands/mount.rst
+++ b/docs/chapters/subcommands/mount.rst
@@ -10,7 +10,7 @@ Syntax follows standard `/etc/fstab` format:
 
   Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]
 
-The 'options' string can include a comma-separated list of mount options, but must start with one of (rw,ro,rq,sw,xx) according to fstab documentation.
+The 'options' string can include a comma-separated list of mount options, but must include one of (rw,ro,rq,sw,xx) according to fstab documentation.
 
 Example: Mount a tmpfs filesystem with options.
 .. code-block:: shell

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -34,14 +34,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille mount [option(s)] TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
-    cat << EOF
-    Options:
-
-    -x | --debug          Enable debug mode.
-
-EOF
-    exit 1
+    error_exit "Usage: bastille mount [option(s)] TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
 }
 
 # Handle options.

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -34,7 +34,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
+    error_notify "Usage: bastille mount [option(s)] TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
     cat << EOF
     Options:
 

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -117,7 +117,7 @@ for _jail in ${JAILS}; do
 
     # Check if mount point has already been added
     _existing_mount="$(echo ${_fullpath_fstab} 2>/dev/null | sed 's#\\#\\\\#g')"
-    if grep -Eq "[[:blank:]]${_existing_mount}.*[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"; then
+    if grep -Eq "[[:blank:]]${_existing_mount}[[:blank:]]" "${bastille_jailsdir}/${_jail}/fstab"; then
         warn "Mountpoint already present in ${bastille_jailsdir}/${_jail}/fstab"
         grep -E "[[:blank:]]${_existing_mount}" "${bastille_jailsdir}/${_jail}/fstab"
         continue

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -47,9 +47,9 @@ EOF
 # Handle options.
 while [ "$#" -gt 0 ]; do
     case "${1}" in
-	    -h|--help|help)
-	        usage
-	        ;;
+        -h|--help|help)
+            usage
+            ;;
         -x|--debug)
             enable_debug
             shift

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -89,8 +89,8 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     usage
 fi
 
-# Mount permissions,options need to include at least one of "ro, rw, rq, sw, xx"
-if ! echo "${_perms}" | grep -Eq '[ro|rw|rq|sw|xx]'; then
+# Mount permissions,options must start with one of "ro, rw, rq, sw, xx"
+if ! echo "${_perms}" | grep -Eq '(ro|rw|rq|sw|xx)(,.*)?$'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -92,7 +92,7 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
 fi
 
 # Mount permissions,options must start with one of "ro, rw, rq, sw, xx"
-if ! echo "${_perms}" | grep -Eq '(ro|rw|rq|sw|xx)(,.*)?$'; then
+if ! echo "${_perms}" | grep -Eq '[ro|rw|rq|sw|xx](,.*)?$'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -89,8 +89,8 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     usage
 fi
 
-# Mount permissions,options need to start with "ro" or "rw"
-if ! echo "${_perms}" | grep -Eq 'r[w|o],.*$'; then
+# Mount permissions,options need to include at least on of "ro, rw, rq, sw, xx"
+if ! echo "${_perms}" | grep -Eq '[ro|rw|rq|sw|xx]'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -34,15 +34,34 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
+    error_notify "Usage: bastille mount TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
+    cat << EOF
+    Options:
+
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
-# Handle special-case commands first.
-case "${1}" in
-    help|-h|--help)
-        usage
-        ;;
-esac
+# Handle options.
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+	    -h|--help|help)
+	        usage
+	        ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*)
+            error_exit "Unknown Option: \"${1}\""
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [ "$#" -lt 3 ] || [ "$#" -gt 7 ]; then
     usage

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -92,7 +92,7 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
 fi
 
 # Mount permissions,options must start with one of "ro, rw, rq, sw, xx"
-if ! echo "${_perms}" | grep -Eq '[ro|rw|rq|sw|xx](,.*)?$'; then
+if ! echo "${_perms}" | grep -Eq '(ro|rw|rq|sw|xx)(,.*)?$'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -50,10 +50,6 @@ while [ "$#" -gt 0 ]; do
         -h|--help|help)
             usage
             ;;
-        -x|--debug)
-            enable_debug
-            shift
-            ;;
         --*|-*)
             error_notify "Unknown Option."
             usage

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -89,7 +89,7 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     usage
 fi
 
-# Mount permissions,options need to include at least on of "ro, rw, rq, sw, xx"
+# Mount permissions,options need to include at least one of "ro, rw, rq, sw, xx"
 if ! echo "${_perms}" | grep -Eq '[ro|rw|rq|sw|xx]'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -110,7 +110,7 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
     usage
 fi
 
-# Mount permissions,options must start with one of "ro, rw, rq, sw, xx"
+# Mount permissions,options must include one of "ro, rw, rq, sw, xx"
 if ! echo "${_perms}" | grep -Eq '(ro|rw|rq|sw|xx)(,.*)?$'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -54,8 +54,9 @@ while [ "$#" -gt 0 ]; do
             enable_debug
             shift
             ;;
-        -*)
-            error_exit "Unknown Option."
+        --*|-*)
+            error_notify "Unknown Option."
+            usage
             ;;
         *)
             break

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -55,7 +55,7 @@ while [ "$#" -gt 0 ]; do
             shift
             ;;
         -*)
-            error_exit "Unknown Option: \"${1}\""
+            error_exit "Unknown Option."
             ;;
         *)
             break


### PR DESCRIPTION
Allow and require at least on of the following strings inside the "options" string of mount.
rw
ro
rq
sw
xx
According to fstab documentation.

Testing
Mount files and directories into jail(s) with different combos of comma separated options, making sure one (and only one) of the above options are also present.

Example `bastille mount jailname /host/path /jail/path nullfs rw,nosuid,mode=01777 0 0` or `bastille mount jailname /host/path /jail/path nullfs nosuid,ro,mode=01777 0 0` 