### PR TITLE
top/htop: update auto-mode and documentation

### DIFF
--- a/docs/chapters/subcommands/htop.rst
+++ b/docs/chapters/subcommands/htop.rst
@@ -2,8 +2,8 @@
 htop
 ====
 
-This one runs `htop` inside the container.
-note: won't work if you don't have htop installed in the container.
+This command runs `htop` in the targeted jail.
+Requires htop to be installed in the jail.
 
 
 .. image:: ../../images/htop.png

--- a/docs/chapters/subcommands/top.rst
+++ b/docs/chapters/subcommands/top.rst
@@ -2,7 +2,7 @@
 top
 ===
 
-This one runs `top` in that container.
+This command runs `top` in the targeted jail.
 
 
 .. image:: ../../images/top.png

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -65,7 +65,7 @@ while [ "$#" -gt 0 ]; do
                 case ${_opt} in
                     a) AUTO=1 ;;
                     x) enable_debug ;;
-                    *) error_exit "Unknown Option: \"${1}\"" ;; 
+                    *) error_exit "Unknown Option: \"${1}\""
                 esac
             done
             shift

--- a/usr/local/share/bastille/top.sh
+++ b/usr/local/share/bastille/top.sh
@@ -38,25 +38,37 @@ usage() {
     cat << EOF
     Options:
 
-    -f | --force -- Start the jail if it is stopped.
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.
 
 EOF
     exit 1
 }
 
 # Handle options.
-FORCE=0
+AUTO=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
             ;;
-        -f|--force)
-            FORCE=1
+        -a|--auto)
+            AUTO=1
+            shift
+            ;;
+        -x|--debug)
+            enable_debug
             shift
             ;;
         -*)
-            error_exit "Unknown option: \"${1}\""
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\"" ;; 
+                esac
+            done
+            shift
             ;;
         *)
             break
@@ -74,10 +86,10 @@ bastille_root_check
 set_target_single "${TARGET}"
 
 info "[${TARGET}]:"
-check_target_is_running "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
     bastille start "${TARGET}"
 else   
     error_notify "Jail is not running."
-    error_continue "Use [-f|--force] to force start the jail."
+    error_continue "Use [-a|--auto] to auto-start the jail."
 fi
 jexec -l "${TARGET}" /usr/bin/top


### PR DESCRIPTION
As per @yaazkal I have update this to now use the new "auto-mode" as opposed to "-f|--force" to auto start the jails if they are stopped.

To test
run htop and top on a running jail to make sure they work.
run htop and top on a stopped jail, using [-a|--auto] to auto-start it.