### PR TITLE
create: Static MAC optional

### DIFF
--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -123,11 +123,11 @@ update_jailconf_vnet() {
                     local _if_vnet="$(grep ${_if_epairb} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
                     sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
                     # If jail had a static MAC, generate one for clone
-                    if grep -oq ether ${JAIL_CONFIG}; then
+                    if grep ether ${JAIL_CONFIG} | grep -qoc epair${uniq_epair_bridge}; then
                         local external_interface="$(grep "epair${uniq_epair_bridge}" ${JAIL_CONFIG} | grep -o '[^ ]* addm' | awk '{print $1}')"
                         generate_static_mac "${NEWNAME}" "${external_interface}"
-                        sed -i '' "s|epair${uniq_epair_bridge}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|epair${uniq_epair_bridge}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|epair${uniq_epair_bridge}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair_bridge}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|epair${uniq_epair_bridge}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair_bridge}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
                     fi
                     sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
                     # Update /etc/rc.conf
@@ -153,7 +153,7 @@ update_jailconf_vnet() {
                     local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
                     sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
                     # If jail had a static MAC, generate one for clone
-                    if grep -oq ether ${JAIL_CONFIG}; then
+                    if grep ether ${JAIL_CONFIG} | grep -qoc ${uniq_epair}; then
                         local external_interface="$(grep ${uniq_epair} ${JAIL_CONFIG} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
                         generate_static_mac "${NEWNAME}" "${external_interface}"
                         sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${JAIL_CONFIG}"
@@ -177,7 +177,6 @@ update_jailconf_vnet() {
         fi
     done
 }
-
 
 update_fstab() {
     # Update fstab to use the new name

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -105,50 +105,79 @@ update_jailconf() {
 
 update_jailconf_vnet() {
     bastille_jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
-
-    # Determine number of containers and define an uniq_epair
-    local list_jails_num="$(bastille list jails | wc -l | awk '{print $1}')"
-    local num_range="$(expr "${list_jails_num}" + 1)"
-    jail_list=$(bastille list jail)
-    for _num in $(seq 0 "${num_range}"); do
-        if [ -n "${jail_list}" ]; then
-            if ! grep -q "e0b_bastille${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                if ! grep -q "epair${_num}" "${bastille_jailsdir}"/*/jail.conf; then
-                    local uniq_epair="bastille${_num}"
+    # Determine number of interfaces and define a uniq_epair
+    local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${JAIL_CONFIG} | sort -u)"
+    for _if in ${_if_list}; do
+        local _epair_if_count="$(grep -Eo 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+        local _bastille_if_count="$(grep -Eo 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+        local epair_num_range=$((_epair_if_count + 1))
+        local bastille_num_range=$((_bastille_if_count + 1))
+        if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
+            # Update bridged VNET config
+            for _num in $(seq 0 "${epair_num_range}"); do
+                if ! grep -oq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                    # Update jail.conf epair name
                     local uniq_epair_bridge="${_num}"
-	            # since we don't have access to the external_interface variable, we cat the jail.conf file to retrieve the mac prefix
-                    # we also do not use the main generate_static_mac function here
+                    local _if_epaira="${_if}a"
+                    local _if_epairb="${_if}b"
+                    local _if_vnet="$(grep ${_if_epairb} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
+                    sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
+                    # If jail had a static MAC, generate one for clone
                     if grep -oq ether ${JAIL_CONFIG}; then
-                        local macaddr_prefix="$(cat ${JAIL_CONFIG} | grep -m 1 ether | grep -oE '([0-9a-f]{2}(:[0-9a-f]{2}){5})' | awk -F: '{print $1":"$2":"$3}')"
-    	                local macaddr_suffix="$(echo -n ${NEWNAME} | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
-                        local macaddr="${macaddr_prefix}:${macaddr_suffix}"
-                        sed -i '' "s|ether.*:.*:.*:.*:.*:.*a\";|ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|ether.*:.*:.*:.*:.*:.*b\";|ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                        local external_interface="$(grep "epair${uniq_epair_bridge}" ${JAIL_CONFIG} | grep -o '[^ ]* addm' | awk '{print $1}')"
+                        generate_static_mac "${NEWNAME}" "${external_interface}"
+                        sed -i '' "s|epair${uniq_epair_bridge}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|epair${uniq_epair_bridge}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
                     fi
-	            # Update the exec.* with uniq_epair when cloning jails.
-                    # for VNET jails
-                    sed -i '' "s|bastille\([0-9]\{1,\}\)|${uniq_epair}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|e\([0-9]\{1,\}\)a_${NEWNAME}|e${uniq_epair_bridge}a_${NEWNAME}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|e\([0-9]\{1,\}\)b_${NEWNAME}|e${uniq_epair_bridge}b_${NEWNAME}|g" "${JAIL_CONFIG}"
-                    sed -i '' "s|epair\([0-9]\{1,\}\)|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-		    sed -i '' "s|exec.prestart += \"ifconfig e0a_bastille\([0-9]\{1,\}\).*description.*|exec.prestart += \"ifconfig e0a_${uniq_epair} description \\\\\"vnet host interface for Bastille jail ${NEWNAME}\\\\\"\";|" "${JAIL_CONFIG}"
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    # Update /etc/rc.conf
+                    sed -i '' "s|${_if_epairb}_name|epair${uniq_epair_bridge}b_name|" "${bastille_jail_rc_conf}"
+                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q "epair${uniq_epair_bridge}b_name"; then
+                        if [ "${IP}" = "0.0.0.0" ]; then
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                        else
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
+                        fi
+                    else
+                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                    fi
                     break
                 fi
-            fi
+            done
+        elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
+            # Update VNET config
+            for _num in $(seq 0 "${bastille_num_range}"); do
+                if ! grep -oq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                    # Update jail.conf epair name
+                    local uniq_epair="bastille${_num}"
+                    local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
+                    sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
+                    # If jail had a static MAC, generate one for clone
+                    if grep -oq ether ${JAIL_CONFIG}; then
+                        local external_interface="$(grep ${uniq_epair} ${JAIL_CONFIG} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
+                        generate_static_mac "${NEWNAME}" "${external_interface}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*b\";|${uniq_epair} ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                    fi
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    # Update /etc/rc.conf
+                    sed -i '' "s|ifconfig_e0b_${_if}_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
+                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q ${uniq_epair}; then
+                        if [ "${IP}" = "0.0.0.0" ]; then
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                        else
+                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0=" inet ${IP} "
+                        fi
+                    else
+                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                    fi
+                    break
+                fi
+            done
         fi
     done
-
-    # Rename interface to new uniq_epair
-    sed -i '' "s|ifconfig_e0b_bastille.*_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-    sed -i '' "s|ifconfig_e.*b_${TARGET}_name|ifconfig_e${uniq_epair_bridge}b_${NEWNAME}_name|" "${bastille_jail_rc_conf}"
-    
-    # If 0.0.0.0 set DHCP, else set static IP address
-    if [ "${IP}" = "0.0.0.0" ]; then
-        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
-    else
-        sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
-    fi
 }
+
 
 update_fstab() {
     # Update fstab to use the new name

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -113,7 +113,7 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
-    local macaddr_prefix="$(echo ${external_interface_mac} | cut -d':' -f1-3)"
+    local macaddr_prefix="58:9c:fc"
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -112,7 +112,7 @@ check_target_is_stopped() {
 generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
-    local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}' | sed 's#:##g')"
+    local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
     local macaddr_prefix="$(echo ${external_interface_mac} | cut -d':' -f1-3)"
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -113,7 +113,9 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
+    # Use the FreeBSD vendor MAC prefix for jail MAC prefix "58:9c:fc"
     local macaddr_prefix="58:9c:fc"
+    # Hash interface+jailname for jail MAC suffix
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -113,8 +113,8 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}' | sed 's#:##g')"
-    local macaddr_prefix="$(echo -n "${external_interface_mac}" | sha256 | cut -b -6 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
-    local macaddr_suffix="$(echo -n "${jail_name}" | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
+    local macaddr_prefix="$(echo ${external_interface_mac} | cut -d':' -f1-3)"
+    local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."
     fi

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -41,12 +41,13 @@ usage() {
     cat << EOF
     Options:
 
-    -E | --empty  -- Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
-    -L | --linux  -- This option is intended for testing with Linux jails, this is considered experimental.
-    -T | --thick  -- Creates a thick container, they consume more space as they are self contained and independent.
-    -V | --vnet   -- Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
-    -C | --clone  -- Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -B | --bridge -- Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    -M | --static-mac  -- Generate a static MAC address for jail (VNET only).
+    -E | --empty       -- Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
+    -L | --linux       -- This option is intended for testing with Linux jails, this is considered experimental.
+    -T | --thick       -- Creates a thick container, they consume more space as they are self contained and independent.
+    -V | --vnet        -- Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
+    -C | --clone       -- Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -B | --bridge      -- Enables VNET, VNET containers are attached to a specified, already existing external bridge.
 
 EOF
     exit 1
@@ -229,7 +230,7 @@ generate_vnet_jail_conf() {
     else
         devfs_ruleset_value=13
     fi
-    NETBLOCK=$(generate_vnet_jail_netblock "$NAME" "${VNET_JAIL_BRIDGE}" "${bastille_jail_conf_interface}")
+    NETBLOCK=$(generate_vnet_jail_netblock "$NAME" "${VNET_JAIL_BRIDGE}" "${bastille_jail_conf_interface}" "${STATIC_MAC}")
     cat << EOF > "${bastille_jail_conf}"
 ${NAME} {
   enforce_statfs = 2;
@@ -630,10 +631,15 @@ THICK_JAIL=""
 CLONE_JAIL=""
 VNET_JAIL=""
 LINUX_JAIL=""
+STATIC_MAC=""
 
 # Handle and parse options
 while [ $# -gt 0 ]; do
     case "${1}" in
+        -M|--static-mac)
+            STATIC_MAC="1"
+            shift
+            ;;
         -E|--empty)
             EMPTY_JAIL="1"
             shift


### PR DESCRIPTION
As per @michael-o I have now modified creating and cloning jails to retain old behavior. It is now required to use "-M|--static-mac" to have a statically assigned MAC address to your jail. MAC will be based on 2 things.
1. The chosen interface's MAC prefix will be the first half.
2. The combination of a hash of "interface+jailname" will be the second half.

If the jail has a statically assigned MAC, then cloning it will also assign a new static MAC to the cloned jail, otherwise, default behavior will persist.

To test this PR here are the steps both for a VNET and bridged-VNET jail.

VNET
1. Create a jail and make sure there is no static MAC
2. Create a jail and use -M to generate a static MAC for it and check jail.conf to ensure it is there and formatted properly
3. Clone both of the above jails, making sure the first does not have a static MAC, and the second jails clone gets one that is different from the original jail

Do the above with VNET jails, then do it with bridged VNET jails. These are the only 2 scenarios that this PR touches.

@yaazkal 
@JRGTH 
@bmac2 