### PR TITLE
template: allow & in arg string

### DIFF
--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -45,8 +45,13 @@ Template Automation Hooks
 | SYSRC   | sysrc command(s)  | nginx_enable=YES                        |
 +---------+-------------------+-----------------------------------------+
 
-Note: SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
+Special Cases
+
+SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
 ie; (`\\"`)
+
+When using an ampersand "\&" in a template hook, and it is to be
+interpreted literally, it must be escaped (`\\&`)
 
 Place these uppercase template hook commands into a `Bastillefile` in any order
 and automate container setup as needed.

--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -45,13 +45,14 @@ Template Automation Hooks
 | SYSRC   | sysrc command(s)  | nginx_enable=YES                        |
 +---------+-------------------+-----------------------------------------+
 
-Special Cases
+Special Hook Cases
+------------------
 
 SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
 ie; (`\\"`)
 
-When using an ampersand "\&" in a template hook, and it is to be
-interpreted literally, it must be escaped (`\\&`)
+ARG requires an ampersand "\&" to be escaped (`\\&`) if it is to be interpreted
+literally, otherwise it is treated as a special character.
 
 Place these uppercase template hook commands into a `Bastillefile` in any order
 and automate container setup as needed.

--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -51,8 +51,8 @@ Special Hook Cases
 SYSRC requires that NO quotes be used or that quotes (`"`) be escaped
 ie; (`\\"`)
 
-ARG requires an ampersand "\&" to be escaped (`\\&`) if it is to be interpreted
-literally, otherwise it is treated as a special character.
+ARG will always treat an ampersand "\&" literally, without the need to escape it.
+Escaping it will cause errors.
 
 Place these uppercase template hook commands into a `Bastillefile` in any order
 and automate container setup as needed.

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ get_arg_name() {
 
 parse_arg_value() {
     # Parses the value after = and then escapes back/forward slashes and single quotes in it. -- cwells
-    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/\\\&/\&/g'
+    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g'
 }
 
 get_arg_value() {

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ get_arg_name() {
 
 parse_arg_value() {
     # Parses the value after = and then escapes back/forward slashes and single quotes in it. -- cwells
-    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g'
+    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g'
 }
 
 get_arg_value() {
@@ -299,7 +299,7 @@ for _jail in ${JAILS}; do
                     ;;
                 cmd)
                     # Escape single-quotes in the command being executed. -- cwells
-                    _args=$(echo "${_args}" | sed "s/'/'\\\\''/g")
+                    _args=$(echo "${_args}" | sed "s/'/'\\\\''/g" | sed 's/&/\\&/g')
                     # Allow redirection within the jail. -- cwells
                     _args="sh -c '${_args}'"
                     ;;

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ get_arg_name() {
 
 parse_arg_value() {
     # Parses the value after = and then escapes back/forward slashes and single quotes in it. -- cwells
-    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g'
+    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/\\\&/\&/g'
 }
 
 get_arg_value() {
@@ -299,7 +299,7 @@ for _jail in ${JAILS}; do
                     ;;
                 cmd)
                     # Escape single-quotes in the command being executed. -- cwells
-                    _args=$(echo "${_args}" | sed "s/'/'\\\\''/g" | sed 's/&/\\&/g')
+                    _args=$(echo "${_args}" | sed "s/'/'\\\\''/g")
                     # Allow redirection within the jail. -- cwells
                     _args="sh -c '${_args}'"
                     ;;


### PR DESCRIPTION
#412 

The PR will make sure the ampersand character is treated literally when used in an arg string.

It fixes #412, but I'm not sure if it will break something else down the road. It shouldn't as it only looks for \& and makes sure it is escaped.

@michael-o 
@tobiastom 