### PR TITLE
update: set -d and -f for release updates and thick jail updates

### DIFF
--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -146,6 +146,7 @@ jail_update() {
 release_update() {
     local _releasepath="${bastille_releasesdir}/${TARGET}"
     local _freebsd_update_conf="${_releasepath}/etc/freebsd-update.conf"
+    local _workdir="${_releasepath}/var/db/freebsd-update"
     # Update a release base(affects child containers)
     if [ -d "${_releasepath}" ]; then
         TARGET_TRIM="${TARGET}"
@@ -155,13 +156,13 @@ release_update() {
         env PAGER="/bin/cat" freebsd-update ${OPTION} \
         --not-running-from-cron \
         -b "${_releasepath}" \
-        -d "${_releasepath}/var/db/freebsd-update" \
+        -d "${_workdir}" \
         -f "${_freebsd_update_conf}" \
         fetch --currently-running "${TARGET_TRIM}"
         env PAGER="/bin/cat" freebsd-update ${OPTION} \
         --not-running-from-cron \
         -b "${_releasepath}" \
-        -d "${_releasepath}/var/db/freebsd-update" \
+        -d "${_workdir}" \
         -f "${_freebsd_update_conf}" \
         install --currently-running "${TARGET_TRIM}"
     else

--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -96,6 +96,9 @@ jail_check() {
 }
 
 jail_update() {
+    local _freebsd_update_conf="${bastille_jailsdir}/${TARGET}/root/etc/freebsd-update.conf"
+    local _jail_dir="${bastille_jailsdir}/${TARGET}/root"
+    local _workdir="${bastille_releasesdir}/${TARGET}/root/var/db/freebsd-update"
     # Update a thick container
     if [ -d "${bastille_jailsdir}/${TARGET}" ]; then
         jail_check    
@@ -103,7 +106,9 @@ jail_update() {
         if [ -z "${CURRENT_VERSION}" ]; then
             error_exit "Can't determine '${TARGET}' version."
         else
-            env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_jailsdir}/${TARGET}/root" \
+            env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${_jail_dir}" \
+            -d "${_workdir}" \
+            -f "${_freebsd_update_conf}" \
             fetch install --currently-running "${CURRENT_VERSION}"
         fi
     else
@@ -112,6 +117,9 @@ jail_update() {
 }
 
 release_update() {
+    local _freebsd_update_conf="${bastille_releasesdir}/${TARGET}/etc/freebsd-update.conf"
+    local _release_dir="${bastille_releasesdir}/${TARGET}"
+    local _workdir="${bastille_releasesdir}/${TARGET}/var/db/freebsd-update"
     # Update a release base(affects child containers)
     if [ -d "${bastille_releasesdir}/${TARGET}" ]; then
         TARGET_TRIM="${TARGET}"
@@ -120,8 +128,12 @@ release_update() {
         fi
 
         env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_releasesdir}/${TARGET}" \
+        -d "${_workdir}" \
+        -f "${_freebsd_update_conf}" \
         fetch --currently-running "${TARGET_TRIM}"
         env PAGER="/bin/cat" freebsd-update ${OPTION} --not-running-from-cron -b "${bastille_releasesdir}/${TARGET}" \
+        -d "${_workdir}" \
+        -f "${_freebsd_update_conf}" \
         install --currently-running "${TARGET_TRIM}"
     else
         error_exit "${TARGET} not found. See 'bastille bootstrap'."


### PR DESCRIPTION
#668
@michael-o This should fix updating a thick jail and also a base release. I have added both "-d" and "-f" to make sure "update_release" and "update_jail" know where they are supposed to set the workdir, basedir, and conf file.

Can you test?

Simply do a `bastille update RELEASE` or `bastille update jail`