### PR TITLE
Please fix regex for fstab hook 

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -92,7 +92,7 @@ elif [ ! -e "${_hostpath}" ] || [ "${_type}" != "nullfs" ]; then
 fi
 
 # Mount permissions,options need to start with "ro" or "rw"
-if ! echo "${_perms}" | grep -Eq 'r[w|o],.*$'; then
+if ! echo "${_perms}" | grep -Eq 'r[w|o](,.*)?$'; then
     error_notify "Detected invalid mount permissions in FSTAB."
     warn "Format: /host/path /jail/path nullfs ro 0 0"
     warn "Read: ${_fstab}"


### PR DESCRIPTION
Commit fb71f0dda55a16e7c26e8f4da055f9896a2f718e introduced to possibility to add options behind permissions
in fstab. Unfortunately it breaks scenarios where no options are provided
as the current regex expects the comma with the options always to be present.

This patch fixes the regex to handle the options as group.