### PR TITLE
bridge: Epair name for ^15 characters

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -164,10 +164,10 @@ version|-v|--version)
 help|-h|--help)
     usage
     ;;
-bootstrap|create|destroy|etcupdate|export|htop|import|list|mount|rdr|restart|setup|start|top|umount|update|upgrade|verify)
+bootstrap|clone|create|destroy|etcupdate|export|htop|import|list|mount|rdr|rename|restart|setup|start|top|umount|update|upgrade|verify)
     # Nothing "extra" to do for these commands. -- cwells
     ;;
-clone|config|cmd|console|convert|cp|edit|limits|pkg|rcp|rename|service|stop|sysrc|tags|template|zfs)
+config|cmd|console|convert|cp|edit|limits|pkg|rcp|service|stop|sysrc|tags|template|zfs)
     # Parse the target and ensure it exists. -- cwells
     if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
         PARAMS='help'

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -215,6 +215,8 @@ update_jailconf_vnet() {
                     sed -i '' "s|= ${_target_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
                     sed -i '' "s|up name ${_target_jail_epair}|up name ${_new_jail_epair}|g" "${_jail_conf}"
                     sed -i '' "s|${_target_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                    # Replace epair name in jail.conf                  
+                    sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
                     # If jail had a static MAC, generate one for clone
                     if grep -q ether ${_jail_conf}; then
                         local external_interface="$(grep "epair${_num}a" ${_jail_conf} | grep -o '[^ ]* addm' | awk '{print $1}')"
@@ -222,8 +224,6 @@ update_jailconf_vnet() {
                         sed -i '' "s|${_new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_host_epair} ether ${macaddr}a\";|" "${_jail_conf}"
                         sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
                     fi
-                    # Replace epair name in jail.conf                  
-                    sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
                     # Replace epair description
                     sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
                     # Update /etc/rc.conf

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -34,24 +34,78 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille clone TARGET NEW_NAME IPADDRESS"
+    error_notify "Usage: bastille clone [option(s)] TARGET NEW_NAME IP_ADDRESS"
+    cat << EOF
+    Options:
+
+    -a | --auto          Auto mode. Start/stop jail(s) if required. Cannot be used with [-l|--live].
+    -l | --live           Clone a running jail. ZFS only. Jail must be running. Cannot be used with [-f|--force].
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
-# Handle special-case commands first
-case "$1" in
-help|-h|--help)
-    usage
-    ;;
-esac
+# Handle options.
+AUTO=0
+LIVE=0
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+        -h|--help|help)
+            usage
+            ;;
+        -a|--auto)
+            AUTO=1
+            shift
+            ;;
+        -l|--live)
+            if ! checkyesno bastille_zfs_enable; then
+                error_exit "[-l|--live] can only be used with ZFS."
+            else
+                LIVE=1
+                shift
+            fi
+            ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*) 
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    l) LIVE=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\""
+                esac
+            done
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
-if [ $# -ne 2 ]; then
+if [ "${AUTO}" -eq 1 ] && [ "${LIVE}" -eq 1 ]; then
+    error_exit "[-a|--auto] cannot be used with [-l|--live]"
+fi
+
+if [ $# -ne 3 ]; then
     usage
 fi
 
-bastille_root_check
+TARGET="${1}"
+NEWNAME="${2}"
+IP="${3}"
 
-NEWNAME="${1}"
-IP="${2}"
+bastille_root_check
+set_target_single "${TARGET}"
+
+## don't allow for dots(.) in container names
+if echo "${NEWNAME}" | grep -q "[.]"; then
+    error_exit "Container names may not contain a dot(.)!"
+fi
 
 validate_ip() {
     IPX_ADDR="ip4.addr"
@@ -89,24 +143,43 @@ update_jailconf() {
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
     if [ -f "${JAIL_CONFIG}" ]; then
         if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${JAIL_CONFIG}"; then
- 	    sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
+            sed -i '' "s|host.hostname = ${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
             sed -i '' "s|exec.consolelog = .*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
             sed -i '' "s|path = .*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
             sed -i '' "s|mount.fstab = .*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
             sed -i '' "s|${TARGET} {|${NEWNAME} {|" "${JAIL_CONFIG}"
-            sed -i '' "s|${IPX_ADDR} = .*;|${IPX_ADDR} = ${IP};|" "${JAIL_CONFIG}"
         fi
     fi
 
     if grep -qw "vnet;" "${JAIL_CONFIG}"; then
         update_jailconf_vnet
+    else
+        _ip4="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"
+        _ip6="$(bastille config ${TARGET} get ip6.addr | sed 's/,/ /g')"
+        # IP4
+        if [ "${_ip4}" != "not set" ]; then
+            for _ip in ${_ip4}; do
+                _ip="$(echo ${_ip} | awk -F"|" '{print $2}')"
+                sed -i '' "/${IPX_ADDR} = .*/ s/${_ip}/${IP}/" "${JAIL_CONFIG}"
+                sed -i '' "/${IPX_ADDR} += .*/ s/${_ip}/127.0.0.1/" "${JAIL_CONFIG}"
+            done
+        fi
+        # IP6
+        if [ "${_ip6}" != "not set" ]; then
+            for _ip in ${_ip6}; do
+                _ip="$(echo ${_ip} | awk -F"|" '{print $2}')"
+                sed -i '' "/${IPX_ADDR} = .*/ s/${_ip}/${IP}/" "${JAIL_CONFIG}"
+                sed -i '' "/${IPX_ADDR} += .*/ s/${_ip}/127.0.0.1/" "${JAIL_CONFIG}"
+            done
+        fi
     fi
 }
 
 update_jailconf_vnet() {
-    bastille_jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
     # Determine number of interfaces and define a uniq_epair
-    local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${JAIL_CONFIG} | sort -u)"
+    local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
     for _if in ${_if_list}; do
         local _epair_if_count="$(grep -Eo 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
         local _bastille_if_count="$(grep -Eo 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
@@ -116,30 +189,53 @@ update_jailconf_vnet() {
             # Update bridged VNET config
             for _num in $(seq 0 "${epair_num_range}"); do
                 if ! grep -oq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
-                    # Update jail.conf epair name
-                    local uniq_epair_bridge="${_num}"
-                    local _if_epaira="${_if}a"
-                    local _if_epairb="${_if}b"
-                    local _if_vnet="$(grep ${_if_epairb} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
-                    sed -i '' "s|${_if}|epair${uniq_epair_bridge}|g" "${JAIL_CONFIG}"
-                    # If jail had a static MAC, generate one for clone
-                    if grep ether ${JAIL_CONFIG} | grep -qoc epair${uniq_epair_bridge}; then
-                        local external_interface="$(grep "epair${uniq_epair_bridge}" ${JAIL_CONFIG} | grep -o '[^ ]* addm' | awk '{print $1}')"
-                        generate_static_mac "${NEWNAME}" "${external_interface}"
-                        sed -i '' "s|epair${uniq_epair_bridge}a ether.*:.*:.*:.*:.*:.*a\";|epair${uniq_epair_bridge}a ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|epair${uniq_epair_bridge}b ether.*:.*:.*:.*:.*:.*b\";|epair${uniq_epair_bridge}b ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                    # Generate new epair name
+                    if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
+                        local _new_host_epair="e${_num}a_${NEWNAME}"
+                        local _new_jail_epair="e${_num}b_${NEWNAME}"
+                    else
+                        local _new_host_epair="epair${_num}a"
+                        local _new_jail_epair="epair${_num}b"
                     fi
-                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    # Get epair name from TARGET
+                    if grep -Eoq "e[0-9]+a_${TARGET}" "${_jail_conf}"; then
+                        _target_host_epair="$(grep -Eo -m 1 "e[0-9]+a_${TARGET}" "${_jail_conf}")"
+                        _target_jail_epair="$(grep -Eo -m 1 "e[0-9]+b_${TARGET}" "${_jail_conf}")"
+                    else
+                        _target_host_epair="${_if}a"
+                        _target_jail_epair="${_if}b"
+                    fi
+                    # Replace epair name in jail.conf                  
+                    sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
+                    # Replace host epair name in jail.conf                  
+                    sed -i '' "s|up name ${_target_host_epair}|up name ${_new_host_epair}|g" "${_jail_conf}"
+                    sed -i '' "s|${_target_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
+                    sed -i '' "s|deletem ${_target_host_epair}|deletem ${_new_host_epair}|g" "${_jail_conf}"
+                    sed -i '' "s|${_target_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
+                    sed -i '' "s|${_target_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+                    # Replace jail epair name in jail.conf
+                    sed -i '' "s|= ${_target_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
+                    sed -i '' "s|up name ${_target_jail_epair}|up name ${_new_jail_epair}|g" "${_jail_conf}"
+                    sed -i '' "s|${_target_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                    # If jail had a static MAC, generate one for clone
+                    if grep -q ether ${_jail_conf}; then
+                        local external_interface="$(grep "${_new_host_epair}" ${_jail_conf} | grep -o '[^ ]* addm' | awk '{print $1}')"
+                        generate_static_mac "${NEWNAME}" "${external_interface}"
+                        sed -i '' "s|${_new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_host_epair} ether ${macaddr}a\";|" "${_jail_conf}"
+                        sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
+                    fi
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
                     # Update /etc/rc.conf
-                    sed -i '' "s|${_if_epairb}_name|epair${uniq_epair_bridge}b_name|" "${bastille_jail_rc_conf}"
-                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q "epair${uniq_epair_bridge}b_name"; then
+                    local _jail_vnet="$(grep ${_target_jail_epair} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
+                    sed -i '' "s|${_target_jail_epair}_name|${_new_jail_epair}_name|" "${_rc_conf}"
+                    if grep "vnet0" "${_rc_conf}" | grep -q "${_new_jail_epair}_name"; then
                         if [ "${IP}" = "0.0.0.0" ]; then
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                            sysrc -f "${_rc_conf}" ifconfig_vnet0="SYNCDHCP"
                         else
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="inet ${IP}"
+                            sysrc -f "${_rc_conf}" ifconfig_vnet0="inet ${IP}"
                         fi
                     else
-                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}="SYNCDHCP"
                     fi
                     break
                 fi
@@ -150,26 +246,26 @@ update_jailconf_vnet() {
                 if ! grep -oq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
-                    local _if_vnet="$(grep ${_if} "${bastille_jail_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
-                    sed -i '' "s|${_if}|${uniq_epair}|g" "${JAIL_CONFIG}"
+                    local _if_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
+                    sed -i '' "s|${_if}|${uniq_epair}|g" "${_jail_conf}"
                     # If jail had a static MAC, generate one for clone
-                    if grep ether ${JAIL_CONFIG} | grep -qoc ${uniq_epair}; then
-                        local external_interface="$(grep ${uniq_epair} ${JAIL_CONFIG} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
+                    if grep ether ${_jail_conf} | grep -qoc ${uniq_epair}; then
+                        local external_interface="$(grep ${uniq_epair} ${_jail_conf} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
                         generate_static_mac "${NEWNAME}" "${external_interface}"
-                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${JAIL_CONFIG}"
-                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*b\";|${uniq_epair} ether ${macaddr}b\";|" "${JAIL_CONFIG}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*a\";|${uniq_epair} ether ${macaddr}a\";|" "${_jail_conf}"
+                        sed -i '' "s|${uniq_epair} ether.*:.*:.*:.*:.*:.*b\";|${uniq_epair} ether ${macaddr}b\";|" "${_jail_conf}"
                     fi
-                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${JAIL_CONFIG}"
+                    sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
                     # Update /etc/rc.conf
-                    sed -i '' "s|ifconfig_e0b_${_if}_name|ifconfig_e0b_${uniq_epair}_name|" "${bastille_jail_rc_conf}"
-                    if grep "vnet0" "${bastille_jail_rc_conf}" | grep -q ${uniq_epair}; then
+                    sed -i '' "s|ifconfig_e0b_${_if}_name|ifconfig_e0b_${uniq_epair}_name|" "${_rc_conf}"
+                    if grep "vnet0" "${_rc_conf}" | grep -q ${uniq_epair}; then
                         if [ "${IP}" = "0.0.0.0" ]; then
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                            sysrc -f "${_rc_conf}" ifconfig_vnet0="SYNCDHCP"
                         else
-                            sysrc -f "${bastille_jail_rc_conf}" ifconfig_vnet0=" inet ${IP} "
+                            sysrc -f "${_rc_conf}" ifconfig_vnet0=" inet ${IP} "
                         fi
                     else
-                        sysrc -f "${bastille_jail_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
+                        sysrc -f "${_rc_conf}" ifconfig_${_if_vnet}="SYNCDHCP"
                     fi
                     break
                 fi
@@ -178,20 +274,21 @@ update_jailconf_vnet() {
     done
 }
 
-update_fstab() {
-    # Update fstab to use the new name
-    FSTAB_CONFIG="${bastille_jailsdir}/${NEWNAME}/fstab"
-    if [ -f "${FSTAB_CONFIG}" ]; then
-        # Update additional fstab paths with new jail path
-        sed -i '' "s|${bastille_jailsdir}/${TARGET}/root/|${bastille_jailsdir}/${NEWNAME}/root/|" "${FSTAB_CONFIG}"
-    fi
-}
-
 clone_jail() {
-    # Attempt container clone
-    info "Attempting to clone '${TARGET}' to ${NEWNAME}..."
+
+    info "Attempting to clone ${TARGET} to ${NEWNAME}..."
+
     if ! [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
         if checkyesno bastille_zfs_enable; then
+            if [ "${LIVE}" -eq 1 ]; then
+                check_target_is_running "${TARGET}" || error_exit "[-l|--live] can only be used with a running jail."
+            else check_target_is_stopped "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+                    bastille stop "${TARGET}"
+                else
+                    error_notify "Jail is running."
+                    error_exit "Use [-f|--force] to force stop the jail, or [-l|--live] (ZFS only) to clone a running jail."
+                fi
+            fi
             if [ -n "${bastille_zfs_zpool}" ]; then
                 # Replicate the existing container
                 DATE=$(date +%F-%H%M%S)
@@ -207,13 +304,13 @@ clone_jail() {
                 zfs destroy "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${NEWNAME}@bastille_clone_${DATE}"
             fi
         else
-            # Just clone the jail directory
-            # Check if container is running
-            if [ -n "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
-                error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
+            # Perform container file copy (archive mode)
+            check_target_is_stopped "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+                bastille stop "${TARGET}"
+            else
+                error_notify "Jail is running."
+                error_exit "Use [-f|--force] to force stop the jail."
             fi
-
-            # Perform container file copy(archive mode)
             cp -a "${bastille_jailsdir}/${TARGET}" "${bastille_jailsdir}/${NEWNAME}"
         fi
     else
@@ -222,7 +319,7 @@ clone_jail() {
 
     # Generate jail configuration files
     update_jailconf
-    update_fstab
+    update_fstab "${TARGET}" "${NEWNAME}"
 
     # Display the exist status
     if [ "$?" -ne 0 ]; then
@@ -230,14 +327,15 @@ clone_jail() {
     else
         info "Cloned '${TARGET}' to '${NEWNAME}' successfully."
     fi
+    if [ "${AUTO}" -eq 1 ]; then
+        if [ "${LIVE}" -eq 0 ]; then
+            bastille start "${TARGET}"
+        fi
+        bastille start "${NEWNAME}"
+    fi
 }
 
-## don't allow for dots(.) in container names
-if echo "${NEWNAME}" | grep -q "[.]"; then
-    error_exit "Container names may not contain a dot(.)!"
-fi
-
-## check if ip address is valid
+# Check if IP address is valid.
 if [ -n "${IP}" ]; then
     validate_ip
 else

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -205,8 +205,6 @@ update_jailconf_vnet() {
                         _target_host_epair="${_if}a"
                         _target_jail_epair="${_if}b"
                     fi
-                    # Replace epair name in jail.conf                  
-                    sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
                     # Replace host epair name in jail.conf                  
                     sed -i '' "s|up name ${_target_host_epair}|up name ${_new_host_epair}|g" "${_jail_conf}"
                     sed -i '' "s|${_target_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
@@ -219,11 +217,14 @@ update_jailconf_vnet() {
                     sed -i '' "s|${_target_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
                     # If jail had a static MAC, generate one for clone
                     if grep -q ether ${_jail_conf}; then
-                        local external_interface="$(grep "${_new_host_epair}" ${_jail_conf} | grep -o '[^ ]* addm' | awk '{print $1}')"
+                        local external_interface="$(grep "epair${_num}a" ${_jail_conf} | grep -o '[^ ]* addm' | awk '{print $1}')"
                         generate_static_mac "${NEWNAME}" "${external_interface}"
                         sed -i '' "s|${_new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_host_epair} ether ${macaddr}a\";|" "${_jail_conf}"
                         sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
                     fi
+                     # Replace epair name in jail.conf                  
+                     sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
+                     # Replace epair description
                     sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
                     # Update /etc/rc.conf
                     local _jail_vnet="$(grep ${_target_jail_epair} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -222,9 +222,9 @@ update_jailconf_vnet() {
                         sed -i '' "s|${_new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_host_epair} ether ${macaddr}a\";|" "${_jail_conf}"
                         sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
                     fi
-                     # Replace epair name in jail.conf                  
-                     sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
-                     # Replace epair description
+                    # Replace epair name in jail.conf                  
+                    sed -i '' "s|${_if}|epair${_num}|g" "${_jail_conf}"
+                    # Replace epair description
                     sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
                     # Update /etc/rc.conf
                     local _jail_vnet="$(grep ${_target_jail_epair} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -181,14 +181,14 @@ update_jailconf_vnet() {
     # Determine number of interfaces and define a uniq_epair
     local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
     for _if in ${_if_list}; do
-        local _epair_if_count="$(grep -Eo 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+        local _epair_if_count="$( (grep -Eo 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf; ifconfig | grep -Eo '(e[0-9]+a|epair[0-9]+a)' ) | sort -u | wc -l | awk '{print $1}')"
         local _bastille_if_count="$(grep -Eo 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
         local epair_num_range=$((_epair_if_count + 1))
         local bastille_num_range=$((_bastille_if_count + 1))
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
             for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -oq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                if ! grep -Eoq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a)"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -305,11 +305,11 @@ clone_jail() {
             fi
         else
             # Perform container file copy (archive mode)
-            check_target_is_stopped "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+            check_target_is_stopped "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
                 bastille stop "${TARGET}"
             else
                 error_notify "Jail is running."
-                error_exit "Use [-f|--force] to force stop the jail."
+                error_exit "Use [-a|--auto] to force stop the jail."
             fi
             cp -a "${bastille_jailsdir}/${TARGET}" "${bastille_jailsdir}/${NEWNAME}"
         fi

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -38,7 +38,7 @@ usage() {
     cat << EOF
     Options:
 
-    -a | --auto          Auto mode. Start/stop jail(s) if required. Cannot be used with [-l|--live].
+    -a | --auto           Auto mode. Start/stop jail(s) if required. Cannot be used with [-l|--live].
     -l | --live           Clone a running jail. ZFS only. Jail must be running. Cannot be used with [-f|--force].
     -x | --debug          Enable debug mode.
 
@@ -282,11 +282,11 @@ clone_jail() {
         if checkyesno bastille_zfs_enable; then
             if [ "${LIVE}" -eq 1 ]; then
                 check_target_is_running "${TARGET}" || error_exit "[-l|--live] can only be used with a running jail."
-            else check_target_is_stopped "${TARGET}" || if [ "${FORCE}" -eq 1 ]; then
+            else check_target_is_stopped "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
                     bastille stop "${TARGET}"
                 else
                     error_notify "Jail is running."
-                    error_exit "Use [-f|--force] to force stop the jail, or [-l|--live] (ZFS only) to clone a running jail."
+                    error_exit "Use [-a|--auto] to force stop the jail, or [-l|--live] (ZFS only) to clone a running jail."
                 fi
             fi
             if [ -n "${bastille_zfs_zpool}" ]; then
@@ -327,10 +327,7 @@ clone_jail() {
     else
         info "Cloned '${TARGET}' to '${NEWNAME}' successfully."
     fi
-    if [ "${AUTO}" -eq 1 ]; then
-        if [ "${LIVE}" -eq 0 ]; then
-            bastille start "${TARGET}"
-        fi
+    if [ "${AUTO}" -eq 1 ] || [ "${LIVE}" -eq 1 ]; then
         bastille start "${NEWNAME}"
     fi
 }

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -228,6 +228,7 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
+    # Use FreeBSD vendor prefix for jail MAC prefix
     local macaddr_prefix="58:9c:fc"
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -228,8 +228,9 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
-    # Use FreeBSD vendor prefix for jail MAC prefix
+    # Use FreeBSD vendor MAC prefix (58:9c:fc) for jail MAC prefix
     local macaddr_prefix="58:9c:fc"
+    # Use hash of interface+jailname for jail MAC suffix
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -247,14 +247,14 @@ generate_vnet_jail_netblock() {
     ## determine number of interfaces + 1
     ## iterate num and grep all jail configs
     ## define uniq_epair
-    local _epair_if_count="$(grep -Eos 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
+    local _epair_if_count="$( (grep -Eos 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf; ifconfig | grep -Eo '(e[0-9]+a|epair[0-9]+a)' ) | sort -u | wc -l | awk '{print $1}')"
     local _bastille_if_count="$(grep -Eos 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
     local epair_num_range=$((_epair_if_count + 1))
     local bastille_num_range=$((_bastille_if_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_if_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a)"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -31,7 +31,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Source config file
-. /usr/local/etc/bastille/bastille.conf
+if [ -f /usr/local/etc/bastille/bastille.conf ]; then
+    . /usr/local/etc/bastille/bastille.conf
+fi
 
 COLOR_RED=
 COLOR_GREEN=
@@ -50,22 +52,28 @@ enable_color() {
     . /usr/local/share/bastille/colors.pre.sh
 }
 
+enable_debug() {
+    # Enable debug mode.
+    warn "***DEBUG MODE***"
+    set -x
+} 
+
 # If "NO_COLOR" environment variable is present, or we aren't speaking to a
 # tty, disable output colors.
 if [ -z "${NO_COLOR}" ] && [ -t 1 ]; then
     enable_color
 fi
 
-# Error/Info functions
-error_notify() {
-    echo -e "${COLOR_RED}$*${COLOR_RESET}" 1>&2
-}
-
+# Notify message on error, and continue to next jail
 error_continue() {
     error_notify "$@"
-    # Disabling this shellcheck as we only ever call it inside of a loop
     # shellcheck disable=SC2104
     continue
+}
+
+# Notify message on error, but do not exit
+error_notify() {
+    echo -e "${COLOR_RED}$*${COLOR_RESET}" 1>&2
 }
 
 # Notify message on error and exit
@@ -84,7 +92,8 @@ warn() {
 
 check_target_exists() {
     local _TARGET="${1}"
-    if [ ! -d "${bastille_jailsdir}"/"${_TARGET}" ]; then
+    local _jaillist="$(bastille list jails)"
+    if ! echo "${_jaillist}" | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -93,7 +102,7 @@ check_target_exists() {
 
 check_target_is_running() {
     local _TARGET="${1}"
-    if [ ! "$(/usr/sbin/jls name | awk "/^${_TARGET}$/")" ]; then
+    if ! jls name | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
@@ -102,10 +111,116 @@ check_target_is_running() {
 
 check_target_is_stopped() {
     local _TARGET="${1}"
-    if [ "$(/usr/sbin/jls name | awk "/^${_TARGET}$/")" ]; then
+    if jls name | grep -Eq "^${_TARGET}$"; then
         return 1
     else
         return 0
+    fi
+}
+
+get_jail_name() {
+    local _JID="${1}"
+    local _jailname="$(jls -j ${_JID} name 2>/dev/null)"
+    if [ -z "${_jailname}" ]; then
+        return 1
+    else
+        echo "${_jailname}"
+    fi
+}
+
+jail_autocomplete() {
+    local _TARGET="${1}"
+    local _jaillist="$(bastille list jails)"
+    local _AUTOTARGET="$(echo "${_jaillist}" | grep -E "^${_TARGET}")"
+    if [ -n "${_AUTOTARGET}" ]; then
+        if [ "$(echo "${_AUTOTARGET}" | wc -l)" -eq 1 ]; then
+            echo "${_AUTOTARGET}"
+        else
+            error_continue "Multiple jails found for ${_TARGET}:\n${_AUTOTARGET}"
+            return 1
+        fi
+    else
+        return 2
+    fi
+}
+
+set_target() {
+    local _TARGET=${1}
+    JAILS=""
+    TARGET=""
+    if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
+        target_all_jails
+    else
+        for _jail in ${_TARGET}; do
+            if [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_jail}" | grep -Eq '^[0-9]+$'; then
+                if get_jail_name "${_jail}" > /dev/null; then
+                    _jail="$(get_jail_name ${_jail})"
+                else
+                    error_continue "Error: JID \"${_jail}\" not found. Is jail running?"
+                fi
+            elif ! check_target_exists "${_jail}"; then
+                if jail_autocomplete "${_jail}" > /dev/null; then
+                    _jail="$(jail_autocomplete ${_jail})"
+                elif [ $? -eq 2 ]; then
+                    error_continue "Jail not found \"${_jail}\""
+                else
+                    exit 1
+                fi
+            fi
+            TARGET="${TARGET} ${_jail}"
+            JAILS="${JAILS} ${_jail}"
+        done
+        export TARGET
+        export JAILS
+    fi
+}
+
+set_target_single() {
+    local _TARGET="${1}"
+    if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
+        error_exit "[all|ALL] not supported with this command."
+    elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
+        error_exit "Error: Command only supports a single TARGET."
+    elif [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
+        if get_jail_name "${_TARGET}" > /dev/null; then
+            _TARGET="$(get_jail_name ${_TARGET})"
+        else
+            error_exit "Error: JID \"${_TARGET}\" not found. Is jail running?"
+        fi
+    elif ! check_target_exists "${_TARGET}"; then
+            if jail_autocomplete "${_TARGET}" > /dev/null; then
+                _TARGET="$(jail_autocomplete ${_TARGET})"
+            elif [ $? -eq 2 ]; then
+                error_exit "Jail not found \"${_TARGET}\""
+            else
+                exit 1
+            fi
+    fi
+    TARGET="${_TARGET}"
+    JAILS="${_TARGET}"
+    export TARGET
+    export JAILS
+}
+
+target_all_jails() {
+    local _JAILS="$(bastille list jails)"
+    JAILS=""
+    for _jail in ${_JAILS}; do
+        if [ -d "${bastille_jailsdir}/${_jail}" ]; then
+            JAILS="${JAILS} ${_jail}"
+        fi
+    done
+    export JAILS
+}
+
+update_fstab() {
+    local _oldname="${1}"
+    local _newname="${2}"
+    local _fstab="${bastille_jailsdir}/${_newname}/fstab"
+    if [ -f "${_fstab}" ]; then
+        sed -i '' "s|${bastille_jailsdir}/${_oldname}/root/|${bastille_jailsdir}/${_newname}/root/|" "${_fstab}"
+    else
+        error_notify "Error: Failed to update fstab: ${_newmane}"
     fi
 }
 
@@ -113,9 +228,7 @@ generate_static_mac() {
     local jail_name="${1}"
     local external_interface="${2}"
     local external_interface_mac="$(ifconfig ${external_interface} | grep ether | awk '{print $2}')"
-    # Use the FreeBSD vendor MAC prefix for jail MAC prefix "58:9c:fc"
     local macaddr_prefix="58:9c:fc"
-    # Hash interface+jailname for jail MAC suffix
     local macaddr_suffix="$(echo -n "${external_interface_mac}${jail_name}" | sed 's#:##g' | sha256 | cut -b -5 | sed 's/\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F][0-9a-fA-F]\)\([0-9a-fA-F]\)/\1:\2:\3/')"
     if [ -z "${macaddr_prefix}" ] || [ -z "${macaddr_suffix}" ]; then
         error_notify "Failed to generate MAC address."
@@ -140,12 +253,26 @@ generate_vnet_jail_netblock() {
         if [ "${_epair_if_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${epair_num_range}"); do
                 if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf; then
-                    local uniq_epair_bridge="${_num}"
+                    if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                        local host_epair=e${_num}a_${jail_name}
+                        local jail_epair=e${_num}b_${jail_name}
+                    else
+                        local host_epair=epair${_num}a
+                        local jail_epair=epair${_num}b
+                    fi
                     break
                 fi
             done
         else
-            local uniq_epair_bridge="0"
+            if [ "$(echo -n "e0a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                local _num=0
+                local host_epair=e${_num}a_${jail_name}
+                local jail_epair=e${_num}b_${jail_name}
+            else
+                local _num=0
+                local host_epair=epair${_num}a
+                local jail_epair=epair${_num}b
+            fi
         fi
     else
         if [ "${_bastille_if_count}" -gt 0 ]; then  
@@ -166,25 +293,29 @@ generate_vnet_jail_netblock() {
             generate_static_mac "${jail_name}" "${external_interface}"
             cat <<-EOF
   vnet;
-  vnet.interface = epair${uniq_epair_bridge}b;
-  exec.prestart += "ifconfig epair${uniq_epair_bridge} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${uniq_epair_bridge}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a ether ${macaddr}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}b ether ${macaddr}b";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a description \"vnet host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "ifconfig ${external_interface} deletem epair${uniq_epair_bridge}a";
-  exec.poststop += "ifconfig epair${uniq_epair_bridge}a destroy";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "ifconfig epair${_num} create";
+  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
+  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
+  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
+  exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "ifconfig ${external_interface} deletem ${host_epair}";
+  exec.poststop += "ifconfig ${host_epair} destroy";
 EOF
         else
             ## Generate bridged VNET config without static MAC address
             cat <<-EOF
   vnet;
-  vnet.interface = epair${uniq_epair_bridge}b;
-  exec.prestart += "ifconfig epair${uniq_epair_bridge} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${uniq_epair_bridge}a";
-  exec.prestart += "ifconfig epair${uniq_epair_bridge}a description \"vnet host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "ifconfig ${external_interface} deletem epair${uniq_epair_bridge}a";
-  exec.poststop += "ifconfig epair${uniq_epair_bridge}a destroy";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "ifconfig epair${_num} create";
+  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
+  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
+  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "ifconfig ${external_interface} deletem ${host_epair}";
+  exec.poststop += "ifconfig ${host_epair} destroy";
 EOF
         fi
     else
@@ -213,58 +344,6 @@ EOF
     fi
 }
 
-set_target() {
-    local _TARGET="${1}"
-    if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
-        target_all_jails
-    else
-        check_target_exists "${_TARGET}" || error_exit "Jail not found \"${_TARGET}\""
-        JAILS="${_TARGET}"
-        TARGET="${_TARGET}"
-        export JAILS
-        export TARGET
-    fi
-}
-
-set_target_single() {
-    local _TARGET="${1}"
-    if [ "${_TARGET}" = ALL ] || [ "${_TARGET}" = all ]; then
-        error_exit "[all|ALL] not supported with this command."
-    elif [ "$(echo ${_TARGET} | wc -w)" -gt 1 ]; then
-        error_exit "Error: Command only supports a single TARGET."
-    elif echo "${_TARGET}" | grep -Eq '^[0-9]+$'; then
-        if get_jail_name "${_TARGET}" > /dev/null; then
-            _TARGET="$(get_jail_name ${_TARGET})"
-        else
-            error_exit "Error: JID \"${_TARGET}\" not found. Is jail running?"
-        fi
-    elif
-        ! check_target_exists "${_TARGET}"; then
-            if jail_autocomplete "${_TARGET}" > /dev/null; then
-                _TARGET="$(jail_autocomplete ${_TARGET})"
-            elif [ $? -eq 2 ]; then
-                error_exit "Jail not found \"${_TARGET}\""
-            else
-                exit 1
-            fi
-    fi
-    TARGET="${_TARGET}"
-    JAILS="${_TARGET}"
-    export TARGET
-    export JAILS
-}
-
-target_all_jails() {
-    local _JAILS="$(bastille list jails)"
-    JAILS=""
-    for _jail in ${_JAILS}; do
-        if [ -d "${bastille_jailsdir}/${_jail}" ]; then
-            JAILS="${JAILS} ${_jail}"
-        fi
-    done
-    export JAILS
-}
-
 checkyesno() {
     ## copied from /etc/rc.subr -- cedwards (20231125)
     ## issue #368 (lowercase values should be parsed)
@@ -285,4 +364,3 @@ checkyesno() {
         ;;
     esac
 }
-

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 #
-# SPDX-License-Identifier: BSD-3-Clause
-#
-# Copyright (c) 2018-2025, Christer Edwards <christer.edwards@gmail.com>
+# Copyright (c) 2018-2024, Christer Edwards <christer.edwards@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,11 +32,62 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille rename TARGET NEW_NAME"
+    error_notify "Usage: bastille rename [option(s)] TARGET NEW_NAME"
+    cat << EOF
+    Options:
+
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
+# Handle options.
+AUTO=0
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+        -h|--help|help)
+            usage
+            ;;
+        -a|--auto)
+            AUTO=1
+            shift
+            ;;
+        -*) 
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\""
+                esac
+            done
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ "$#" -ne 2 ]; then
+    usage
+fi
+
+TARGET="${1}"
+NEWNAME="${2}"
+
+bastille_root_check
+set_target_single "${TARGET}"
+check_target_is_stopped "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
+    bastille stop "${TARGET}"
+else   
+    error_notify "Jail is running."
+    error_exit "Use [-a|--auto] to auto-stop the jail."
+fi
+
 validate_name() {
-    local NAME_VERIFY=${NEWNAME}
+    local NAME_VERIFY="${NEWNAME}"
     local NAME_SANITY="$(echo "${NAME_VERIFY}" | tr -c -d 'a-zA-Z0-9-_')"
     if [ -n "$(echo "${NAME_SANITY}" | awk "/^[-_].*$/" )" ]; then
         error_exit "Container names may not begin with (-|_) characters!"
@@ -47,44 +96,64 @@ validate_name() {
     fi
 }
 
-# Handle special-case commands first
-case "$1" in
-help|-h|--help)
-    usage
-    ;;
-esac
-
-if [ $# -ne 1 ]; then
-    usage
-fi
-
-bastille_root_check
-
-NEWNAME="${1}"
-
 update_jailconf() {
     # Update jail.conf
-    JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
-    if [ -f "${JAIL_CONFIG}" ]; then
-        if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${JAIL_CONFIG}"; then
-            sed -i '' "s|host.hostname.*=.*${TARGET};|host.hostname = ${NEWNAME};|" "${JAIL_CONFIG}"
-            sed -i '' "s|exec.consolelog.*=.*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${JAIL_CONFIG}"
-            sed -i '' "s|path.*=.*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${JAIL_CONFIG}"
-            sed -i '' "s|mount.fstab.*=.*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${JAIL_CONFIG}"
-            sed -i '' "s|${TARGET}.*{|${NEWNAME} {|" "${JAIL_CONFIG}"
-            # Rename vnet interface
-            sed -i '' "/vnet.interface/s|_${TARGET}\";|_${NEWNAME}\";|" "${JAIL_CONFIG}"
-            sed -i '' "/ifconfig/s|_${TARGET}|_${NEWNAME}|" "${JAIL_CONFIG}"
+    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    if [ -f "${_jail_conf}" ]; then
+        if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${_jail_conf}"; then
+            sed -i '' "s|host.hostname.*=.*${TARGET};|host.hostname = ${NEWNAME};|" "${_jail_conf}"
+            sed -i '' "s|exec.consolelog.*=.*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${_jail_conf}"
+            sed -i '' "s|path.*=.*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${_jail_conf}"
+            sed -i '' "s|mount.fstab.*=.*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${_jail_conf}"
+            sed -i '' "s|${TARGET}.*{|${NEWNAME} {|" "${_jail_conf}"
+        fi
+        if grep -qo "vnet;" "${_jail_conf}"; then
+            update_jailconf_vnet
         fi
     fi
 }
 
-update_fstab() {
-    # Update fstab to use the new name
-    FSTAB_CONFIG="${bastille_jailsdir}/${NEWNAME}/fstab"
-    if [ -f "${FSTAB_CONFIG}" ]; then
-        sed -i '' "s|${bastille_jailsdir}/${TARGET}|${bastille_jailsdir}/${NEWNAME}|g" "${FSTAB_CONFIG}"
-    fi
+update_jailconf_vnet() {
+    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    # Change epair name (if needed)
+    local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
+    for _if in ${_if_list}; do
+        if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
+            # Check if epair name = jail name
+            local _epair_num="$(grep -Eo -m 1 "epair[0-9]+" "${_jail_conf}" | grep -Eo "[0-9]+")" 
+            if grep -E "epair[0-9]+a" "${_jail_conf}" | grep -Eo "e[0-9]+a_${TARGET}"; then
+                local _target_host_epair="$(grep -Eo -m 1 "e[0-9]+a_${TARGET}" "${_jail_conf}")"
+                local _target_jail_epair="$(grep -Eo -m 1 "e[0-9]+b_${TARGET}" "${_jail_conf}")"
+            else
+                local _target_host_epair="$(grep -Eo -m 1 "epair[0-9]+a" "${_jail_conf}")"
+                local _target_jail_epair="$(grep -Eo -m 1 "epair[0-9]+b" "${_jail_conf}")"
+            fi
+            if [ "$(echo -n "e${_epair_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
+                # Generate new epair name
+                local _new_host_epair="e${_epair_num}a_${NEWNAME}"
+                local _new_jail_epair="e${_epair_num}b_${NEWNAME}"
+            else
+                local _new_host_epair="epair${_epair_num}a"
+                local _new_jail_epair="epair${_epair_num}b"
+            fi
+            # Replace host epair name in jail.conf                  
+            sed -i '' "s|up name ${_target_host_epair}|up name ${_new_host_epair}|g" "${_jail_conf}"
+            sed -i '' "s|${_target_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
+            sed -i '' "s|deletem ${_target_host_epair}|deletem ${_new_host_epair}|g" "${_jail_conf}"
+            sed -i '' "s|${_target_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
+            sed -i '' "s|${_target_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+            # Replace jail epair name in jail.conf
+            sed -i '' "s|= ${_target_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
+            sed -i '' "s|up name ${_target_jail_epair}|up name ${_new_jail_epair}|g" "${_jail_conf}"
+            sed -i '' "s|${_target_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+            # Replace epair description
+            sed -i '' "s|vnet host interface for Bastille jail ${TARGET}|vnet host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+            # Replace epair name in /etc/rc.conf
+            sed -i '' "/ifconfig/ s|${_target_jail_epair}|${_new_jail_epair}|g" "${_rc_conf}"
+        fi
+    done
 }
 
 change_name() {
@@ -124,24 +193,27 @@ change_name() {
         fi
     fi
 
-    # Update jail configuration files accordingly
+    # Update jail conf files
     update_jailconf
-    update_fstab
+    update_fstab "${TARGET}" "${NEWNAME}"
 
     # Check exit status and notify
     if [ "$?" -ne 0 ]; then
         error_exit "An error has occurred while attempting to rename '${TARGET}'."
     else
         info "Renamed '${TARGET}' to '${NEWNAME}' successfully."
+        if [ "${AUTO}" -eq 1 ]; then
+            bastille start "${NEWNAME}"
+        fi
     fi
 }
 
-## validate jail name
+# Validate NEW_NAME
 if [ -n "${NEWNAME}" ]; then
     validate_name
 fi
 
-## check if a jail already exists with the new name
+# Check if a jail already exists with NEW_NAME
 if [ -d "${bastille_jailsdir}/${NEWNAME}" ]; then
     error_exit "Jail: ${NEWNAME} already exists."
 fi


### PR DESCRIPTION
#786

Allow bridged-VNET interface to work when interface name exceeds 15 characters. This is done by using "epairX" as the name instead of "eXa_jailname" in such cases.

Testing (all with bridged VNET, nothing else should be affected)

1. Create jail called test, rename to test1, validate jail.conf, rc.conf, and networking

2. Create jail called test, rename to testtesttesttest, validate jail.conf, rc.conf, and networking

3. Create jail called testtesttesttest, rename to test1, validate jail.conf, rc.conf, and networking

4. Create jail called testtesttesttest, rename to testing12345678, validate jail.conf, rc.conf, and networking

The purpose of the above is to validate all use cases (short name to short and long name, and long name to short and long name)

5. Do all of the above with "clone" also.

You should find that anytime the new name exceeds 15 characters (plus the interface prefix of eXa_) it will be named "epairXa epairXb" but anytime is is shorter, the current default naming applies.