### PR TITLE
Add auto-mode and debug mode to mount and umount

### DIFF
--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -34,18 +34,41 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille mount [option(s)] TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
+    error_notify "Usage: bastille mount [option(s)] TARGET HOST_PATH JAIL_PATH [filesystem_type options dump pass_number]"
+    cat << EOF
+    Options:
+
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
 # Handle options.
+AUTO=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
             ;;
-        --*|-*)
-            error_notify "Unknown Option."
-            usage
+        -a|--auto)
+            AUTO=1
+            shift
+            ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*)
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\""
+                esac
+            done
+            shift
             ;;
         *)
             break
@@ -119,6 +142,13 @@ fi
 for _jail in ${JAILS}; do
 
     info "[${_jail}]:"
+
+    check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${TARGET}"
+    else
+        error_notify "Jail is not running."
+        error_exit "Use [-a|--auto] to auto-start the jail."
+    fi
 
     _fullpath_fstab="$( echo "${bastille_jailsdir}/${_jail}/root/${_jailpath_fstab}" 2>/dev/null | sed 's#//#/#' )"
     _fullpath="$( echo "${bastille_jailsdir}/${_jail}/root/${_jailpath}" 2>/dev/null | sed 's#//#/#' )"

--- a/usr/local/share/bastille/mount.sh
+++ b/usr/local/share/bastille/mount.sh
@@ -143,8 +143,8 @@ for _jail in ${JAILS}; do
 
     info "[${_jail}]:"
 
-    check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
-        bastille start "${TARGET}"
+    check_target_is_running "${_jail}" || if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${_jail}"
     else
         error_notify "Jail is not running."
         error_exit "Use [-a|--auto] to auto-start the jail."

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -34,15 +34,47 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_exit "Usage: bastille umount TARGET JAIL_PATH"
+    error_notify "Usage: bastille umount [option(s)] TARGET JAIL_PATH"
+    cat << EOF
+    Options:
+
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
-# Handle special-case commands first.
-case "${1}" in
-    help|-h|--help)
-        usage
-        ;;
-esac
+# Handle options.
+AUTO=0
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+        -h|--help|help)
+            usage
+            ;;
+        -a|--auto)
+            AUTO=1
+            shift
+            ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*)
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\""
+                esac
+            done
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [ "$#" -ne 2 ]; then
     usage
@@ -57,6 +89,13 @@ set_target "${TARGET}"
 for _jail in ${JAILS}; do
 
     info "[${_jail}]:"
+
+    check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${TARGET}"
+    else
+        error_notify "Jail is not running."
+        error_exit "Use [-a|--auto] to auto-start the jail."
+    fi
 
     _jailpath="$( echo "${bastille_jailsdir}/${_jail}/root/${MOUNT_PATH}" 2>/dev/null | sed 's#//#/#' | sed 's#\\##g')"
     _mount="$( mount | grep -Eo "[[:blank:]]${_jailpath}[[:blank:]]" )"

--- a/usr/local/share/bastille/umount.sh
+++ b/usr/local/share/bastille/umount.sh
@@ -90,8 +90,8 @@ for _jail in ${JAILS}; do
 
     info "[${_jail}]:"
 
-    check_target_is_running "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
-        bastille start "${TARGET}"
+    check_target_is_running "${_jail}" || if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${_jail}"
     else
         error_notify "Jail is not running."
         error_exit "Use [-a|--auto] to auto-start the jail."


### PR DESCRIPTION
This is because if you try to mount and umount while the jail is stopped, you will then run into all sorts of issues when trying to start it because the mount points will already be mounted.

This PR will require the jail to be running when doing mounting and unmounting.

Testing-
Mount and unmount files/directories while jail is stopped. you should find that it will error unless you add "-a" to auto start the jail before attempting the mount.