### PR TITLE
Fixed rdr rule directive error when a jail has both ipv4 and ipv6 addresses

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -122,7 +122,7 @@ load_rdr_rule() {
       | pfctl -a "rdr/${JAIL_NAME}" -f-
 if [ -n "$JAIL_IP6" ]; then
   ( pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null;
-  printf '%s\nrdr pass on $%s inet proto %s to port %s -> %s port %s\n' "$EXT_IF" "${bastille_network_pf_ext_if}" "$1" "$2" "$JAIL_IP6" "$3" ) \
+  printf '%s\nrdr pass on $%s inet6 proto %s to port %s -> %s port %s\n' "$EXT_IF" "${bastille_network_pf_ext_if}" "$1" "$2" "$JAIL_IP6" "$3" ) \
     | pfctl -a "rdr/${JAIL_NAME}" -f-
 fi
 }
@@ -137,7 +137,7 @@ log=$@
       | pfctl -a "rdr/${JAIL_NAME}" -f-
 if [ -n "$JAIL_IP6" ]; then
   ( pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null;
-  printf '%s\nrdr pass %s on $%s inet proto %s to port %s -> %s port %s\n' "$EXT_IF" "$log" "${bastille_network_pf_ext_if}" "$proto" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+  printf '%s\nrdr pass %s on $%s inet6 proto %s to port %s -> %s port %s\n' "$EXT_IF" "$log" "${bastille_network_pf_ext_if}" "$proto" "$host_port" "$JAIL_IP6" "$jail_port" ) \
     | pfctl -a "rdr/${JAIL_NAME}" -f-
 fi
 


### PR DESCRIPTION

When a jail has both an ipv4 and ipv6 address, the PF ``rdr`` directive needs to differentiate between ``inet`` and ``inet6`` address families; otherwise, the firewall rule for the ipv6 interface will fail to load on starting the jail:

```
stdin:3: no translation address with matching address family found.
pfctl: Syntax error in config file: pf rules not loaded
```

This change changes the address family for ipv6 addresses from ``inet`` to ``inet6``. Specifications for ipv4 addresses are unchanged.