### PR TITLE
template: Fix default value with spaces

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ get_arg_name() {
 
 parse_arg_value() {
     # Parses the value after = and then escapes back/forward slashes and single quotes in it. -- cwells
-    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g'
+    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g' -e 's/""/"/g'
 }
 
 get_arg_value() {

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -54,7 +54,7 @@ get_arg_name() {
 
 parse_arg_value() {
     # Parses the value after = and then escapes back/forward slashes and single quotes in it. -- cwells
-    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g' -e 's/""/"/g'
+    echo "${1}" | sed -E 's/[^=]+=?//' | sed -e 's/\\/\\\\/g' -e 's/\//\\\//g' -e 's/'\''/'\''\\'\'\''/g' -e 's/&/\\&/g' -e 's/"//g'
 }
 
 get_arg_value() {


### PR DESCRIPTION
#692 
@michael-o 

This essentially just makes sure there are not multiple quotes following each other inside the ARG value.

```
root@dev1:~ # bastille template test sample/top --arg SEARCH_DOMAINS="soo boo doo"
[test]:
Applying template: sample/top...
[test]:
soo boo doo
[test]: 0

[test]:
Applying template: sample/bottom...
[test]:
soo boo doo
[test]: 0

Template applied: sample/bottom

Template applied: sample/top

root@dev1:~ # bastille template test sample/top
[test]:
Applying template: sample/top...
[test]:
foo bar
[test]: 0

[test]:
Applying template: sample/bottom...
[test]:
foo bar
[test]: 0

Template applied: sample/bottom

Template applied: sample/top
```