### PR TITLE
Let jails ip4.addr be added to pf jails table if it isn't local to any interface

### DIFF
--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -89,7 +89,6 @@ for _jail in ${JAILS}; do
             fi
             ## add ip4.addr to firewall table if its using the loop back interface
             if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-                info "Adding ${_ip4} to pf table ${bastille_network_pf_table}"
                 pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
  	    fi
         fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -87,10 +87,14 @@ for _jail in ${JAILS}; do
                 error_notify "Error: IP address (${_ip4}) already in use."
                 continue
             fi
-            ## add ip4.addr to firewall table if its using the loop back interface
-            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
-                pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
- 	    fi
+            ## add ip4.addr to firewall table if pfctl is installed, pf table is available and
+            ## the ip4.addr is not reachable trough local interface (assumes NAT/rdr is needed)
+            if [ "${bastille_network_pf_table}X" != "X" ] && \
+                [ -x /sbin/pfctl ] && pfctl -s Tables | grep "${bastille_network_pf_table}" >/dev/null ; then 
+                    if route -n get ${_ip4} | grep "gateway" >/dev/null; then
+                        pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
+                    fi
+            fi
         fi
 
         ## start the container

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -87,13 +87,9 @@ for _jail in ${JAILS}; do
                 error_notify "Error: IP address (${_ip4}) already in use."
                 continue
             fi
-            ## add ip4.addr to firewall table if pfctl is installed, pf table is available and
-            ## the ip4.addr is not reachable trough local interface (assumes NAT/rdr is needed)
+            ## add ip4.addr to firewall table if the ip4.addr is not reachable trough local interface (assumes NAT/rdr is needed)
             if route -n get ${_ip4} | grep "gateway" >/dev/null; then
-                if [ "${bastille_network_pf_table}X" != "X" ] && \
-                  [ -x /sbin/pfctl ] && pfctl -s Tables | grep "${bastille_network_pf_table}" >/dev/null ; then 
-                        pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
-                fi
+                pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
             fi
         fi
 

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -87,8 +87,11 @@ for _jail in ${JAILS}; do
                 error_notify "Error: IP address (${_ip4}) already in use."
                 continue
             fi
-            ## add ip4.addr to firewall table
-            pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
+            ## add ip4.addr to firewall table if its using the loop back interface
+            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
+                info "Adding ${_ip4} to pf table ${bastille_network_pf_table}"
+                pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
+ 	    fi
         fi
 
         ## start the container

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -89,11 +89,11 @@ for _jail in ${JAILS}; do
             fi
             ## add ip4.addr to firewall table if pfctl is installed, pf table is available and
             ## the ip4.addr is not reachable trough local interface (assumes NAT/rdr is needed)
-            if [ "${bastille_network_pf_table}X" != "X" ] && \
-                [ -x /sbin/pfctl ] && pfctl -s Tables | grep "${bastille_network_pf_table}" >/dev/null ; then 
-                    if route -n get ${_ip4} | grep "gateway" >/dev/null; then
+            if route -n get ${_ip4} | grep "gateway" >/dev/null; then
+                if [ "${bastille_network_pf_table}X" != "X" ] && \
+                  [ -x /sbin/pfctl ] && pfctl -s Tables | grep "${bastille_network_pf_table}" >/dev/null ; then 
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${_ip4}"
-                    fi
+                fi
             fi
         fi
 

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -75,8 +75,7 @@ for _jail in ${JAILS}; do
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r "${_jail}"
 
         ## remove (captured above) ip4.addr from firewall table
-        if [ "${_ip4}" != "not set" ] && [ "${bastille_network_pf_table}X" != "X" ] && \
-            [ -x /sbin/pfctl ] && pfctl -t "${bastille_network_pf_table}" -T show | grep "${_ip4}" >/dev/null; then
+        if [ "${_ip4}" != "not set" ]; then
                 pfctl -q -t "${bastille_network_pf_table}" -T delete "${_ip4}"
         fi
     fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -75,10 +75,9 @@ for _jail in ${JAILS}; do
         jail -f "${bastille_jailsdir}/${_jail}/jail.conf" -r "${_jail}"
 
         ## remove (captured above) ip4.addr from firewall table
-        if [ -n "${bastille_network_loopback}" ] && [ "${_ip4}" != "not set" ]; then
-            if grep -qw "interface.*=.*${bastille_network_loopback}" "${bastille_jailsdir}/${_jail}/jail.conf"; then
+        if [ "${_ip4}" != "not set" ] && [ "${bastille_network_pf_table}X" != "X" ] && \
+            [ -x /sbin/pfctl ] && pfctl -t "${bastille_network_pf_table}" -T show | grep "${_ip4}" >/dev/null; then
                 pfctl -q -t "${bastille_network_pf_table}" -T delete "${_ip4}"
-            fi
         fi
     fi
     echo


### PR DESCRIPTION
#841
I added the same check that is present in stop.sh, but could just as well be:
`if [ $(bastille config "${_jail}" get interface) == ${bastille_network_loopback} ]; then`

