### PR TITLE
Add an option to invoke a startup delay between starting each jail

### DIFF
--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -32,6 +32,7 @@ rcvar=${name}_enable
 : ${bastille_conf:="/usr/local/etc/bastille/bastille.conf"}
 : ${bastille_list:="ALL"}
 : ${bastille_rcorder:="NO"}
+: ${bastille_startup_delay:=0}
 
 command=/usr/local/bin/${name}
 start_cmd="bastille_start"
@@ -60,6 +61,7 @@ bastille_start()
     for _jail in ${bastille_ordered_list}; do
         echo "Starting Bastille Container: ${_jail}"
         ${command} start ${_jail}
+        sleep ${bastille_startup_delay}
     done
 }
 

--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -59,9 +59,9 @@ bastille_start()
     fi
 
     for _jail in ${bastille_ordered_list}; do
+        sleep ${bastille_startup_delay}
         echo "Starting Bastille Container: ${_jail}"
         ${command} start ${_jail}
-        sleep ${bastille_startup_delay}
     done
 }
 


### PR DESCRIPTION
Sometimes it can be beneficial that multiple jails to not all start immediately one after the other. For example, I have a PostgreSQL jail which runs databases used in multiple other jails. On occasion, one of my other jails fails to successfully start services within it after reboot of the host because that service depends on postgresql which isn't accepting incoming connections, yet.
Ideally, these services would have appropriate rc scripts to cater for when a database isn't ready, but as not all of them do it can be a useful workaround to have a delay between jail startups with enough time for dependencies to start up first. This, coupled with a dependency ordered `bastille_list` can save a lot of manual intervention at reboot.

Apologies if this has been covered elsewhere and I have missed it, isn't within scope of the project or if you feel there's a better way to handle this then please do as you wish.