### PR TITLE
template: Implement new functions and redo bastille main exec

### DIFF
--- a/docs/chapters/subcommands/verify.rst
+++ b/docs/chapters/subcommands/verify.rst
@@ -2,12 +2,12 @@
 verify
 ======
 
-This command scans a bootstrapped release and validates that everything looks
-in order. This is not a 100% comprehensive check, but it compares the release
+This command scans a bootstrapped release or template and validates that everything looks
+in order. This is not a 100% comprehensive check, but it compares the release or template
 against a "known good" index.
 
 If you see errors or issues here, consider deleting and re-bootstrapping
-the release.
+the release or template .
 
 .. code-block:: shell
 
@@ -19,3 +19,26 @@ the release.
   Applying metadata patches... done.
   Fetching 1 metadata files... done.
   Inspecting system... done.
+
+  ishmael ~ # bastille verify bastillebsd-templates/jellyfin
+  Detected Bastillefile hook.
+  [Bastillefile]:
+  CMD mkdir -p /usr/local/etc/pkg/repos
+  CMD echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' > 
+  /usr/local/etc/pkg/repos/FreeBSD.conf
+  CONFIG set allow.mlock=1;
+  CONFIG set ip6=inherit;
+  RESTART
+  PKG jellyfin
+  SYSRC jellyfin_enable=TRUE
+  SERVICE jellyfin start
+  Template ready to use.
+
+.. code-block:: shell
+
+  ishmael ~ # bastille verify 11.2-RELEASE
+  Usage: bastille verify [RELEASE|TEMPLATE]
+    
+    Options:
+
+    -x | --debug          Enable debug mode.

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -59,9 +59,6 @@ bastille_conf_check
 ## we only load this if conf_check passes
 . /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
-# Set default values for config properties added during the current major version:
-: "${bastille_network_pf_ext_if:=ext_if}"
-: "${bastille_network_pf_table:=jails}"
 
 ## bastille_prefix should be 0750
 ## this restricts file system access to privileged users
@@ -134,104 +131,62 @@ EOF
     exit 1
 }
 
-[ $# -lt 1 ] && usage
-
-CMD=$1
-shift
-
-target_all_jails_old() {
-  _JAILS=$(/usr/sbin/jls name)
-  JAILS=""
-  for _jail in ${_JAILS}; do
-      _JAILPATH=$(/usr/sbin/jls -j "${_jail}" path)
-      if [ -z ${_JAILPATH##${bastille_jailsdir}*} ]; then
-          JAILS="${JAILS} ${_jail}"
-      fi
-  done
-}
-
-check_target_is_running_old() {
-  if [ ! "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
-      error_exit "[${TARGET}]: Not started. See 'bastille start ${TARGET}'."
-  fi
-}
+if [ "$#" -lt 1 ]; then
+    usage
+else
+    CMD="${1}"
+    shift
+fi
 
 # Handle special-case commands first.
 case "${CMD}" in
-version|-v|--version)
-    info "${BASTILLE_VERSION}"
-    exit 0
-    ;;
-help|-h|--help)
-    usage
-    ;;
-bootstrap|clone|cmd|config|console|convert|create|cp|destroy|edit|etcupdate|export|htop|import|jcp|list|mount|pkg|rcp|rdr|rename|restart|service|setup|start|stop|sysrc|top|umount|update|upgrade|verify|zfs)
-    # Nothing "extra" to do for these commands. -- cwells
-    ;;
-template)
-    # Parse the target and ensure it exists. -- cwells
-    if [ $# -eq 0 ]; then # No target was given, so show the command's help. -- cwells
-        PARAMS='help'
-    elif [ "${1}" != 'help' ] && [ "${1}" != '-h' ] && [ "${1}" != '--help' ]; then
-        TARGET="${1}"
-        shift
-
-        # This is needed to handle the special case of 'bastille rcp' and 'bastille cp' with the '-q' or '--quiet'
-        # option specified before the TARGET. Also seems the cp and rcp commands does not support ALL as a target, so
-        # that's why is handled here. Maybe this behaviour needs an improvement later. -- yaazkal
-        if { [ "${CMD}" = 'rcp' ] || [ "${CMD}" = 'cp' ]; } && \
-           { [ "${TARGET}" = '-q' ] || [ "${TARGET}" = '--quiet' ]; }; then
-          TARGET="${1}"
-          JAILS="${TARGET}"
-          OPTION="-q"
-          export OPTION
-          shift
-        fi
-
-        if [ "${TARGET}" = 'ALL' ]; then
-            target_all_jails_old
-        elif [ "${CMD}" = "pkg" ] && [ "${TARGET}" = '-H' ] || [ "${TARGET}" = '--host' ]; then
-            TARGET="${1}"
-            USE_HOST_PKG=1
-            if [ "${TARGET}" = 'ALL' ]; then
-              target_all_jails_old
-            else
-              JAILS="${TARGET}"
-              check_target_is_running_old
-            fi
-            shift
-        elif [ "${CMD}" = 'template' ] && [ "${TARGET}" = '--convert' ]; then
-            # This command does not act on a jail, so we are temporarily bypassing the presence/started
-            # checks. The command will simply convert a template from hooks to a Bastillefile. -- cwells
-            :
-        else
-            JAILS="${TARGET}"
-
-            # Ensure the target exists. -- cwells
-            if [ ! -d "${bastille_jailsdir}/${TARGET}" ]; then
-                error_exit "[${TARGET}]: Not found."
-            fi
-
-            case "${CMD}" in
-            cmd|pkg|service|stop|sysrc|template)
-                check_target_is_running_old
-                ;;
-            convert|rename)
-                # Require the target to be stopped. -- cwells
-                if [ "$(/usr/sbin/jls name | awk "/^${TARGET}$/")" ]; then
-                    error_exit "${TARGET} is running. See 'bastille stop ${TARGET}'."
-                fi
-                ;;
-            esac
-        fi
-        export USE_HOST_PKG
-        export TARGET
-        export JAILS
-    fi
-    ;;
-*) # Filter out all non-commands
-    usage
-    ;;
+    version|-v|--version)
+        info "${BASTILLE_VERSION}"
+        exit 0
+        ;;
+    help|-h|--help)
+        usage
+        ;;
+    bootstrap| \
+    clone| \
+    cmd| \
+    config| \
+    console| \
+    convert| \
+    cp| \
+    create| \
+    destroy| \
+    edit| \
+    etcupdate| \
+    export| \
+    htop| \
+    import| \
+    limits| \
+    list| \
+    mount| \
+    network| \
+    pkg| \
+    rcp| \
+    rdr| \
+    rename| \
+    restart| \
+    service| \
+    setup| \
+    start| \
+    stop| \
+    sysrc| \
+    tags| \
+    template| \
+    top| \
+    umount| \
+    update| \
+    upgrade| \
+    verify| \
+    zfs)
+        ;;
+    *)
+        usage
+        ;;
 esac
 
 # shellcheck disable=SC2154

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -276,7 +276,7 @@ for _jail in ${JAILS}; do
         _jail_ip6="$(bastille config ${_jail} get ip6.addr | sed 's/,/ /g' | awk '{print $1}')"
     fi
     ## remove value if ip4 was not set or disabled, otherwise get value
-    if [ "${_jail_ip4}" = "not set" ] || [ "${_jail_ip4}" = "disabled" ]; then
+    if [ "${_jail_ip4}" = "not set" ] || [ "${_jail_ip4}" = "disable" ]; then
         _jail_ip4='' # In case it was -. -- cwells
     elif echo "${_jail_ip4}" | grep -q "|"; then
         _jail_ip4="$(echo ${_jail_ip4} | awk -F"|" '{print $2}' | sed -E 's#/[0-9]+$##g')"
@@ -284,7 +284,7 @@ for _jail in ${JAILS}; do
         _jail_ip4="$(echo ${_jail_ip4} | sed -E 's#/[0-9]+$##g')"
     fi
     ## remove value if ip6 was not set or disabled, otherwise get value
-    if [ "${_jail_ip6}" = "not set" ] || [ "${_jail_ip6}" = "disabled" ]; then
+    if [ "${_jail_ip6}" = "not set" ] || [ "${_jail_ip6}" = "disable" ]; then
         _jail_ip6='' # In case it was -. -- cwells
     elif echo "${_jail_ip6}" | grep -q "|"; then
         _jail_ip6="$(echo ${_jail_ip6} | awk -F"|" '{print $2}' | sed -E 's#/[0-9]+$##g')"
@@ -292,8 +292,8 @@ for _jail in ${JAILS}; do
         _jail_ip6="$(echo ${_jail_ip6} | sed -E 's#/[0-9]+$##g')"
     fi
     # print error when both ip4 and ip6 are not set
-    if { [ "${_jail_ip4}" = "not set" ] || [ "${_jail_ip4}" = "disabled" ]; } && \
-       { [ "${_jail_ip6}" = "not set" ] || [ "${_jail_ip6}" = "disabled" ]; } then
+    if { [ "${_jail_ip4}" = "not set" ] || [ "${_jail_ip4}" = "disable" ]; } && \
+       { [ "${_jail_ip6}" = "not set" ] || [ "${_jail_ip6}" = "disable" ]; } then
         error_notify "Jail IP not found: ${_jail}"
     fi
     

--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -33,8 +33,16 @@
 . /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
-bastille_usage() {
-    error_exit "Usage: bastille template TARGET|--convert project/template"
+usage() {
+    error_notify "Usage: bastille template [option(s)] TARGET [--convert|project/template]"
+    cat << EOF
+    Options:
+
+    -a | --auto           Auto mode. Start/stop jail(s) if required.
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
 post_command_hook() {
@@ -107,26 +115,51 @@ render() {
     fi
 }
 
-# Handle special-case commands first.
-case "$1" in
-help|-h|--help)
-    bastille_usage
-    ;;
-esac
+# Handle options.
+AUTO=0
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+	-h|--help|help)
+	    usage
+	    ;;
+	-a|--auto)
+	    AUTO=1
+	    shift
+	    ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*) 
+            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
+                case ${_opt} in
+                    a) AUTO=1 ;;
+                    x) enable_debug ;;
+                    *) error_exit "Unknown Option: \"${1}\"" ;; 
+                esac
+            done
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 2 ]; then
     bastille_usage
 fi
 
-bastille_root_check
-
-## global variables
-TEMPLATE="${1}"
+TARGET="${1}"
+TEMPLATE="${2}"
 bastille_template=${bastille_templatesdir}/${TEMPLATE}
 if [ -z "${HOOKS}" ]; then
     HOOKS='LIMITS INCLUDE PRE FSTAB PF PKG OVERLAY CONFIG SYSRC SERVICE CMD RENDER'
 fi
 
+bastille_root_check
+
+# We set the target only if it is not --convert
 # Special case conversion of hook-style template files into a Bastillefile. -- cwells
 if [ "${TARGET}" = '--convert' ]; then
     if [ -d "${TEMPLATE}" ]; then # A relative path was provided. -- cwells
@@ -174,6 +207,8 @@ if [ "${TARGET}" = '--convert' ]; then
 
     info "Template converted: ${TEMPLATE}"
     exit 0
+else
+    set_target "${TARGET}"
 fi
 
 case ${TEMPLATE} in
@@ -201,10 +236,6 @@ case ${TEMPLATE} in
         error_exit "Template name/URL not recognized."
 esac
 
-if [ -z "${JAILS}" ]; then
-    error_exit "Container ${TARGET} is not running."
-fi
-
 # Check for an --arg-file parameter. -- cwells
 for _script_arg in "$@"; do
     case ${_script_arg} in
@@ -226,7 +257,16 @@ if [ -n "${ARG_FILE}" ] && [ ! -f "${ARG_FILE}" ]; then
 fi
 
 for _jail in ${JAILS}; do
+
     info "[${_jail}]:"
+
+    check_target_is_running "${_jail}" || if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${_jail}"
+    else   
+        error_notify "Jail is not running."
+        error_continue "Use [-a|--auto] to auto-start the jail."
+    fi
+    
     info "Applying template: ${TEMPLATE}..."
 
     ## get jail ip4 and ip6 values

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -89,7 +89,7 @@ verify_template() {
             ## line count must match newline count
             # shellcheck disable=SC2046
             # shellcheck disable=SC3003
-            if [ $(wc -l "${_path}" | awk '{print $1}') -ne $(grep -c $'\n' "${_path}") ]; then
+            if [ $(wc -l "${_path}" | awk '{print $1}') -ne $(grep -c '\n' "${_path}") ]; then
                 info "[${_hook}]:"
                 error_notify "${BASTILLE_TEMPLATE}:${_hook} [failed]."
                 error_notify "Line numbers don't match line breaks."

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -33,8 +33,15 @@
 . /usr/local/share/bastille/common.sh
 . /usr/local/etc/bastille/bastille.conf
 
-bastille_usage() {
-    error_exit "Usage: bastille verify [release|template]"
+usage() {
+    error_notify "Usage: bastille verify [RELEASE|TEMPLATE]"
+    cat << EOF
+    Options:
+
+    -x | --debug          Enable debug mode.
+
+EOF
+    exit 1
 }
 
 verify_release() {
@@ -147,36 +154,48 @@ verify_template() {
     fi
 }
 
-# Handle special-case commands first.
-case "$1" in
-help|-h|--help)
-    bastille_usage
-    ;;
-esac
+# Handle options.
+while [ "$#" -gt 0 ]; do
+    case "${1}" in
+	    -h|--help|help)
+	        usage
+	        ;;
+        -x|--debug)
+            enable_debug
+            shift
+            ;;
+        -*) 
+            error_exit "Unknown Option: \"${1}\""
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
-if [ $# -gt 1 ] || [ $# -lt 1 ]; then
-    bastille_usage
+if [ "$#" -ne 1 ]; then
+    usage
 fi
 
 bastille_root_check
 
-case "$1" in
-*-RELEASE|*-release|*-RC[1-9]|*-rc[1-9])
-    RELEASE=$1
-    verify_release
-    ;;
-*-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
-    RELEASE=$1
-    verify_release
-    ;;
-http?*)
-    bastille_usage
-    ;;
-*/*)
-    BASTILLE_TEMPLATE=$1
-    verify_template
-    ;;
-*)
-    bastille_usage
-    ;;
+case "${1}" in
+    *-RELEASE|*-release|*-RC[1-9]|*-rc[1-9])
+        RELEASE="${1}"
+        verify_release
+        ;;
+    *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)
+        RELEASE="${1}"
+        verify_release
+        ;;
+    http?*)
+        bastille_usage
+        ;;
+    */*)
+        BASTILLE_TEMPLATE="${1}"
+        verify_template
+        ;;
+    *)
+        usage
+        ;;
 esac

--- a/usr/local/share/bastille/verify.sh
+++ b/usr/local/share/bastille/verify.sh
@@ -89,7 +89,7 @@ verify_template() {
             ## line count must match newline count
             # shellcheck disable=SC2046
             # shellcheck disable=SC3003
-            if [ $(wc -l "${_path}" | awk '{print $1}') -ne $(grep -c '\n' "${_path}") ]; then
+            if [ $(wc -l "${_path}" | awk '{print $1}') -ne "$(tr -d -c '\n' < "${_path}" | wc -c)" ]; then
                 info "[${_hook}]:"
                 error_notify "${BASTILLE_TEMPLATE}:${_hook} [failed]."
                 error_notify "Line numbers don't match line breaks."


### PR DESCRIPTION
This PR adds the final touches to finally allowing the main bastille executable to now only redirect commands to their respective scripts. It no more does any functions. Each command now takes care of its own functions like setting the target.

Testing

- run each command to make sure it functions as it should, report any errors here and we will get the corrected