### PR TITLE
import: Import jails using new interface format (iocage,ezjail)

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -554,10 +554,12 @@ create_jail() {
         fi
     fi
 
-    # Exit if jail was not started, which means something is wrong.
-    if ! check_target_is_running "${NAME}"; then
-        bastille destroy "${NAME}"
-        error_exit "[${NAME}]: Failed to create jail..."
+    # Exit if jail was not started, except for empty jails
+    if [ -z "${EMPTY_JAIL}" ]; then
+        if ! check_target_is_running "${NAME}"; then
+            bastille destroy "${NAME}"
+            error_exit "[${NAME}]: Failed to create jail..."
+        fi
     fi
 
     if [ -n "${VNET_JAIL}" ]; then

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -68,6 +68,18 @@ opt_count() {
     COMP_OPTION=$((COMP_OPTION + 1))
 }
 
+# Reset export options
+GZIP_EXPORT=
+XZ_EXPORT=
+SAFE_EXPORT=
+USER_EXPORT=
+RAW_EXPORT=
+DIR_EXPORT=
+TXZ_EXPORT=
+TGZ_EXPORT=
+OPT_ZSEND="-R"
+COMP_OPTION="0"
+
 if [ -n "${bastille_export_options}" ]; then
     # Overrides the case options by the user defined option(s) automatically.
     # Add bastille_export_options="--optionA --optionB" to bastille.conf, or simply `export bastille_export_options="--optionA --optionB"` environment variable.
@@ -162,10 +174,9 @@ else
                 usage
                 ;;
             *)
-                if echo "${1}" | grep -q "\/"; then
-                    DIR_EXPORT="${1}"
+                if echo "${2}" | grep -q "\/"; then
+                    DIR_EXPORT="${2}"
                 fi
-                shift
                 ;;
         esac
     done
@@ -176,16 +187,11 @@ if [ $# -gt 2 ] || [ $# -lt 1 ]; then
 fi
 
 TARGET="${1}"
-GZIP_EXPORT=
-XZ_EXPORT=
-SAFE_EXPORT=
-USER_EXPORT=
-RAW_EXPORT=
-DIR_EXPORT=
-TXZ_EXPORT=
-TGZ_EXPORT=
-OPT_ZSEND="-R"
-COMP_OPTION="0"
+
+# Check for directory export
+if echo "${2}" | grep -q "\/"; then
+    DIR_EXPORT="${2}"
+fi
 
 bastille_root_check
 set_target_single "${TARGET}"

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -174,9 +174,7 @@ else
                 usage
                 ;;
             *)
-                if echo "${2}" | grep -q "\/"; then
-                    DIR_EXPORT="${2}"
-                fi
+                break
                 ;;
         esac
     done

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -153,6 +153,10 @@ else
                 OPT_ZSEND="-Rv"
                 shift
                 ;;
+            -x)
+               enable_debug
+               shift
+               ;;
             -*)
                 error_notify "Unknown Option: \"${1}\""
                 usage
@@ -160,10 +164,6 @@ else
             *)
                 if echo "${1}" | grep -q "\/"; then
                     DIR_EXPORT="${1}"
-                else
-                    if [ $# -gt 2 ] || [ $# -lt 1 ]; then
-                       usage
-                    fi
                 fi
                 shift
                 ;;

--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -65,7 +65,7 @@ zfs_enable_check() {
 }
 
 opt_count() {
-    COMP_OPTION=$(expr ${COMP_OPTION} + 1)
+    COMP_OPTION=$((COMP_OPTION + 1))
 }
 
 if [ -n "${bastille_export_options}" ]; then

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -228,7 +228,7 @@ generate_config() {
 	    if [ -z "${RELEASE}" ]; then
                 CONFIG_RELEASE=$(echo ${PROP_CONFIG} | grep -o '[0-9]\{2\}\.[0-9]_RELEASE' | sed 's/_/-/g')
 	    else 
-                CONFIG_RELEASE="${RELEASE}"
+                ="${RELEASE}"
 	    fi
         fi
         # Always assume it's thin for ezjail
@@ -410,7 +410,11 @@ update_config() {
     # The config on select archives does not provide a clear way to determine
     # the base release, so lets try to get it from the base/COPYRIGHT file,
     # otherwise warn user and fallback to host system release
-    CONFIG_RELEASE=$(grep -wo 'releng/[0-9]\{2\}.[0-9]/COPYRIGHT' "${bastille_jailsdir}/${TARGET_TRIM}/root/COPYRIGHT" | sed 's|releng/||;s|/COPYRIGHT|-RELEASE|')
+    if [ -z "${RELEASE}" ]; then
+        CONFIG_RELEASE=$(grep -wo 'releng/[0-9]\{2\}.[0-9]/COPYRIGHT' "${bastille_jailsdir}/${TARGET_TRIM}/root/COPYRIGHT" | sed 's|releng/||;s|/COPYRIGHT|-RELEASE|')
+    else
+        CONFIG_RELEASE="${RELEASE}"
+    fi
     if [ -z "${CONFIG_RELEASE}" ]; then
         # Fallback to host version
         CONFIG_RELEASE=$(freebsd-version | sed 's/\-[pP].*//')

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -343,7 +343,7 @@ generate_config() {
         fi
 
         # Let the user configure network manually
-        if [ -z "${NETIF_CONFIG}" ]; then
+        if [ -z "${IP4_DEFINITION}" ] && [ -z "${IP6_DEFINITION}" ]; then
 	    IP4_DEFINITION="ip4.addr = lo1|-;"
             IP6_DEFINITION=""
             IP6_MODE="disable"

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -206,7 +206,7 @@ generate_config() {
             IS_VNET_JAIL=$(grep -wo '\"vnet\": .*' "${JSON_CONFIG}" | tr -d '" ,' | sed 's/vnet://')
             VNET_DEFAULT_INTERFACE=$(grep -wo '\"vnet_default_interface\": \".*\"' "${JSON_CONFIG}" | tr -d '" ' | sed 's/vnet_default_interface://')
             ALLOW_EMPTY_DIRS_TO_BE_SYMLINKED=1
-            if [ "${VNET_DEFAULT_INTERFACE}" = "auto" ]; then
+            if [ "${VNET_DEFAULT_INTERFACE}" = "auto" ] || [ "${VNET_DEFAULT_INTERFACE}" = "none" ]; then
                 # Grab the default ipv4 route from netstat and pull out the interface
                 VNET_DEFAULT_INTERFACE=$(netstat -nr4 | grep default | cut -w -f 4)
             fi
@@ -385,6 +385,7 @@ ${TARGET_TRIM} {
   mount.fstab = ${bastille_jailsdir}/${TARGET_TRIM}/fstab;
   path = ${bastille_jailsdir}/${TARGET_TRIM}/root;
   securelevel = 2;
+  osrelease = ${CONFIG_RELEASE};
 
 ${NETBLOCK}
 }

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -228,7 +228,7 @@ generate_config() {
 	    if [ -z "${RELEASE}" ]; then
                 CONFIG_RELEASE=$(echo ${PROP_CONFIG} | grep -o '[0-9]\{2\}\.[0-9]_RELEASE' | sed 's/_/-/g')
 	    else 
-                ="${RELEASE}"
+                CONFIG_RELEASE="${RELEASE}"
 	    fi
         fi
         # Always assume it's thin for ezjail


### PR DESCRIPTION
Imported jails from iocage and ezjail should now be imported using the new "if|ip" format and overall better handling on the network side of the import.

Testing requires an exported iocage jail to be imported into bastille.