### PR TITLE
create: Allow setting zfs options on creating jail

### DIFF
--- a/docs/chapters/subcommands/create.rst
+++ b/docs/chapters/subcommands/create.rst
@@ -50,3 +50,27 @@ Also, uname does not work from within a jail.  Much like MOTD, it gives you the 
 information about the host system instead of the jail.  If you need to check the version
 of freebsd running on the jail use the freebsd-version command to get accurate information.
 
+
+Bastille can create many different types of jails, along with many different options. See
+the below help output.
+
+.. code-block:: shell
+
+  ishmael ~ # bastille create help
+
+  Usage: bastille create [option(s)] NAME RELEASE IP_ADDRESS [interface]"
+
+    Options:
+    
+    -B | --bridge                            Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    -C | --clone                             Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -D | --dual                              Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
+    -E | --empty                             Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
+    -L | --linux                             This option is intended for testing with Linux jails, this is considered experimental.
+    -M | --static-mac                        Generate a static MAC address for jail (VNET only).
+         --no-validate                       Do not validate the release when creating the jail.
+    -T | --thick                             Creates a thick container, they consume more space as they are self contained and independent.
+    -V | --vnet                              Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
+    -x | --debug                             Enable debug mode.
+    -Z | --zfs-opts [zfs,options]            Comma separated list of ZFS options to create the jail with. This overrides the defaults.
+

--- a/docs/chapters/subcommands/create.rst
+++ b/docs/chapters/subcommands/create.rst
@@ -64,6 +64,7 @@ the below help output.
     
     -B | --bridge                            Enables VNET, VNET containers are attached to a specified, already existing external bridge.
     -C | --clone                             Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -c | --config                            Use a customized configuration file to override the default values.
     -D | --dual                              Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
     -E | --empty                             Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
     -L | --linux                             This option is intended for testing with Linux jails, this is considered experimental.

--- a/docs/chapters/subcommands/create.rst
+++ b/docs/chapters/subcommands/create.rst
@@ -64,7 +64,6 @@ the below help output.
     
     -B | --bridge                            Enables VNET, VNET containers are attached to a specified, already existing external bridge.
     -C | --clone                             Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -c | --config                            Use a customized configuration file to override the default values.
     -D | --dual                              Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
     -E | --empty                             Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
     -L | --linux                             This option is intended for testing with Linux jails, this is considered experimental.

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -38,7 +38,6 @@ usage() {
     cat << EOF
     Options:
     
-    -c | --config          Use a customized configuration file to override the default values.
     -x | --debug           Enable debug mode.
 
 EOF
@@ -424,24 +423,6 @@ while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
-            ;;
-        -c|--config)
-            OPT_CONFIG="${2}"
-	        if [ ! -f "${OPT_CONFIG}" ]; then
-                if [ ! -f /usr/local/etc/bastille/${OPT_CONFIG} ]; then
-                    error_notify "Not a valid config file: ${OPT_CONFIG}"
-		            usage
-                else
-                    info "Using custom config: ${OPT_CONFIG}"
-		        # shellcheck disable=SC1090
-		        . /usr/local/etc/bastille/${OPT_CONFIG}
-                fi
-	        else
-                info "Using custom config: ${OPT_CONFIG}"
-		        # shellcheck disable=SC1090
-                . "${OPT_CONFIG}"
-	        fi
-            shift 2
             ;;
         -x|--debug)
             enable_debug

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -37,8 +37,9 @@ usage() {
     error_notify "Usage: bastille bootstrap [option(s)] [RELEASE|TEMPLATE] [update|arch]"
     cat << EOF
     Options:
-
-    -x | --debug          Enable debug mode.
+    
+    -c | --config          Use a customized configuration file to override the default values.
+    -x | --debug           Enable debug mode.
 
 EOF
     exit 1
@@ -423,6 +424,24 @@ while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
             usage
+            ;;
+        -c|--config)
+            OPT_CONFIG="${2}"
+	        if [ ! -f "${OPT_CONFIG}" ]; then
+                if [ ! -f /usr/local/etc/bastille/${OPT_CONFIG} ]; then
+                    error_notify "Not a valid config file: ${OPT_CONFIG}"
+		            usage
+                else
+                    info "Using custom config: ${OPT_CONFIG}"
+		        # shellcheck disable=SC1090
+		        . /usr/local/etc/bastille/${OPT_CONFIG}
+                fi
+	        else
+                info "Using custom config: ${OPT_CONFIG}"
+		        # shellcheck disable=SC1090
+                . "${OPT_CONFIG}"
+	        fi
+            shift 2
             ;;
         -x|--debug)
             enable_debug

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -41,17 +41,17 @@ usage() {
     cat << EOF
     Options:
     
-    -B | --bridge                          Enables VNET, VNET containers are attached to a specified, already existing external bridge.
-    -C | --clone                           Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -D | --dual                            Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
-    -E | --empty                           Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
-    -L | --linux                           This option is intended for testing with Linux jails, this is considered experimental.
-    -M | --static-mac                      Generate a static MAC address for jail (VNET only).
-         --no-validate                     Do not validate the release when creating the jail.
-    -T | --thick                           Creates a thick container, they consume more space as they are self contained and independent.
-    -V | --vnet                            Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
-    -x | --debug                           Enable debug mode.
-    -Z | --zfs-opts [zfs,options]          Comma separated list of ZFS options to create the jail with. This overrides the defaults.
+    -B | --bridge                        Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    -C | --clone                         Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -D | --dual                          Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
+    -E | --empty                         Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
+    -L | --linux                         This option is intended for testing with Linux jails, this is considered experimental.
+    -M | --static-mac                    Generate a static MAC address for jail (VNET only).
+         --no-validate                   Do not validate the release when creating the jail.
+    -T | --thick                         Creates a thick container, they consume more space as they are self contained and independent.
+    -V | --vnet                          Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
+    -x | --debug                         Enable debug mode.
+    -Z | --zfs-opts zfs,options          Comma separated list of ZFS options to create the jail with. This overrides the defaults.
 
 EOF
     exit 1

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -43,6 +43,7 @@ usage() {
     
     -B | --bridge                          Enables VNET, VNET containers are attached to a specified, already existing external bridge.
     -C | --clone                           Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -c | --config                          Use a customized configuration file to override the default values.
     -D | --dual                            Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
     -E | --empty                           Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
     -L | --linux                           This option is intended for testing with Linux jails, this is considered experimental.
@@ -667,6 +668,7 @@ LINUX_JAIL=""
 STATIC_MAC=""
 DUAL_STACK=""
 VALIDATE_RELEASE="1"
+OPT_CONFIG=""
 while [ $# -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
@@ -680,6 +682,22 @@ while [ $# -gt 0 ]; do
         -C|--clone)
             CLONE_JAIL="1"
             shift
+            ;;
+        -c|--config)
+            OPT_CONFIG="${2}"
+	    if [ ! -f "${OPT_CONFIG}" ]; then
+                if [ ! -f /usr/local/etc/bastille/${OPT_CONFIG} ]; then
+                    error_notify "Not a valid config file: ${OPT_CONFIG}"
+		    usage
+                else
+                    info "Using custom config: ${OPT_CONFIG}"
+		    . /usr/local/etc/bastille/${OPT_CONFIG}
+                fi
+	    else
+                info "Using custom config: ${OPT_CONFIG}"
+                . "${OPT_CONFIG}"
+	    fi
+            shift 2
             ;;
         -D|--dual)
             DUAL_STACK="1"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -40,15 +40,18 @@ usage() {
 
     cat << EOF
     Options:
-
-    -D | --dual                Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
-    -M | --static-mac          Generate a static MAC address for jail (VNET only).
-    -E | --empty               Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
-    -L | --linux               This option is intended for testing with Linux jails, this is considered experimental.
-    -T | --thick               Creates a thick container, they consume more space as they are self contained and independent.
-    -V | --vnet                Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
-    -C | --clone               Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -B | --bridge              Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    
+    -B | --bridge               Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    -C | --clone                Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -D | --dual                 Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
+    -E | --empty                Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
+    -L | --linux                This option is intended for testing with Linux jails, this is considered experimental.
+    -M | --static-mac           Generate a static MAC address for jail (VNET only).
+         --no-validate          Do not validate the release when creating the jail.
+    -T | --thick                Creates a thick container, they consume more space as they are self contained and independent.
+    -V | --vnet                 Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
+    -x | --debug                Enable debug mode.
+    -Z | --zfs-opts             Comma separated list of ZFS options to create the jail with. This overrides the defaults.
 
 EOF
     exit 1
@@ -669,12 +672,17 @@ while [ $# -gt 0 ]; do
         -h|--help|help)
             usage
             ;;
-        -D|--dual)
-            DUAL_STACK="1"
+        -B|--bridge)
+            VNET_JAIL="1"
+            VNET_JAIL_BRIDGE="1"
             shift
             ;;
-        -M|--static-mac)
-            STATIC_MAC="1"
+        -C|--clone)
+            CLONE_JAIL="1"
+            shift
+            ;;
+        -D|--dual)
+            DUAL_STACK="1"
             shift
             ;;
         -E|--empty)
@@ -685,6 +693,14 @@ while [ $# -gt 0 ]; do
             LINUX_JAIL="1"
             shift
             ;;
+        -M|--static-mac)
+            STATIC_MAC="1"
+            shift
+            ;;
+        --no-validate|no-validate)
+            VALIDATE_RELEASE=""
+            shift
+            ;;
         -T|--thick)
             THICK_JAIL="1"
             shift
@@ -693,18 +709,13 @@ while [ $# -gt 0 ]; do
             VNET_JAIL="1"
             shift
             ;;
-        -B|--bridge)
-            VNET_JAIL="1"
-            VNET_JAIL_BRIDGE="1"
+        -x|--debug)
+            enable_debug
             shift
             ;;
-        -C|--clone)
-            CLONE_JAIL="1"
-            shift
-            ;;
-        --no-validate|no-validate)
-            VALIDATE_RELEASE=""
-            shift
+        -Z|--zfs-opts)
+            bastille_zfs_options="${2}"
+            shift 2
             ;;
         -*) 
             for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -41,17 +41,17 @@ usage() {
     cat << EOF
     Options:
     
-    -B | --bridge               Enables VNET, VNET containers are attached to a specified, already existing external bridge.
-    -C | --clone                Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -D | --dual                 Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
-    -E | --empty                Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
-    -L | --linux                This option is intended for testing with Linux jails, this is considered experimental.
-    -M | --static-mac           Generate a static MAC address for jail (VNET only).
-         --no-validate          Do not validate the release when creating the jail.
-    -T | --thick                Creates a thick container, they consume more space as they are self contained and independent.
-    -V | --vnet                 Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
-    -x | --debug                Enable debug mode.
-    -Z | --zfs-opts             Comma separated list of ZFS options to create the jail with. This overrides the defaults.
+    -B | --bridge                          Enables VNET, VNET containers are attached to a specified, already existing external bridge.
+    -C | --clone                           Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
+    -D | --dual                            Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
+    -E | --empty                           Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
+    -L | --linux                           This option is intended for testing with Linux jails, this is considered experimental.
+    -M | --static-mac                      Generate a static MAC address for jail (VNET only).
+         --no-validate                     Do not validate the release when creating the jail.
+    -T | --thick                           Creates a thick container, they consume more space as they are self contained and independent.
+    -V | --vnet                            Enables VNET, VNET containers are attached to a virtual bridge interface for connectivity.
+    -x | --debug                           Enable debug mode.
+    -Z | --zfs-opts [zfs,options]          Comma separated list of ZFS options to create the jail with. This overrides the defaults.
 
 EOF
     exit 1

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -667,7 +667,6 @@ LINUX_JAIL=""
 STATIC_MAC=""
 DUAL_STACK=""
 VALIDATE_RELEASE="1"
-OPT_CONFIG=""
 while [ $# -gt 0 ]; do
     case "${1}" in
         -h|--help|help)

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -43,7 +43,6 @@ usage() {
     
     -B | --bridge                          Enables VNET, VNET containers are attached to a specified, already existing external bridge.
     -C | --clone                           Creates a clone container, they are duplicates of the base release, consume low space and preserves changing data.
-    -c | --config                          Use a customized configuration file to override the default values.
     -D | --dual                            Creates the jails with both IPv4 and IPv6 networking ('inherit' and 'ip_hostname' only).
     -E | --empty                           Creates an empty container, intended for custom jail builds (thin/thick/linux or unsupported).
     -L | --linux                           This option is intended for testing with Linux jails, this is considered experimental.
@@ -682,24 +681,6 @@ while [ $# -gt 0 ]; do
         -C|--clone)
             CLONE_JAIL="1"
             shift
-            ;;
-        -c|--config)
-            OPT_CONFIG="${2}"
-	    if [ ! -f "${OPT_CONFIG}" ]; then
-                if [ ! -f /usr/local/etc/bastille/${OPT_CONFIG} ]; then
-                    error_notify "Not a valid config file: ${OPT_CONFIG}"
-		    usage
-                else
-                    info "Using custom config: ${OPT_CONFIG}"
-		    # shellcheck disable=SC1090
-		    . /usr/local/etc/bastille/${OPT_CONFIG}
-                fi
-	    else
-                info "Using custom config: ${OPT_CONFIG}"
-		# shellcheck disable=SC1090
-                . "${OPT_CONFIG}"
-	    fi
-            shift 2
             ;;
         -D|--dual)
             DUAL_STACK="1"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -691,10 +691,12 @@ while [ $# -gt 0 ]; do
 		    usage
                 else
                     info "Using custom config: ${OPT_CONFIG}"
+		    # shellcheck disable=SC1090
 		    . /usr/local/etc/bastille/${OPT_CONFIG}
                 fi
 	    else
                 info "Using custom config: ${OPT_CONFIG}"
+		# shellcheck disable=SC1090
                 . "${OPT_CONFIG}"
 	    fi
             shift 2


### PR DESCRIPTION
#514
@s1dh

Run 'bastille create help' to see syntax

If you set the "--zfs-opts" the defaults will be overridden and allow you to specify non-default options.