### PR TITLE
create: Allow setting VLAN for VNET jails

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -66,3 +66,4 @@ bastille_template_thick="default/thick"                               ## default
 bastille_template_clone="default/clone"                               ## default: "default/clone"
 bastille_template_thin="default/thin"                                 ## default: "default/thin"
 bastille_template_vnet="default/vnet"                                 ## default: "default/vnet"
+bastille_template_vlan="default/vlan"                                 ## default: "default/vlan"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -704,7 +704,7 @@ while [ $# -gt 0 ]; do
             ;;
         -v|--vlan)
 	    if echo "${2}" | grep -Eq '^[0-9]+$'; then
-                VLAN_ID="${2}
+                VLAN_ID="${2}"
 	    else
                 error_exit "Not a valid VLAN ID: ${2}"
 	    fi

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -612,7 +612,7 @@ create_jail() {
 
             # Add VLAN ID if it was given
 	    if [ -n "${VLAN_ID}" ]; then
-                bastille template "${NAME}" ${bastille_template_vlan} --arg VLANID="${VLAN_ID}" --arg  IFCONFIG="${_ifconfig}"
+                bastille template "${NAME}" ${bastille_template_vlan} --arg VLANID="${VLAN_ID}" --arg IFCONFIG="${_ifconfig}"
 	    fi
         fi
     fi

--- a/usr/local/share/bastille/templates/default/vlan/Bastillefile
+++ b/usr/local/share/bastille/templates/default/vlan/Bastillefile
@@ -1,0 +1,6 @@
+ARG VLANID
+ARG IFCONFIG="SYNCDHCP"
+
+SYSRC ifconfig_vnet0="up"
+SYSRC vlans_vnet0="${VLANID}"
+SYSRC ifconfig_vnet0_${VLANID}="${IFCONFIG}"


### PR DESCRIPTION
#893 
@2Belette

This PR will allow users to specify a VLAN ID when creating a VNET jail.
You will need to add the bottom line of the update config file to your config file if it does not automatically add it.
This is because a template has been created for VLAN purposes, as that was the best approach.

Usage:

`bastille create -V --vlan 20 jail 14.2-RELEASE 192.168.13.13/24 vtnet0`

Adjust the above to fit your network.