### PR TITLE
minor fix to allow for display of multiple IP addresses from a jail w…

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -101,7 +101,7 @@ list_all(){
                     if [ "$(/usr/sbin/jls name | awk "/^${JAIL_NAME}$/")" ]; then
                         JAIL_STATE="Up"
                         if [ "$(awk '$1 == "vnet;" { print $1 }' "${bastille_jailsdir}/${JAIL_NAME}/jail.conf" 2> /dev/null)" ]; then
-                            JAIL_IP=$(jexec -l ${JAIL_NAME} ifconfig -an | grep -v "127.0.0.1" | grep "inet " | awk '{print $2}')
+                            JAIL_IP=$(jexec -l ${JAIL_NAME} ifconfig -an | grep -v "127.0.0.1" | grep "inet " | awk '{print $2}' | tr '\n' ',' | sed 's/,$//')
                             if [ ! "${JAIL_IP}" ]; then JAIL_IP=$(jexec -l ${JAIL_NAME} ifconfig -an | grep -v "lo0" | awk '{print $2}'); fi
                         else
                             JAIL_IP=$(/usr/sbin/jls -j ${JAIL_NAME} ip4.addr 2> /dev/null)


### PR DESCRIPTION
Small fix to allow for jails with multiple IP addresses/interfaces.  The output from 'bastille list -a' was showing a newline with just the secondary IP which was causing errors for the json output as well.

This patch just concatenates IP addresses into a comma separated value
