### PR TITLE
Implement parallel mode

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION="0.13.20250126"
+BASTILLE_VERSION=904f855
 
 ## check for config existence
 bastille_conf_check() {
@@ -119,6 +119,7 @@ Available Commands:
 Use "bastille -v|--version" for version information.
 Use "bastille command -h|--help" for more information about a command.
 Use "bastille [-c|--config FILE] command" to specify a non-default config file.
+Use "bastille [-p|--parallel VALUE] command" to run bastille in parallel mode.
 
 EOF
     exit 1
@@ -144,6 +145,7 @@ fi
 . /usr/local/share/bastille/common.sh
 
 # Handle options
+PARALLEL_MODE=0
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
@@ -164,18 +166,22 @@ while [ "$#" -gt 0 ]; do
                 export BASTILLE_CONFIG
             else
                 error_exit "Not a valid config file: ${BASTILLE_CONFIG}"
-            fi                
+            fi
+            # Load common.sh after setting BASTILLE_CONFIG
+            . /usr/local/share/bastille/common.sh 
             shift 2
             ;;
+        -p|--parallel)
+            PARALLEL_MODE=1
+            PROCESS_LIMIT="${2}"
+            if ! echo "${PROCESS_LIMIT}" | grep -Eq "^[0-9]+$"; then
+                error_exit "Not a valid process limit: ${PROCESS_LIMIT}"
+            else
+                shift 2
+            fi
+            ;;
         -*)
-            for _opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
-                case ${_opt} in
-                    x) enable_debug ;;
-                    a) AUTO=1 ;;
-                    *) error_exit "Unknown Option: \"${1}\"" ;; 
-                esac
-            done
-            shift
+            error_exit "Unknown Option: \"${1}\""
             ;;
         *)
             break
@@ -234,6 +240,26 @@ case "${CMD}" in
         ;;
 esac
 
+# Extract JAILS from command for parallel mode
+OPTIONS=""
+while [ "$#" -gt 0 ] && [ "${PARALLEL_MODE}" -eq 1 ]; do
+    case "${1}" in
+        -*)
+            OPTIONS="${OPTIONS} ${1}"
+            shift 1
+            ;;
+        *)
+            if ! set_target "${1}" >/dev/null 2>&1; then
+                OPTIONS="${OPTIONS} ${1}"
+                shift 1
+            else
+                XARGS_JAILS="${JAILS}"
+                shift 1
+                break
+            fi
+    esac
+done
+
 # shellcheck disable=SC2154
 SCRIPTPATH="${bastille_sharedir}/${CMD}.sh"
 if [ -f "${SCRIPTPATH}" ]; then
@@ -241,12 +267,13 @@ if [ -f "${SCRIPTPATH}" ]; then
     umask "${UMASK}"
 
     : "${SH:=sh}"
-
-    if [ -n "${PARAMS}" ]; then
-        exec "${SH}" "${SCRIPTPATH}" "${PARAMS}"
+    
+    if [ "${PARALLEL_MODE}" -eq 1 ]; then
+        echo "${XARGS_JAILS}" | xargs -P "${PROCESS_LIMIT}" -I {} "${SH}" "${SCRIPTPATH}" ${OPTIONS} {} "$@"
     else
         exec "${SH}" "${SCRIPTPATH}" "$@"
     fi
+
 else
     error_exit "${SCRIPTPATH} not found."
 fi

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -188,6 +188,7 @@ while [ "$#" -gt 0 ]; do
             ;;
     esac
 done
+
 if [ "$#" -lt 1 ]; then
     usage
 else
@@ -195,70 +196,75 @@ else
     shift
 fi
 
-# Handle special-case commands first.
+# Handle sub-commands.
 case "${CMD}" in
+    # Commands that don't allow parallel mode
     bootstrap| \
     clone| \
-    cmd| \
-    config| \
     console| \
     convert| \
     cp| \
     create| \
-    destroy| \
     edit| \
-    etcupdate| \
     export| \
     htop| \
     jcp | \
     import| \
-    limits| \
     list| \
-    mount| \
     network| \
-    pkg| \
     rcp| \
     rdr| \
     rename| \
+    setup| \
+    top| \
+    verify| \
+    zfs)
+        if [ "${PARALLEL_MODE}" -eq 1 ]; then
+            error_exit "Command does not support parallel mode: ${CMD}"
+        fi
+        ;;
+    # Commands that allow parallel mode
+    cmd| \
+    config| \
+    destroy| \
+    etcupdate| \
+    limits| \
+    mount| \
+    pkg| \
     restart| \
     service| \
-    setup| \
     start| \
     stop| \
     sysrc| \
     tags| \
     template| \
-    top| \
     umount| \
     update| \
-    upgrade| \
-    verify| \
-    zfs)
+    upgrade)
+        # Extract JAILS from command for parallel mode
+        OPTIONS=""
+        while [ "$#" -gt 0 ] && [ "${PARALLEL_MODE}" -eq 1 ]; do
+            case "${1}" in
+                -*)
+                    OPTIONS="${OPTIONS} ${1}"
+                    shift 1
+                    ;;
+                *)
+                    if ! set_target "${1}" >/dev/null 2>&1; then
+                        OPTIONS="${OPTIONS} ${1}"
+                        shift 1
+                    else
+                        XARGS_JAILS="${JAILS}"
+                        shift 1
+                        break
+                    fi
+            esac
+        done
         ;;
     *)
         usage
         ;;
 esac
-
-# Extract JAILS from command for parallel mode
-OPTIONS=""
-while [ "$#" -gt 0 ] && [ "${PARALLEL_MODE}" -eq 1 ]; do
-    case "${1}" in
-        -*)
-            OPTIONS="${OPTIONS} ${1}"
-            shift 1
-            ;;
-        *)
-            if ! set_target "${1}" >/dev/null 2>&1; then
-                OPTIONS="${OPTIONS} ${1}"
-                shift 1
-            else
-                XARGS_JAILS="${JAILS}"
-                shift 1
-                break
-            fi
-    esac
-done
 
 # shellcheck disable=SC2154
 SCRIPTPATH="${bastille_sharedir}/${CMD}.sh"

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -203,7 +203,6 @@ case "${CMD}" in
     clone| \
     console| \
     convert| \
-    cp| \
     create| \
     edit| \
     export| \
@@ -226,6 +225,7 @@ case "${CMD}" in
     # Commands that allow parallel mode
     cmd| \
     config| \
+    cp| \
     destroy| \
     etcupdate| \
     limits| \


### PR DESCRIPTION
This PR allows to run commands on multiple jails in parallel. Simply use '-p 3' to set a process limit. If not set, bastille will operate normally. The switch must follow the `bastille` keyword.

`bastille -p 3 start all` will start all jails but run 3 processes at a time.

This is a very rough implementation, and could be more streamlined, but here it is to test. 

@yaazkal @bmac2 What do you think?