### PR TITLE
convert: Allow converting jail to release

### DIFF
--- a/usr/local/share/bastille/convert.sh
+++ b/usr/local/share/bastille/convert.sh
@@ -99,9 +99,9 @@ validate_release_name() {
 }
 
 convert_jail_to_release() {
+
     _jailname="${1}"
     _release="${2}"
-    bastille_jail_path="${bastille_jailsdir}/${TARGET}/root"
     
     info "Creating ${_release} from ${_jailname}..."
 
@@ -269,8 +269,8 @@ elif  [ "$#" -eq 2 ]; then
     elif grep -qw ".bastille" "${bastille_jailsdir}/${TARGET}/fstab"; then
         error_exit "${TARGET} is not a thick jail."
     fi
-    validate_release_name "${2}"
-    convert_jail_to_release "${1}" "${2}"
+    validate_release_name "${CONVERT_RELEASE}"
+    convert_jail_to_release "${TARGET}" "${CONVERT_RELEASE}"
 else
     usage
 fi


### PR DESCRIPTION
#574
#926 

@PythonLinks 
@jhfoo

This PR will allow a user to convert an entire current jail to a release that can then be used to spin up new jails. These jails will have to be created using the --no-validate flag, depending on the name that is given them.

Jails must be thick jails in order to create a release from them. Jails that use the release should also be thick jails (or clone jails) to take advantage of any pkgs or files inside the created release.

NOTE: I don't know if thin jails will work by using this created release, but it would be nice if someone could verify this.

`bastille convert TARGET RELEASENAME` will convert TARGET to RELEASENAME
`bastille convert TARGET` will function as it always has by converting TARGET from a thin jail to a thick jail

Keep in mind. The `--no-validate` flag is very expiremental. The end user is left to keep track of which release (14.X, 13.X) it is based upon. Bastille has no control over that. Releases created in this way will not be able to be updated and upgraded using the regular bastille commands, as they don't follow standard naming conventions, and even include/exclude things that the official release does not.