### PR TITLE
Fix epair numbering when mixing -V and -B jails on one systme

### DIFF
--- a/docs/chapters/configuration.rst
+++ b/docs/chapters/configuration.rst
@@ -93,11 +93,13 @@ Custom Configuration
 Bastille now supports using a custom config in addition to the default one. This is nice if you have multiple users, or want to store different
 jails at different locations based on your needs.
 
+The customized config file MUST BE PLACED INSIDE THE BASTILLE CONFIG FOLDER at ``/usr/local/etc/bastille`` or it will not work.
+
 Simply copy the default config file and edit it according to your new environment or user. Then, it can be used in a couple of ways.
 
-1. Run Bastille using ``bastille --config /path/to/config.conf bootstrap 14.2-RELEASE`` to bootstrap the release using the new config.
+1. Run Bastille using ``bastille --config config.conf bootstrap 14.2-RELEASE`` to bootstrap the release using the new config.
 
-2. As a specific user, export the ``BASTILLE_CONFIG`` variable using ``export BASTILLE_CONFIG=/path/to/config.conf``. This config will then always be used when running Bastille with that user. See notes below...
+2. As a specific user, export the ``BASTILLE_CONFIG`` variable using ``export BASTILLE_CONFIG=config.conf``. This config will then always be used when running Bastille with that user. See notes below...
 
 - Exporting the ``BASTILLE_CONFIG`` variable will only export it for the current session. If you want to persist the export, see documentation for the shell that you use.
 

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -130,8 +130,6 @@ bastille_perms_check
 if [ -z "${BASTILLE_CONFIG}" ]; then
     BASTILLE_CONFIG=/usr/local/etc/bastille/bastille.conf
     export BASTILLE_CONFIG
-elif [ -r "${BASTILLE_CONFIG}" ]; then
-    export BASTILLE_CONFIG
 elif [ -r "/usr/local/etc/bastille/${BASTILLE_CONFIG}" ]; then
     BASTILLE_CONFIG="/usr/local/etc/bastille/${BASTILLE_CONFIG}"
     export BASTILLE_CONFIG
@@ -155,10 +153,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         -c|--config)
             BASTILLE_CONFIG="${2}"
-            if [ -r "${BASTILLE_CONFIG}" ]; then
-                info "Using custom config: ${BASTILLE_CONFIG}"
-                export BASTILLE_CONFIG
-            elif [ -r "/usr/local/etc/bastille/${BASTILLE_CONFIG}" ]; then
+            if [ -r "/usr/local/etc/bastille/${BASTILLE_CONFIG}" ]; then
                 BASTILLE_CONFIG="/usr/local/etc/bastille/${BASTILLE_CONFIG}"
                 info "Using custom config: ${BASTILLE_CONFIG}"
                 export BASTILLE_CONFIG

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -128,14 +128,16 @@ bastille_conf_check
 bastille_perms_check
 
 if [ -z "${BASTILLE_CONFIG}" ]; then
-    BASTILLE_CONFIG=/usr/local/etc/bastille/bastille.conf
-    export BASTILLE_CONFIG
-elif [ -r "/usr/local/etc/bastille/${BASTILLE_CONFIG}" ]; then
-    BASTILLE_CONFIG="/usr/local/etc/bastille/${BASTILLE_CONFIG}"
-    export BASTILLE_CONFIG
-else
-    echo "Not a valid config file: ${BASTILLE_CONFIG}"
-    exit 1
+    if [ -z "${BASTILLE_CONFIG}" ]; then
+        BASTILLE_CONFIG=/usr/local/etc/bastille/bastille.conf
+        export BASTILLE_CONFIG
+    elif [ -r "/usr/local/etc/bastille/${BASTILLE_CONFIG}" ]; then
+        BASTILLE_CONFIG="/usr/local/etc/bastille/${BASTILLE_CONFIG}"
+        export BASTILLE_CONFIG
+    else
+        echo "Not a valid config file: ${BASTILLE_CONFIG}"
+        exit 1
+    fi
 fi   
 
 # Load common.sh after setting BASTILLE_CONFIG

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -203,7 +203,7 @@ update_jailconf_vnet() {
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"
@@ -272,7 +272,7 @@ update_jailconf_vnet() {
         elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
             # Update VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -203,7 +203,7 @@ update_jailconf_vnet() {
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"
@@ -272,7 +272,7 @@ update_jailconf_vnet() {
         elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
             # Update VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -197,7 +197,8 @@ update_jailconf_vnet() {
     # Determine number of interfaces and define a uniq_epair
     local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
     for _if in ${_if_list}; do
-        local _epair_count="$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair ) | grep -Eo "[0-9]+" | sort -u | wc -l | awk '{print $1}')"
+        # Get number of epairs on the system
+        get_epair_count
         local _epair_num_range=$((_epair_count + 1))
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -203,7 +203,7 @@ update_jailconf_vnet() {
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"
@@ -272,7 +272,7 @@ update_jailconf_vnet() {
         elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
             # Update VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -112,6 +112,8 @@ validate_ip() {
     if [ -n "${ip6}" ]; then
         info "Valid: (${ip6})."
         IP6_MODE="new"
+    elif { [ "${IP}" = "0.0.0.0" ] || [ "${IP}" = "DHCP" ]; } && [ "$(bastille config ${TARGET} get vnet)" = "enabled" ];  then
+        info "Valid: (${IP})."
     else
         local IFS
         if echo "${IP}" | grep -Eq '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$'; then
@@ -195,14 +197,12 @@ update_jailconf_vnet() {
     # Determine number of interfaces and define a uniq_epair
     local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
     for _if in ${_if_list}; do
-        local _epair_if_count="$( (grep -Eo 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf; ifconfig | grep -Eo '(e[0-9]+a|epair[0-9]+a)' ) | sort -u | wc -l | awk '{print $1}')"
-        local _bastille_if_count="$(grep -Eo 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-        local epair_num_range=$((_epair_if_count + 1))
-        local bastille_num_range=$((_bastille_if_count + 1))
+        local _epair_count="$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair ) | grep -Eo "[0-9]+" | sort -u | wc -l | awk '{print $1}')"
+        local _epair_num_range=$((_epair_count + 1))
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
-            for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -Eoq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a)"; then
+            for _num in $(seq 0 "${_epair_num_range}"); do
+                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"
@@ -270,8 +270,8 @@ update_jailconf_vnet() {
             done
         elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
             # Update VNET config
-            for _num in $(seq 0 "${bastille_num_range}"); do
-                if ! grep -oq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
+            for _num in $(seq 0 "${_epair_num_range}"); do
+                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eoq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -203,7 +203,7 @@ update_jailconf_vnet() {
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Update bridged VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Generate new epair name
                     if [ "$(echo -n "e${_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                         local _new_host_epair="e${_num}a_${NEWNAME}"
@@ -272,7 +272,7 @@ update_jailconf_vnet() {
         elif echo ${_if} | grep -Eoq 'bastille[0-9]+'; then
             # Update VNET config
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eoq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     # Update jail.conf epair name
                     local uniq_epair="bastille${_num}"
                     local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,7 +121,7 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        _epair_list="$(printf '%s\n' "$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
+        _epair_list="$(printf '%s\n' "$( (grep -Eo '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eo "_bastille[0-9]+$"; ifconfig -g epair | grep -v "bastille" | grep -Eo "e[0-9]+a_") | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
     done
     _epair_count=$(printf '%s' "${_epair_list}" | wc -l | awk '{print $1}')
     export _epair_list

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,9 +121,9 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        _epair_list="$(printf '%s\n' "$( (grep -Eos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs "bastille" | grep -Eos "e[0-9]+a_") | grep -Eos "[0-9]+")" "${_epair_list}" | sort -u)"
+        _epair_list="$(printf '%s\n%s' "$( (grep -Eos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs "bastille" | grep -Eos "e[0-9]+a_") | grep -Eos "[0-9]+")" "${_epair_list}" | sort -u)"
     done
-    _epair_count=$(printf '%s' "${_epair_list}" | wc -l | awk '{print $1}')
+    _epair_count=$(printf '%s' "${_epair_list}" | sort -u | wc -l | awk '{print $1}')
     export _epair_list
     export _epair_count
 }
@@ -293,7 +293,7 @@ generate_vnet_jail_netblock() {
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -318,7 +318,7 @@ generate_vnet_jail_netblock() {
     else
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,7 +121,7 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        _epair_list="$(printf '%s\n%s' "$( (grep -Eos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs "bastille" | grep -Eos "e[0-9]+a_") | grep -Eos "[0-9]+")" "${_epair_list}" | sort -u)"
+        _epair_list="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_epair_list}")"
     done
     _epair_count=$(printf '%s' "${_epair_list}" | sort -u | wc -l | awk '{print $1}')
     export _epair_list
@@ -293,7 +293,7 @@ generate_vnet_jail_netblock() {
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -318,7 +318,7 @@ generate_vnet_jail_netblock() {
     else
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,7 +121,7 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        _epair_list="$(printf '%s\n' "$( (grep -Eo '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eo "_bastille[0-9]+$"; ifconfig -g epair | grep -v "bastille" | grep -Eo "e[0-9]+a_") | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
+        _epair_list="$(printf '%s\n' "$( (grep -Eos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs "bastille" | grep -Eos "e[0-9]+a_") | grep -Eos "[0-9]+")" "${_epair_list}" | sort -u)"
     done
     _epair_count=$(printf '%s' "${_epair_list}" | wc -l | awk '{print $1}')
     export _epair_list

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -280,14 +280,12 @@ generate_vnet_jail_netblock() {
     ## determine number of interfaces + 1
     ## iterate num and grep all jail configs
     ## define uniq_epair
-    local _epair_if_count="$( (grep -Eos 'epair[0-9]+' ${bastille_jailsdir}/*/jail.conf; ifconfig | grep -Eo '(e[0-9]+a|epair[0-9]+a)' ) | sort -u | wc -l | awk '{print $1}')"
-    local _bastille_if_count="$(grep -Eos 'bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | sort -u | wc -l | awk '{print $1}')"
-    local epair_num_range=$((_epair_if_count + 1))
-    local bastille_num_range=$((_bastille_if_count + 1))
+    local _epair_count="$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair ) | grep -Eo "[0-9]+" | sort -u | wc -l | awk '{print $1}')"
+    local _epair_num_range=$((_epair_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
-        if [ "${_epair_if_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${epair_num_range}"); do
-                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a)"; then
+        if [ "${_epair_count}" -gt 0 ]; then  
+            for _num in $(seq 0 "${_epair_num_range}"); do
+                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -310,8 +308,8 @@ generate_vnet_jail_netblock() {
             fi
         fi
     else
-        if [ "${_bastille_if_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${bastille_num_range}"); do
+        if [ "${_epair_count}" -gt 0 ]; then  
+            for _num in $(seq 0 "${_epair_num_range}"); do
                 if ! grep -Eosq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
                     local uniq_epair="bastille${_num}"
                     break

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -292,7 +292,7 @@ generate_vnet_jail_netblock() {
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "epair${_num}" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -317,7 +317,7 @@ generate_vnet_jail_netblock() {
     else
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "bastille${_num}" ${bastille_jailsdir}/*/jail.conf; then
+                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -118,6 +118,15 @@ check_target_is_stopped() {
     fi
 }
 
+get_epair_count() {
+    for _config in /usr/local/etc/bastille/*.conf; do
+        local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
+        local _epair_list="$(printf '%s\n' $( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+") ${_epair_list} | sort -u)"
+    done
+    _epair_count="$(echo ${_epair_list} | wc -l | awk '{print $1}')"
+    export _epair_count
+}
+
 get_jail_name() {
     local _JID="${1}"
     local _jailname="$(jls -j ${_JID} name 2>/dev/null)"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -286,10 +286,8 @@ generate_vnet_jail_netblock() {
     local use_unique_bridge="${2}"
     local external_interface="${3}"
     local static_mac="${4}"
-    ## determine number of interfaces + 1
-    ## iterate num and grep all jail configs
-    ## define uniq_epair
-    local _epair_count="$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair ) | grep -Eo "[0-9]+" | sort -u | wc -l | awk '{print $1}')"
+    # Get number of epairs on the system
+    get_epair_count
     local _epair_num_range=$((_epair_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -123,7 +123,7 @@ get_epair_count() {
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
         local _epair_list="$(printf '%s\n' "$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
     done
-    _epair_count="$(echo ${_epair_list} | wc -l | awk '{print $1}')"
+    _epair_count=$(printf '%s' "${_epair_list}" | wc -l | awk '{print $1}')
     export _epair_count
 }
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,7 +121,7 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        local _epair_list="$(printf '%s\n' $( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+") ${_epair_list} | sort -u)"
+        local _epair_list="$(printf '%s\n' "$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
     done
     _epair_count="$(echo ${_epair_list} | wc -l | awk '{print $1}')"
     export _epair_count

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,9 +121,10 @@ check_target_is_stopped() {
 get_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        local _epair_list="$(printf '%s\n' "$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
+        _epair_list="$(printf '%s\n' "$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair) | grep -Eo "[0-9]+")" "${_epair_list}" | sort -u)"
     done
     _epair_count=$(printf '%s' "${_epair_list}" | wc -l | awk '{print $1}')
+    export _epair_list
     export _epair_count
 }
 
@@ -292,7 +293,7 @@ generate_vnet_jail_netblock() {
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -317,7 +318,7 @@ generate_vnet_jail_netblock() {
     else
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -292,7 +292,7 @@ generate_vnet_jail_netblock() {
     if [ -n "${use_unique_bridge}" ]; then
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -317,7 +317,7 @@ generate_vnet_jail_netblock() {
     else
         if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     local uniq_epair="bastille${_num}"
                     break
                 fi

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -231,12 +231,13 @@ add_interface() {
     local _ip="${3}"
     local _jail_config="${bastille_jailsdir}/${_jailname}/jail.conf"
     local _jail_rc_config="${bastille_jailsdir}/${_jailname}/root/etc/rc.conf"
-    local _epair_count="$( (grep -Eos '(e[0-9]+b|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair ) | grep -Eo "[0-9]+" | sort -u | wc -l | awk '{print $1}')"
+    # Get number of epairs on the system
+    get_epair_count
     local _vnet_if_count="$(grep -Eo 'vnet[1-9]+' ${_jail_rc_config} | sort -u | wc -l | awk '{print $1}')"
     local _if_vnet="vnet$((_vnet_if_count + 1))"
-    local _epair_num_range=$((_epair_if_count + 1))
+    local _epair_num_range=$((_epair_count + 1))
     if [ "${BRIDGE}" -eq 1 ]; then
-       if [ "${_epair_if_count}" -gt 0 ]; then  
+       if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
                 if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -239,7 +239,7 @@ add_interface() {
     if [ "${BRIDGE}" -eq 1 ]; then
        if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${_jailname}
                         local jail_epair=e${_num}b_${_jailname}

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -239,7 +239,7 @@ add_interface() {
     if [ "${BRIDGE}" -eq 1 ]; then
        if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${_jailname}
                         local jail_epair=e${_num}b_${_jailname}
@@ -312,7 +312,7 @@ EOF
 
     elif [ "${VNET}" -eq 1 ]; then
         for _num in $(seq 0 "${_epair_num_range}"); do
-            if ! grep -Eq "(bastille${_num}|epair${_num})" "${bastille_jailsdir}"/*/jail.conf; then
+            if ! echo "${_epair_list}" | grep -osq "${_num}"; then
                     local bastille_epair="bastille${_num}"
                     break
             fi

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -239,7 +239,7 @@ add_interface() {
     if [ "${BRIDGE}" -eq 1 ]; then
        if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${_jailname}
                         local jail_epair=e${_num}b_${_jailname}
@@ -312,7 +312,7 @@ EOF
 
     elif [ "${VNET}" -eq 1 ]; then
         for _num in $(seq 0 "${_epair_num_range}"); do
-            if ! echo "${_epair_list}" | grep -osq "${_num}"; then
+            if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
                     local bastille_epair="bastille${_num}"
                     break
             fi

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -239,7 +239,7 @@ add_interface() {
     if [ "${BRIDGE}" -eq 1 ]; then
        if [ "${_epair_count}" -gt 0 ]; then  
             for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
+                if ! echo "${_epair_list}" | grep -osq "${_num}" && ! grep -Eosq "(bastille${_num}|epair${_num})" ${bastille_jailsdir}/*/jail.conf && ! ifconfig -g epair | grep -Eosq "(e${_num}a|epair${_num}a|bastille${_num})"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${_jailname}
                         local jail_epair=e${_num}b_${_jailname}


### PR DESCRIPTION
This fixes a bug when using VNET and bridged VNET jails on the same system.