### PR TITLE
bastille: Initial support for netgraph

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -52,6 +52,7 @@ bastille_decompress_gz_options="-k -d -c -v"                          ## default
 bastille_export_options=""                                            ## default "" predefined export options, e.g. "--safe --gz"
 
 ## Networking
+bastille_network_vnet_type="if_bridge"                                ## default: "if_bridge"
 bastille_network_loopback="bastille0"                                 ## default: "bastille0"
 bastille_network_pf_ext_if="ext_if"                                   ## default: "ext_if"
 bastille_network_pf_table="jails"                                     ## default: "jails"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -150,7 +150,7 @@ update_jailconf() {
     fi
 
     if grep -qw "vnet;" "${JAIL_CONFIG}"; then
-        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
+        validate_netconf
         update_jailconf_vnet
     else
         _ip4="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -136,15 +136,6 @@ validate_ip() {
     fi
 }
 
-validate_netconf_clone() {
-    if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
-        error_exit "Invalid network configuration."
-    fi
-    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
-        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
-    fi
-}
-
 update_jailconf() {
     # Update jail.conf
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
@@ -159,7 +150,7 @@ update_jailconf() {
     fi
 
     if grep -qw "vnet;" "${JAIL_CONFIG}"; then
-        validate_netconf_clone
+        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
         update_jailconf_vnet
     else
         _ip4="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -136,6 +136,15 @@ validate_ip() {
     fi
 }
 
+validate_netconf_clone() {
+    if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
+        error_exit "Invalid network configuration."
+    fi
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] || [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
+    fi
+}
+
 update_jailconf() {
     # Update jail.conf
     JAIL_CONFIG="${bastille_jailsdir}/${NEWNAME}/jail.conf"
@@ -150,6 +159,7 @@ update_jailconf() {
     fi
 
     if grep -qw "vnet;" "${JAIL_CONFIG}"; then
+        validate_netconf
         update_jailconf_vnet
     else
         _ip4="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -140,7 +140,7 @@ validate_netconf_clone() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
         error_exit "Invalid network configuration."
     fi
-    if [ "${bastille_network_vnet_type}" != "if_bridge" ] || [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
         error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
     fi
 }

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -159,7 +159,7 @@ update_jailconf() {
     fi
 
     if grep -qw "vnet;" "${JAIL_CONFIG}"; then
-        validate_netconf
+        validate_netconf_clone
         update_jailconf_vnet
     else
         _ip4="$(bastille config ${TARGET} get ip4.addr | sed 's/,/ /g')"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -415,8 +415,6 @@ EOF
   exec.poststop += "jng shutdown ${_jail_if}";
 EOF
             fi
-        else
-            error_exit "[ERROR]: 'bastille_network_vnet_type' is not set correctly: ${bastille_network_vnet_type}"
         fi
     fi
 }

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -135,6 +135,8 @@ get_bastille_if_count() {
         _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
         export _bastille_if_list
         export _bastille_if_count
+    else
+        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
     fi
 }
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -118,14 +118,24 @@ check_target_is_stopped() {
     fi
 }
 
-get_epair_count() {
-    for _config in /usr/local/etc/bastille/*.conf; do
-        local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        _epair_list="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_epair_list}")"
-    done
-    _epair_count=$(printf '%s' "${_epair_list}" | sort -u | wc -l | awk '{print $1}')
-    export _epair_list
-    export _epair_count
+get_bastille_if_count() {
+    if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+        for _config in /usr/local/etc/bastille/*.conf; do
+            local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
+            _bastille_if_list="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_bastille_if_list}")"
+        done
+        _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
+        export _bastille_if_list
+        export _bastille_if_count
+    elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+        for _config in /usr/local/etc/bastille/*.conf; do
+            local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
+            _bastille_if_list="$(printf '%s\n%s' "$( (grep -Ehos 'ng[0-9]+_bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | grep -Eos 'bastille[0-9]+'; ngctl list -n | grep "eiface" | grep -Eos 'ng[0-9]+_bastille[0-9]+' | grep -Eos 'bastille[0-9]+') | grep -Eos '[0-9]+')" "${_bastille_if_list}")"
+        done
+        _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
+        export _bastille_if_list
+        export _bastille_if_count
+    fi
 }
 
 get_jail_name() {
@@ -288,12 +298,12 @@ generate_vnet_jail_netblock() {
     local external_interface="${3}"
     local static_mac="${4}"
     # Get number of epairs on the system
-    get_epair_count
-    local _epair_num_range=$((_epair_count + 1))
+    get_bastille_if_count
+    local _bastille_if_num_range=$((_bastille_if_count + 1))
     if [ -n "${use_unique_bridge}" ]; then
-        if [ "${_epair_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
+        if [ "${_bastille_if_count}" -gt 0 ]; then  
+            for _num in $(seq 0 "${_bastille_if_num_range}"); do
+                if ! echo "${_bastille_if_list}" | grep -oqswx "${_num}"; then
                     if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
                         local host_epair=e${_num}a_${jail_name}
                         local jail_epair=e${_num}b_${jail_name}
@@ -316,15 +326,15 @@ generate_vnet_jail_netblock() {
             fi
         fi
     else
-        if [ "${_epair_count}" -gt 0 ]; then  
-            for _num in $(seq 0 "${_epair_num_range}"); do
-                if ! echo "${_epair_list}" | grep -oqswx "${_num}"; then
-                    local uniq_epair="bastille${_num}"
+        if [ "${_bastille_if_count}" -gt 0 ]; then  
+            for _num in $(seq 0 "${_bastille_if_num_range}"); do
+                if ! echo "${_bastille_if_list}" | grep -oqswx "${_num}"; then
+                    local _jail_if="bastille${_num}"
                     break
                 fi
             done
         else
-            local uniq_epair="bastille0"
+            local _jail_if="bastille0"
         fi
     fi
     ## If BRIDGE is enabled, generate bridge config, else generate VNET config
@@ -366,21 +376,21 @@ EOF
                 generate_static_mac "${jail_name}" "${external_interface}"
                 cat <<-EOF
   vnet;
-  vnet.interface = e0b_${uniq_epair};
-  exec.prestart += "jib addm ${uniq_epair} ${external_interface}";
-  exec.prestart += "ifconfig e0a_${uniq_epair} ether ${macaddr}a";
-  exec.prestart += "ifconfig e0b_${uniq_epair} ether ${macaddr}b";
-  exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "jib destroy ${uniq_epair}";
+  vnet.interface = e0b_${_jail_if};
+  exec.prestart += "jib addm ${_jail_if} ${external_interface}";
+  exec.prestart += "ifconfig e0a_${_jail_if} ether ${macaddr}a";
+  exec.prestart += "ifconfig e0b_${_jail_if} ether ${macaddr}b";
+  exec.prestart += "ifconfig e0a_${_jail_if} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "jib destroy ${_jail_if}";
 EOF
             else
                 ## Generate VNET config without static MAC address
                 cat <<-EOF
   vnet;
-  vnet.interface = e0b_${uniq_epair};
-  exec.prestart += "jib addm ${uniq_epair} ${external_interface}";
-  exec.prestart += "ifconfig e0a_${uniq_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "jib destroy ${uniq_epair}";
+  vnet.interface = e0b_${_jail_if};
+  exec.prestart += "jib addm ${_jail_if} ${external_interface}";
+  exec.prestart += "ifconfig e0a_${_jail_if} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "jib destroy ${_jail_if}";
 EOF
             fi
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
@@ -389,18 +399,18 @@ EOF
                 generate_static_mac "${jail_name}" "${external_interface}"
                 cat <<-EOF
   vnet;
-  vnet.interface = ng0_${uniq_epair};
-  exec.prestart += "jng bridge ${uniq_epair} ${external_interface}";
-  exec.prestart += "ifconfig ng0_${uniq_epair} ether ${macaddr}a";
-  exec.poststop += "jng shutdown ${uniq_epair}";
+  vnet.interface = ng0_${_jail_if};
+  exec.prestart += "jng bridge ${_jail_if} ${external_interface}";
+  exec.prestart += "ifconfig ng0_${_jail_if} ether ${macaddr}a";
+  exec.poststop += "jng shutdown ${_jail_if}";
 EOF
             else
                 ## Generate VNET config without static MAC address
                 cat <<-EOF
   vnet;
-  vnet.interface = ng0_${uniq_epair};
-  exec.prestart += "jng bridge ${uniq_epair} ${external_interface}";
-  exec.poststop += "jng shutdown ${uniq_epair}";
+  vnet.interface = ng0_${_jail_if};
+  exec.prestart += "jng bridge ${_jail_if} ${external_interface}";
+  exec.poststop += "jng shutdown ${_jail_if}";
 EOF
             fi
         else

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -135,8 +135,6 @@ get_bastille_if_count() {
         _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
         export _bastille_if_list
         export _bastille_if_count
-    else
-        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
     fi
 }
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -417,6 +417,15 @@ EOF
     fi
 }
 
+validate_netconf() {
+    if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
+        error_exit "Invalid network configuration."
+    fi
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
+    fi
+}
+
 checkyesno() {
     ## copied from /etc/rc.subr -- cedwards (20231125)
     ## issue #368 (lowercase values should be parsed)

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -419,7 +419,7 @@ EOF
 
 validate_netconf() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
-        error_exit "Invalid network configuration."
+        error_exit "[ERROR]: 'bastille_network_loopback' and 'bastille_network_shared' cannot both be set."
     fi
     if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
         error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -536,7 +536,7 @@ create_jail() {
                     fi
                 fi
             elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-                if [ ! "$(command -v jib)" ]; then
+                if [ ! "$(command -v jng)" ]; then
                     if [ -f /usr/share/examples/jails/jng ] && [ ! -f /usr/local/bin/jng ]; then
                         install -m 0544 /usr/share/examples/jails/jng /usr/local/bin/jng
                     fi
@@ -828,7 +828,7 @@ elif [ -n "${VNET_JAIL}" ] && [ -z "${VNET_JAIL_BRIDGE}" ]; then
 fi
 
 # Do not allow netgraph with -B|--bridge yet...
-if [ "${bastille_network_vnet_type}" = "netgraph" ] && [ "${VNET_JAIL_BRIDGE}" -eq 1 ]; then
+if [ "${bastille_network_vnet_type}" = "netgraph" ] && [ -n "${VNET_JAIL_BRIDGE}" ]; then
     error_exit "[ERROR]: Netgraph does not support the [-B|--bridge] option."
 fi
 
@@ -1012,4 +1012,5 @@ fi
 if check_target_exists "${NAME}"; then
     error_exit "Error: Existing jail found: ${NAME}"
 fi
+
 create_jail "${NAME}" "${RELEASE}" "${IP}" "${INTERFACE}"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -168,7 +168,7 @@ validate_netif() {
     fi
 }
 
-validate_netconf() {
+validate_netconf_create() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
         error_exit "Invalid network configuration."
     fi
@@ -966,18 +966,18 @@ if [ -z "${EMPTY_JAIL}" ]; then
     ## check if interface is valid
     if [ -n "${INTERFACE}" ]; then
         validate_netif
-        validate_netconf
+        validate_netconf_create
     elif [ -n "${VNET_JAIL}" ]; then
         if [ -z "${INTERFACE}" ]; then
             if [ -z "${bastille_network_shared}" ]; then
                 # User must specify interface on vnet jails.
                 error_exit "Error: Network interface not defined."
             else
-                validate_netconf
+                validate_netconf_create
             fi
         fi
     else
-        validate_netconf
+        validate_netconf_create
     fi
 else
     info "Creating empty jail: ${NAME}."

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -172,6 +172,9 @@ validate_netconf() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
         error_exit "Invalid network configuration."
     fi
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] || [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
+    fi
 }
 
 validate_release() {

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -168,15 +168,6 @@ validate_netif() {
     fi
 }
 
-validate_netconf_create() {
-    if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
-        error_exit "Invalid network configuration."
-    fi
-    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
-        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
-    fi
-}
-
 validate_release() {
     ## ensure the user set the Linux(experimental) option explicitly
     if [ -n "${UBUNTU}" ]; then
@@ -458,11 +449,11 @@ create_jail() {
 
                         ## sane bastille zfs options
                         ZFS_OPTIONS=$(echo ${bastille_zfs_options} | sed 's/-o//g')
-			## send without -R if encryption is enabled
+                        ## send without -R if encryption is enabled
                         if [ "$(zfs get -H -o value encryption "${bastille_zfs_zpool}/${bastille_zfs_prefix}")" = "off" ]; then
-			    OPT_SEND="-R"
+                            OPT_SEND="-R"
                         else
-			    OPT_SEND=""
+                            OPT_SEND=""
                         fi
 
                         ## take a temp snapshot of the base release
@@ -966,18 +957,18 @@ if [ -z "${EMPTY_JAIL}" ]; then
     ## check if interface is valid
     if [ -n "${INTERFACE}" ]; then
         validate_netif
-        validate_netconf_create
+        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
     elif [ -n "${VNET_JAIL}" ]; then
         if [ -z "${INTERFACE}" ]; then
             if [ -z "${bastille_network_shared}" ]; then
                 # User must specify interface on vnet jails.
                 error_exit "Error: Network interface not defined."
             else
-                validate_netconf_create
+                validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
             fi
         fi
     else
-        validate_netconf_create
+        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
     fi
 else
     info "Creating empty jail: ${NAME}."

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -528,10 +528,18 @@ create_jail() {
 
         ## VNET specific
         if [ -n "${VNET_JAIL}" ]; then
-            ## VNET requires jib script
-            if [ ! "$(command -v jib)" ]; then
-                if [ -f /usr/share/examples/jails/jib ] && [ ! -f /usr/local/bin/jib ]; then
-                    install -m 0544 /usr/share/examples/jails/jib /usr/local/bin/jib
+            ## VNET requires jib or jng script
+            if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+                if [ ! "$(command -v jib)" ]; then
+                    if [ -f /usr/share/examples/jails/jib ] && [ ! -f /usr/local/bin/jib ]; then
+                        install -m 0544 /usr/share/examples/jails/jib /usr/local/bin/jib
+                    fi
+                fi
+            elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+                if [ ! "$(command -v jib)" ]; then
+                    if [ -f /usr/share/examples/jails/jng ] && [ ! -f /usr/local/bin/jng ]; then
+                        install -m 0544 /usr/share/examples/jails/jng /usr/local/bin/jng
+                    fi
                 fi
             fi
         fi
@@ -817,6 +825,11 @@ elif [ -n "${VNET_JAIL}" ] && [ -z "${VNET_JAIL_BRIDGE}" ]; then
     if ifconfig -g bridge | grep -owq "${INTERFACE}"; then
         error_exit "Interface is a bridge: ${INTERFACE}"
     fi
+fi
+
+# Do not allow netgraph with -B|--bridge yet...
+if [ "${bastille_network_vnet_type}" = "netgraph" ] && [ "${VNET_JAIL_BRIDGE}" -eq 1 ]; then
+    error_exit "[ERROR]: Netgraph does not support the [-B|--bridge] option."
 fi
 
 if [ -n "${LINUX_JAIL}" ] && [ -n "${VALIDATE_RELEASE}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -172,7 +172,7 @@ validate_netconf_create() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
         error_exit "Invalid network configuration."
     fi
-    if [ "${bastille_network_vnet_type}" != "if_bridge" ] || [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
         error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
     fi
 }

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -540,9 +540,7 @@ create_jail() {
                     if [ -f /usr/share/examples/jails/jng ] && [ ! -f /usr/local/bin/jng ]; then
                         install -m 0544 /usr/share/examples/jails/jng /usr/local/bin/jng
                     fi
-                fi
-            else 
-                error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
+                fi 
             fi
         fi
     elif [ -n "${LINUX_JAIL}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -957,18 +957,18 @@ if [ -z "${EMPTY_JAIL}" ]; then
     ## check if interface is valid
     if [ -n "${INTERFACE}" ]; then
         validate_netif
-        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
+        validate_netconf
     elif [ -n "${VNET_JAIL}" ]; then
         if [ -z "${INTERFACE}" ]; then
             if [ -z "${bastille_network_shared}" ]; then
                 # User must specify interface on vnet jails.
                 error_exit "Error: Network interface not defined."
             else
-                validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
+                validate_netconf
             fi
         fi
     else
-        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
+        validate_netconf
     fi
 else
     info "Creating empty jail: ${NAME}."

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -541,6 +541,8 @@ create_jail() {
                         install -m 0544 /usr/share/examples/jails/jng /usr/local/bin/jng
                     fi
                 fi
+            else 
+                error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
             fi
         fi
     elif [ -n "${LINUX_JAIL}" ]; then

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -81,7 +81,7 @@ destroy_jail() {
                         # This will deal with the common "cannot unmount 'XYZ': pool or dataset is busy"
                         # unless the force option is defined by the user, otherwise will have a partially deleted jail.
                         if ! zfs destroy "${OPTIONS}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"; then
-                            error_exit "Jail dataset(s) appears to be busy, exiting."
+                            error_continue "Jail dataset(s) appears to be busy, exiting."
                         fi
                     fi
                 fi

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -236,8 +236,8 @@ generate_config() {
 
     # See if we need to generate a vnet network section
     if [ "${IS_VNET_JAIL:-0}" = "1" ]; then
-        NETBLOCK=$(generate_vnet_jail_netblock "${TARGET_TRIM}" "" "${VNET_DEFAULT_INTERFACE}" "${OPT_STATIC_MAC}")
         vnet_requirements
+        NETBLOCK=$(generate_vnet_jail_netblock "${TARGET_TRIM}" "" "${VNET_DEFAULT_INTERFACE}" "${OPT_STATIC_MAC}")
     else
         # If there are multiple IP/NIC let the user configure network
         IP4_DEFINITION=""
@@ -443,11 +443,21 @@ workout_components() {
 
 vnet_requirements() {
     # VNET jib script requirement
-    if [ ! "$(command -v jib)" ]; then
-        if [ -f "/usr/share/examples/jails/jib" ] && [ ! -f "/usr/local/bin/jib" ]; then
-            install -m 0544 /usr/share/examples/jails/jib /usr/local/bin/jib
-        else
-            warn "Warning: Unable to locate/install jib script required by VNET jails."
+    if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+        if [ ! "$(command -v jib)" ]; then
+            if [ -f "/usr/share/examples/jails/jib" ] && [ ! -f "/usr/local/bin/jib" ]; then
+                install -m 0544 /usr/share/examples/jails/jib /usr/local/bin/jib
+            else
+                warn "Warning: Unable to locate/install jib script required by VNET jails."
+            fi
+        fi
+    elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+        if [ ! "$(command -v jng)" ]; then
+            if [ -f "/usr/share/examples/jails/jng" ] && [ ! -f "/usr/local/bin/jng" ]; then
+                install -m 0544 /usr/share/examples/jails/jng /usr/local/bin/jng
+            else
+                warn "Warning: Unable to locate/install jng script required by VNET jails."
+            fi
         fi
     fi
 }

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -560,7 +560,7 @@ add_vlan() {
 
 case "${ACTION}" in
     add)
-        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
+        validate_netconf
         validate_netif "${INTERFACE}"
         if check_interface_added "${TARGET}" "${INTERFACE}" && [ -z "${VLAN_ID}" ]; then
             error_exit "Interface is already added: \"${INTERFACE}\""

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -208,9 +208,12 @@ validate_netif() {
     fi
 }
 
-validate_netconf() {
+validate_netconf_network() {
     if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
         error_exit "Invalid network configuration."
+    fi
+    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
+        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
     fi
 }
 
@@ -566,15 +569,15 @@ add_vlan() {
 
 case "${ACTION}" in
     add)
-        validate_netconf
+        validate_netconf_network
         validate_netif "${INTERFACE}"
         if check_interface_added "${TARGET}" "${INTERFACE}" && [ -z "${VLAN_ID}" ]; then
             error_exit "Interface is already added: \"${INTERFACE}\""
         elif { [ "${VNET}" -eq 1 ] || [ "${BRIDGE}" -eq 1 ] || [ "${PASSTHROUGH}" -eq 1 ]; } && [ -n "${VLAN_ID}" ]; then
-	    add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
+            add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
             exit 0
         fi
-	## validate IP if not empty
+        ## validate IP if not empty
         if [ -n "${IP}" ]; then
             validate_ip "${IP}"
         fi
@@ -585,8 +588,8 @@ case "${ACTION}" in
                 error_exit "\"${INTERFACE}\" is a bridge interface."
             else
                 add_interface "${TARGET}" "${INTERFACE}" "${IP}"
-		if [ -n "${VLAN_ID}" ]; then
-		    add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
+                if [ -n "${VLAN_ID}" ]; then
+                    add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
                 fi
                 if [ "${AUTO}" -eq 1 ]; then
                     bastille start "${TARGET}"
@@ -599,8 +602,8 @@ case "${ACTION}" in
                 error_exit "\"${INTERFACE}\" is not a bridge interface."
             else
                 add_interface "${TARGET}" "${INTERFACE}" "${IP}"
-		if [ -n "${VLAN_ID}" ]; then
-		    add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
+		        if [ -n "${VLAN_ID}" ]; then
+		            add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
                 fi
                 if [ "${AUTO}" -eq 1 ]; then
                     bastille start "${TARGET}"
@@ -613,7 +616,7 @@ case "${ACTION}" in
                 add_interface "${TARGET}" "${INTERFACE}" "${IP}"
             fi
             if [ -n "${VLAN_ID}" ]; then
-		add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
+                add_vlan "${TARGET}" "${INTERFACE}" "${IP}" "${VLAN_ID}"
             fi
             if [ "${AUTO}" -eq 1 ]; then
                 bastille start "${TARGET}"

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -360,7 +360,7 @@ EOF
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
             for _num in $(seq 0 "${_bastille_if_num_range}"); do
                 if ! echo "${_bastille_if_list}" | grep -oqswx "${_num}"; then
-                        local jail_if="bastille${_num}"
+                        local _jail_if="bastille${_num}"
                         break
                 fi
             done

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -208,15 +208,6 @@ validate_netif() {
     fi
 }
 
-validate_netconf_network() {
-    if [ -n "${bastille_network_loopback}" ] && [ -n "${bastille_network_shared}" ]; then
-        error_exit "Invalid network configuration."
-    fi
-    if [ "${bastille_network_vnet_type}" != "if_bridge" ] && [ "${bastille_network_vnet_type}" != "netgraph" ]; then
-        error_exit "[ERROR]: 'bastille_network_vnet_type' not set properly: ${bastille_network_vnet_type}"
-    fi
-}
-
 check_interface_added() {
     local _jailname="${1}"
     local _if="${2}"
@@ -569,7 +560,7 @@ add_vlan() {
 
 case "${ACTION}" in
     add)
-        validate_netconf_network
+        validate_netconf || error_exit "[ERROR]: Failed to validate Bastille network configuration."
         validate_netif "${INTERFACE}"
         if check_interface_added "${TARGET}" "${INTERFACE}" && [ -z "${VLAN_ID}" ]; then
             error_exit "Interface is already added: \"${INTERFACE}\""

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -114,10 +114,18 @@ update_jailconf() {
 }
 
 update_jailconf_vnet() {
+
     local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
     local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
-    # Change epair name (if needed)
-    local _if_list="$(grep -Eo 'epair[0-9]+|bastille[0-9]+' ${_jail_conf} | sort -u)"
+
+    # Change bastille interface name (only needed for bridged epairs)
+    # We still gather interface names for JIB and JNG managed interfaces (for future use)
+    if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+        local _if_list="$(grep -Eo 'epair[0-9]+|e[0-9]+_bastille[0-9]+' ${_jail_conf} | sort -u)"
+    elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+        local _if_list="$(grep -Eo 'ng[0-9]+_bastille[0-9]+' ${_jail_conf} | sort -u)"
+    fi
+
     for _if in ${_if_list}; do
         if echo ${_if} | grep -Eoq 'epair[0-9]+'; then
             # Check if epair name = jail name


### PR DESCRIPTION
#262 

This introduces initial support for netgraph using the JNG script included in a default BSD install. 

This requires a host that is brand new. Netgraph DOES NOT work with epairs. You must use one or the other. 

To get started.

1. Run `bastille setup netgraph` to load the required modules. This will also set the new variable inside bastille.conf `bastille_network_vnet_type=netgraph`. Don't forget to diff update your old config file.

2. Create a jail using -V. -B is not supported. 

EDIT: Create, rename, clone, network, import subcommands should all work with netgraph at this point. Bug reports are welcome.

This is highly experimental, but it seems to work fine.