### PR TITLE
Initial beta support for dependant jails

### DIFF
--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -157,14 +157,14 @@ for _jail in ${JAILS}; do
     # Depend property
     elif [ "${PROPERTY}" = "depend" ] || [ "${PROPERTY}" = "depends" ]; then
 
-        PROPERTY="depends"
+        PROPERTY="depend"
         BASTILLE_PROPERTY=1
         FILE="${bastille_jailsdir}/${_jail}/settings.conf"
 
         if [ "${ACTION}" = "set" ]; then
 
             if [ -z "${VALUE}" ]; then
-                error_exit "[ERROR]: Adding a jail to the 'depends' property requires a TARGET."
+                error_exit "[ERROR]: Adding a jail to the 'depend' property requires a TARGET."
             else
                 set_target "${VALUE}"
             fi
@@ -176,7 +176,7 @@ for _jail in ${JAILS}; do
         elif [ "${ACTION}" = "remove" ]; then
 
             if [ -z "${VALUE}" ]; then
-                error_exit "[ERROR]: Removing a jail from the 'depends' property requires a TARGET."
+                error_exit "[ERROR]: Removing a jail from the 'depend' property requires a TARGET."
             else
                 set_target "${VALUE}"
             fi

--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -88,16 +88,16 @@ shift 2
 set_target "${TARGET}"
 
 case "${ACTION}" in
-    get|remove)
+    get)
         if [ "$#" -ne 1 ]; then
             error_notify 'Too many parameters for [get|remove] operation.'
             usage
         fi
         ;;
-    set) 
+    set|remove) 
         ;;
     *)
-        error_exit 'Only get and set are supported.'
+        error_exit "[ERROR]: Only set, remove and get are supported."
         ;;
 esac
 
@@ -117,31 +117,78 @@ print_jail_conf() {
 for _jail in ${JAILS}; do
 
     # Handle Bastille specific properties
-    # Currently only 'priority' and 'boot'
+    # Currently only 'depend' 'priority' and 'boot'
     if [ "${PROPERTY}" = "priority" ] || [ "${PROPERTY}" = "prio" ]; then
+
         PROPERTY="priority"
         BASTILLE_PROPERTY=1
         FILE="${bastille_jailsdir}/${_jail}/boot.conf"
+
         if [ "${ACTION}" = "set" ]; then
             if echo "${VALUE}" | grep -Eq '^[0-9]+$'; then
                 sysrc -f "${FILE}" "${PROPERTY}=${VALUE}"
             else
                 error_exit "Priority value must be a number."
             fi
-        else
+        elif [ "${ACTION}" = "remove" ]; then
+            error_exit "[ERROR]: Cannot remove the 'priority' property."
+        elif [ "${ACTION}" = "get" ]; then
             sysrc -f "${FILE}" -n "${PROPERTY}"
         fi
+
+    # Boot property
     elif [ "${PROPERTY}" = "boot" ]; then
+
         BASTILLE_PROPERTY=1
         FILE="${bastille_jailsdir}/${_jail}/boot.conf"
+
         if [ "${ACTION}" = "set" ]; then
             if [ "${VALUE}" = "on" ] || [ "${VALUE}" = "off" ]; then
                 sysrc -f "${FILE}" "${PROPERTY}=${VALUE}"
             else
                 error_exit "Boot value must be 'on' or 'off'."
             fi
-        else
+        elif [ "${ACTION}" = "remove" ]; then
+            error_exit "[ERROR]: Cannot remove the 'boot' property."
+        elif [ "${ACTION}" = "get" ]; then
             sysrc -f "${FILE}" -n "${PROPERTY}"
+        fi
+
+    # Depend property
+    elif [ "${PROPERTY}" = "depend" ] || [ "${PROPERTY}" = "depends" ]; then
+
+        PROPERTY="depends"
+        BASTILLE_PROPERTY=1
+        FILE="${bastille_jailsdir}/${_jail}/settings.conf"
+
+        if [ "${ACTION}" = "set" ]; then
+
+            if [ -z "${VALUE}" ]; then
+                error_exit "[ERROR]: Adding a jail to the 'depends' property requires a TARGET."
+            else
+                set_target "${VALUE}"
+            fi
+
+            info "\n[${_jail}]:"
+
+            sysrc -f "${FILE}" "${PROPERTY}+=${JAILS}"
+
+        elif [ "${ACTION}" = "remove" ]; then
+
+            if [ -z "${VALUE}" ]; then
+                error_exit "[ERROR]: Removing a jail from the 'depends' property requires a TARGET."
+            else
+                set_target "${VALUE}"
+            fi
+
+            info "\n[${_jail}]:"
+
+            sysrc -f "${FILE}" "${PROPERTY}-=${JAILS}"
+
+        elif [ "${ACTION}" = "get" ]; then
+
+            sysrc -f "${FILE}" -n "${PROPERTY}"
+
         fi
     else
         FILE="${bastille_jailsdir}/${_jail}/jail.conf"
@@ -186,9 +233,15 @@ for _jail in ${JAILS}; do
             fi
         elif [ "${ACTION}" = "remove" ]; then
             if [ "$(bastille config ${_jail} get ${PROPERTY})" != "not set" ]; then
+
+                info "\n[${_jail}]:"
+
                 sed -i '' "/.*${PROPERTY}.*/d" "${FILE}"
+
+                echo "Property removed: ${PROPERTY}"
+
             else
-                error_exit "Value not present in jail.conf: ${PROPERTY}"
+                error_exit "[ERROR]: Value not present in jail.conf: ${PROPERTY}"
             fi
         else # Setting the value. -- cwells
             if [ -n "${VALUE}" ]; then

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -576,8 +576,9 @@ create_jail() {
     # Set strict permissions on the jail by default
     chmod 0700 "${bastille_jailsdir}/${NAME}"
 
-    # Apply priority and boot settings before starting jail
+    # Apply boot, depends and priority settings before starting jail
     sysrc -f "${bastille_jailsdir}/${NAME}/boot.conf" boot=${BOOT} >/dev/null
+    sysrc -f "${bastille_jailsdir}/${NAME}/settings.conf" depend="" >/dev/null
     sysrc -f "${bastille_jailsdir}/${NAME}/boot.conf" priority="${PRIORITY}" >/dev/null
 
     # Jail must be started before applying the default template. -- cwells

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -112,11 +112,22 @@ for _jail in ${JAILS}; do
         fi
     fi
 
-    info "\n[${_jail}]:"
+    # Validate that all 'depends' jails are running
+    _depend_jails="$(sysrc -f ${bastille_jailsdir}/${_jail}/settings.conf -n depends)"
+    for _depend_jail in ${_depend_jails}; do
+        if check_target_is_running; then
+            continue
+        else
+            bastille start ${_depend_jail}
+        fi
+    done
 	
     if check_target_is_running "${_jail}"; then
+        info "\n[${_jail}]:"
         error_continue "Jail is already running."
     fi
+
+    info "\n[${_jail}]:"
 	
     # Validate interfaces and add IPs to firewall table
     if [ "$(bastille config ${_jail} get vnet)" != 'enabled' ]; then

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -113,7 +113,7 @@ for _jail in ${JAILS}; do
     fi
 
     # Validate that all 'depends' jails are running
-    _depend_jails="$(sysrc -f ${bastille_jailsdir}/${_jail}/settings.conf -n depends)"
+    _depend_jails="$(sysrc -f ${bastille_jailsdir}/${_jail}/settings.conf -n depend)"
     for _depend_jail in ${_depend_jails}; do
         if check_target_is_running; then
             continue

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -89,8 +89,8 @@ for _jail in ${JAILS}; do
 
     # Validate that all jails that 'depend' on this one are stopped
     for _depend_jail in $(ls --color=never ${bastille_jailsdir} | sed -e 's/\n//g'); do
-    if ! grep -hoqsw "depends=" ${bastille_jailsdir}/${_depend_jail}/settings.conf; then
-        sysrc -q -f ${bastille_jailsdir}/${_depend_jail}/settings.conf depends="" >/dev/null
+    if ! grep -hoqsw "depend=" ${bastille_jailsdir}/${_depend_jail}/settings.conf; then
+        sysrc -q -f ${bastille_jailsdir}/${_depend_jail}/settings.conf depend="" >/dev/null
     fi
         if [ "${_jail}" = "${_depend_jail}" ]; then
             continue


### PR DESCRIPTION
This will add support for `bastille config TARGET set depend jail1`

When starting TARGET, jail1 should be started before TARGET starts.

When stopping jail1, TARGET should be stopped before jail1 stops.

This is simply a value at `${bastille_jailsdir}/${TARGET}/settings.conf` which can also be edited manually.

This is beta, so bug reports are welcome.

The `depends` value will be auto filled with and empty value when jails are first stopped, or first created.