### PR TITLE
support altroot

### DIFF
--- a/docs/chapters/subcommands/setup.rst
+++ b/docs/chapters/subcommands/setup.rst
@@ -14,7 +14,6 @@ Below is a list of available options that can be used with the ``setup`` command
 
   ishmael ~ # bastille setup -h
   Usage: bastille setup [option(s)] [bridge]
-                                    [filesystem]
                                     [loopback]
                                     [pf|firewall]
                                     [shared]
@@ -40,9 +39,6 @@ that jails will get linked to on creation. It is not attached to any specific in
 networking option. The ``loopback`` and ``shared`` options are only for cases where the ``interface``
 is not specified during the ``create`` command. If an interface is specified, these options have no effect. 
 Instead, the specified interface will be used.
-
-The ``filesystem`` option is to ensure the proper datasets/directories are in place
-for using Bastille. This should only have to be run once on a new system.
 
 The ``shared`` option is for cases where you want an actual interface to use with bastille as
 opposed to a loopback. Jails will be linked to the shared interface on creation.

--- a/docs/chapters/zfs-support.rst
+++ b/docs/chapters/zfs-support.rst
@@ -1,5 +1,6 @@
 ZFS Support
-====================
+===========
+
 .. image:: /images/bastillebsd-twitter-poll.png
   :width: 400
   :alt: Alternative text
@@ -58,6 +59,19 @@ dataset for bastille.
 Bastille will mount the datasets it creates at ``bastille_prefix`` which
 defaults to ``/usr/local/bastille``
 If this is not desirable, you can change it at the top of the config file.
+
+Altroot
+-------
+
+If a ZFS pool has been imported using ``-R`` (altroot), your system will automatically add whatever the ``altroot`` is to
+any ``zfs mount`` commands. Bastille supports using an ``altroot``, and there should be no issues using this feature.
+
+One thing to note though, is that you MUST NOT include your ``altroot`` path in the ``bastille_prefix``. For example, if
+you imported your pool with ``zpool import -R /mnt poolname``, and you wish for your jails to live at ``/mnt/poolname/bastille``
+then ``bastille_prefix`` should be set to ``/poolname/bastille`` without the ``/mnt`` part.
+
+If you do accidentally add the ``/mnt`` part, your datasets will be mounted at ``/mnt/mnt/poolname/bastille`` and Bastille will
+throw all kinds of errors due to not finding the proper paths.
 
 Jailing a Dataset
 -----------------

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -404,7 +404,7 @@ bootstrap_template() {
     if [ ! -d "${bastille_templatesdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
             fi
         else
             mkdir -p "${bastille_templatesdir}"

--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -81,7 +81,7 @@ bootstrap_directories() {
     if [ ! -d "${bastille_prefix}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_prefix}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_prefix_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
             fi
         else
             mkdir -p "${bastille_prefix}"
@@ -90,9 +90,9 @@ bootstrap_directories() {
     # Make sure the dataset is mounted in the proper place
     elif [ -d "${bastille_prefix}" ] && checkyesno bastille_zfs_enable; then
         if ! zfs list "${bastille_zfs_zpool}/${bastille_zfs_prefix}" >/dev/null; then
-            zfs create ${bastille_zfs_options} -o mountpoint="${bastille_prefix}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
+            zfs create ${bastille_zfs_options} -o mountpoint="${bastille_prefix_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
         elif [ "$(zfs get -H -o value mountpoint ${bastille_zfs_zpool}/${bastille_zfs_prefix})" != "${bastille_prefix}" ]; then
-            zfs set mountpoint="${bastille_prefix}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
+            zfs set mountpoint="${bastille_prefix_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}"
         fi
     fi
 
@@ -100,7 +100,7 @@ bootstrap_directories() {
     if [ ! -d "${bastille_backupsdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_backupsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/backups"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_backupsdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/backups"
             fi
         else
             mkdir -p "${bastille_backupsdir}"
@@ -112,10 +112,10 @@ bootstrap_directories() {
     if [ ! -d "${bastille_cachedir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache"
                 # Don't create unused/stale cache/RELEASE directory on Linux jails creation.
                 if [ -z "${NOCACHEDIR}" ]; then
-                    zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
+                    zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir_mountpoint}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
                 fi
             fi
         else
@@ -131,7 +131,7 @@ bootstrap_directories() {
         if [ -z "${NOCACHEDIR}" ]; then
             if checkyesno bastille_zfs_enable; then
                 if [ -n "${bastille_zfs_zpool}" ]; then
-                    zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
+                    zfs create ${bastille_zfs_options} -o mountpoint="${bastille_cachedir_mountpoint}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/cache/${RELEASE}"
                 fi
             else
                 mkdir -p "${bastille_cachedir}/${RELEASE}"
@@ -143,7 +143,7 @@ bootstrap_directories() {
     if [ ! -d "${bastille_jailsdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_jailsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_jailsdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails"
             fi
         else
             mkdir -p "${bastille_jailsdir}"
@@ -154,7 +154,7 @@ bootstrap_directories() {
     if [ ! -d "${bastille_logsdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_logsdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/logs"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_logsdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/logs"
             fi
         else
             mkdir -p "${bastille_logsdir}"
@@ -165,7 +165,7 @@ bootstrap_directories() {
     if [ ! -d "${bastille_templatesdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_templatesdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/templates"
             fi
         else
             mkdir -p "${bastille_templatesdir}"
@@ -176,8 +176,8 @@ bootstrap_directories() {
     if [ ! -d "${bastille_releasesdir}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases"
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir_mountpoint}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir_mountpoint}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
             fi
         else
             mkdir -p "${bastille_releasesdir}/${RELEASE}"
@@ -186,7 +186,7 @@ bootstrap_directories() {
     elif [ ! -d "${bastille_releasesdir}/${RELEASE}" ]; then
         if checkyesno bastille_zfs_enable; then
             if [ -n "${bastille_zfs_zpool}" ]; then
-                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
+                zfs create ${bastille_zfs_options} -o mountpoint="${bastille_releasesdir_mountpoint}/${RELEASE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/releases/${RELEASE}"
             fi
        else
            mkdir -p "${bastille_releasesdir}/${RELEASE}"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -295,6 +295,34 @@ set_target_single() {
     export JAILS
 }
 
+set_zfs_mountpoints() {
+
+    # We have to do this if ALTROOT is enabled/present
+    local _altroot="$(zpool get -Ho value altroot ${bastille_zfs_zpool})"
+
+    if [ "${_altroot}" != "-" ]; then
+
+        # Set mountpoints to *dir*
+        bastille_prefix_mountpoint="${bastille_prefix}"
+        bastille_backupsdir_mountpoint="${bastille_backupsdir}"
+        bastille_cachedir_mountpoint="${bastille_cachedir}"
+        bastille_jailsdir_mountpoint="${bastille_jailsdir}"
+        bastille_releasesdir_mountpoint="${bastille_releasesdir}"
+        bastille_templatesdir_mountpoint="${bastille_templatesdir}"
+        bastille_logsdir_mountpoint="${bastille_logsdir}"  
+
+        # Set *dir* to include ALTROOT
+        bastille_prefix="${_altroot}${bastille_prefix}"
+        bastille_backupsdir="${_altroot}${bastille_backupsdir}"
+        bastille_cachedir="${_altroot}${bastille_cachedir}"
+        bastille_jailsdir="${_altroot}${bastille_jailsdir}"
+        bastille_releasesdir="${_altroot}${bastille_releasesdir}"
+        bastille_templatesdir="${_altroot}${bastille_templatesdir}"
+        bastille_logsdir="${_altroot}${bastille_logsdir}" 
+
+    fi
+}
+
 target_all_jails() {
     local _JAILS="$(bastille list jails)"
     JAILS=""

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -301,17 +301,24 @@ set_zfs_mountpoints() {
     # We have to do this if ALTROOT is enabled/present
     local _altroot="$(zpool get -Ho value altroot ${bastille_zfs_zpool})"
 
-    if [ "${_altroot}" != "-" ]; then
+    # Set mountpoints to *bastille*dir*
+    # shellcheck disable=SC2034
+    bastille_prefix_mountpoint="${bastille_prefix}"
+    # shellcheck disable=SC2034
+    bastille_backupsdir_mountpoint="${bastille_backupsdir}"
+    # shellcheck disable=SC2034
+    bastille_cachedir_mountpoint="${bastille_cachedir}"
+    # shellcheck disable=SC2034
+    bastille_jailsdir_mountpoint="${bastille_jailsdir}"
+    # shellcheck disable=SC2034
+    bastille_releasesdir_mountpoint="${bastille_releasesdir}"
+    # shellcheck disable=SC2034
+    bastille_templatesdir_mountpoint="${bastille_templatesdir}"
+    # shellcheck disable=SC2034
+    bastille_logsdir_mountpoint="${bastille_logsdir}"
 
-        # Set mountpoints to *dir*
-        bastille_prefix_mountpoint="${bastille_prefix}"
-        bastille_backupsdir_mountpoint="${bastille_backupsdir}"
-        bastille_cachedir_mountpoint="${bastille_cachedir}"
-        bastille_jailsdir_mountpoint="${bastille_jailsdir}"
-        bastille_releasesdir_mountpoint="${bastille_releasesdir}"
-        bastille_templatesdir_mountpoint="${bastille_templatesdir}"
-        bastille_logsdir_mountpoint="${bastille_logsdir}"  
-
+    # Add _altroot to *dir* if set
+    if [ "${_altroot}" != "-" ]; then  
         # Set *dir* to include ALTROOT
         bastille_prefix="${_altroot}${bastille_prefix}"
         bastille_backupsdir="${_altroot}${bastille_backupsdir}"
@@ -320,7 +327,6 @@ set_zfs_mountpoints() {
         bastille_releasesdir="${_altroot}${bastille_releasesdir}"
         bastille_templatesdir="${_altroot}${bastille_templatesdir}"
         bastille_logsdir="${_altroot}${bastille_logsdir}" 
-
     fi
 }
 set_zfs_mountpoints

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -295,6 +295,7 @@ set_target_single() {
     export JAILS
 }
 
+# This function is run immediately
 set_zfs_mountpoints() {
 
     # We have to do this if ALTROOT is enabled/present
@@ -322,6 +323,7 @@ set_zfs_mountpoints() {
 
     fi
 }
+set_zfs_mountpoints
 
 target_all_jails() {
     local _JAILS="$(bastille list jails)"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -296,40 +296,42 @@ set_target_single() {
 }
 
 # This function is run immediately
-set_zfs_mountpoints() {
+set_bastille_mountpoints() {
 
-    # We have to do this if ALTROOT is enabled/present
-    local _altroot="$(zpool get -Ho value altroot ${bastille_zfs_zpool})"
+    if checkyesno bastille_zfs_enable; then
 
-    # Set mountpoints to *bastille*dir*
-    # shellcheck disable=SC2034
-    bastille_prefix_mountpoint="${bastille_prefix}"
-    # shellcheck disable=SC2034
-    bastille_backupsdir_mountpoint="${bastille_backupsdir}"
-    # shellcheck disable=SC2034
-    bastille_cachedir_mountpoint="${bastille_cachedir}"
-    # shellcheck disable=SC2034
-    bastille_jailsdir_mountpoint="${bastille_jailsdir}"
-    # shellcheck disable=SC2034
-    bastille_releasesdir_mountpoint="${bastille_releasesdir}"
-    # shellcheck disable=SC2034
-    bastille_templatesdir_mountpoint="${bastille_templatesdir}"
-    # shellcheck disable=SC2034
-    bastille_logsdir_mountpoint="${bastille_logsdir}"
+        # We have to do this if ALTROOT is enabled/present
+        local _altroot="$(zpool get -Ho value altroot ${bastille_zfs_zpool})"
 
-    # Add _altroot to *dir* if set
-    if [ "${_altroot}" != "-" ]; then  
-        # Set *dir* to include ALTROOT
-        bastille_prefix="${_altroot}${bastille_prefix}"
-        bastille_backupsdir="${_altroot}${bastille_backupsdir}"
-        bastille_cachedir="${_altroot}${bastille_cachedir}"
-        bastille_jailsdir="${_altroot}${bastille_jailsdir}"
-        bastille_releasesdir="${_altroot}${bastille_releasesdir}"
-        bastille_templatesdir="${_altroot}${bastille_templatesdir}"
-        bastille_logsdir="${_altroot}${bastille_logsdir}" 
+        # Set mountpoints to *bastille*dir*
+        # shellcheck disable=SC2034
+        bastille_prefix_mountpoint="${bastille_prefix}"
+        # shellcheck disable=SC2034
+        bastille_backupsdir_mountpoint="${bastille_backupsdir}"
+        # shellcheck disable=SC2034
+        bastille_cachedir_mountpoint="${bastille_cachedir}"
+        # shellcheck disable=SC2034
+        bastille_jailsdir_mountpoint="${bastille_jailsdir}"
+        # shellcheck disable=SC2034
+        bastille_releasesdir_mountpoint="${bastille_releasesdir}"
+        # shellcheck disable=SC2034
+        bastille_templatesdir_mountpoint="${bastille_templatesdir}"
+        # shellcheck disable=SC2034
+        bastille_logsdir_mountpoint="${bastille_logsdir}"
+
+        # Add _altroot to *dir* if set
+        if [ "${_altroot}" != "-" ]; then  
+            # Set *dir* to include ALTROOT
+            bastille_prefix="${_altroot}${bastille_prefix}"
+            bastille_backupsdir="${_altroot}${bastille_backupsdir}"
+            bastille_cachedir="${_altroot}${bastille_cachedir}"
+            bastille_jailsdir="${_altroot}${bastille_jailsdir}"
+            bastille_releasesdir="${_altroot}${bastille_releasesdir}"
+            bastille_templatesdir="${_altroot}${bastille_templatesdir}"
+            bastille_logsdir="${_altroot}${bastille_logsdir}" 
+        fi
     fi
 }
-set_zfs_mountpoints
 
 target_all_jails() {
     local _JAILS="$(bastille list jails)"
@@ -541,3 +543,5 @@ checkyesno() {
         ;;
     esac
 }
+
+set_bastille_mountpoints

--- a/usr/local/share/bastille/import.sh
+++ b/usr/local/share/bastille/import.sh
@@ -137,12 +137,13 @@ validate_archive() {
 }
 
 update_zfsmount() {
+	
     # Update the mountpoint property on the received ZFS data stream
     OLD_ZFS_MOUNTPOINT=$(zfs get -H mountpoint "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root" | awk '{print $3}')
     NEW_ZFS_MOUNTPOINT="${bastille_jailsdir}/${TARGET_TRIM}/root"
     if [ "${NEW_ZFS_MOUNTPOINT}" != "${OLD_ZFS_MOUNTPOINT}" ]; then
         info "\nUpdating ZFS mountpoint..."
-        zfs set mountpoint="${bastille_jailsdir}/${TARGET_TRIM}/root" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root"
+        zfs set mountpoint="${bastille_jailsdir_mountpoint}/${TARGET_TRIM}/root" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET_TRIM}/root"
     fi
 
     # Mount new container ZFS datasets


### PR DESCRIPTION
This will allow systems that have been imported using `-R /some/path` to run bastille without mucking everything up.