### PR TITLE
template: Pass ARG_FILE to INCLUDE templates

### DIFF
--- a/docs/chapters/subcommands/template.rst
+++ b/docs/chapters/subcommands/template.rst
@@ -21,5 +21,6 @@ The TEMPLATE arg should be called with the ``project/template`` format.
   
       Options:
 
-      -a | --auto           Auto mode. Start/stop jail(s) if required.
-      -x | --debug          Enable debug mode.
+      -a | --auto               Auto mode. Start/stop jail(s) if required.
+      -r | --recursive          Pass ARGS recursively to INCLUDE templates (only if supplied using '--arg').
+      -x | --debug              Enable debug mode.


### PR DESCRIPTION
@tobiastom 

This should now pass `--arg-file` to any INCLUDE templates. 

Unfortunately we might not be able to support using `--arg ARG=VALUE` because there are times when we don't want to pass the same ARGS to the INCLUDE template. For example, we are writing some unit tests that are 3 layers deep, and call different ARGS at different times.

One option would be to include a `--recursive` options in the template command. Do you think that would work ok, or should we just pass the arg file by default?