### PR TITLE
fix missing sourcing of bastille_network_pf_ext_if in rdr.sh

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -194,7 +194,7 @@ load_rdr_log_rule() {
 
     local inet="${1}"
     local if_name="${2}"
-    local if=ext_if=\"${2}\"
+    local if="${bastille_network_pf_ext_if}"=\"${2}\"
     local src="${3}"
     local dst="${4}"
     local proto="${5}"

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -159,7 +159,7 @@ load_rdr_rule() {
 
     local inet="${1}"
     local if_name="${2}"
-    local if=ext_if=\"${2}\"
+    local if="${bastille_network_pf_ext_if}"=\"${2}\"
     local src="${3}"
     local dst="${4}"
     local proto="${5}"


### PR DESCRIPTION
When upgrading to **0.14.20250420**, using a custom `bastille_network_pf_ext_if` in `/usr/local/etc/bastille.conf` causes `rdr.sh` to fail (using 'WAN_IF' instead of the default 'ext_if' in one's pf config, for instance):

```shell
stdin:2: macro 'WAN_IF' not defined
stdin:2: syntax error
pfctl: Syntax error in config file: pf rules not loaded
```

This happens because _ext_if_ is hardcoded in `rdr.sh`'s `load_rdr_rule()`. This PR fixes this.
