### PR TITLE
Update MidnightBSD release versions

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -539,7 +539,7 @@ fi
 
 ## Filter sane release names
 case "${1}" in
-    2.[0-9]*)
+    [2-4].[0-9]*)
         ## check for MidnightBSD releases name
         NAME_VERIFY=$(echo "${RELEASE}")
         UPSTREAM_URL="${bastille_url_midnightbsd}${HW_MACHINE_ARCH}/${NAME_VERIFY}"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -949,7 +949,7 @@ if [ -z "${EMPTY_JAIL}" ]; then
     if [ -n "${VALIDATE_RELEASE}" ]; then
         ## verify release
         case "${RELEASE}" in
-        2.[0-9]*)
+        [2-4].[0-9]*)
             ## check for MidnightBSD releases name
             NAME_VERIFY=$(echo "${RELEASE}")
             validate_release


### PR DESCRIPTION
MidnightBSD 3.x has been out for awhile now.  Allow bootstrapping the current stable release (3.2.x) as well as prepare for 4.x which will be the next major release this year.