### PR TITLE
template.sh: restore JAIL_IP default variable

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -330,7 +330,7 @@ for _jail in ${JAILS}; do
 
     # Build a list of sed commands like this: -e 's/${username}/root/g' -e 's/${domain}/example.com/g'
     # Values provided by default (without being defined by the user) are listed here. -- cwells
-    ARG_REPLACEMENTS="-e 's/\${jail_ip4}/${_jail_ip4}/g' -e 's/\${jail_ip6}/${_jail_ip6}/g' -e 's/\${JAIL_NAME}/${_jail}/g'"
+    ARG_REPLACEMENTS="-e 's/\${JAIL_IP}/${_jail_ip4}/g' -e 's/\${JAIL_IP6}/${_jail_ip6}/g' -e 's/\${JAIL_NAME}/${_jail}/g'"
     # This is parsed outside the HOOKS loop so an ARG file can be used with a Bastillefile. -- cwells
     if [ -s "${bastille_template}/ARG" ]; then
         while read _line; do


### PR DESCRIPTION
It looks like commit [4b092e5](https://github.com/BastilleBSD/bastille/commit/4b092e513a0f0b2c02383c2ec0a85c512998b572) renamed the **$JAIL_IP** default template variable to **$jail_ip4** by mistake, breaking existing templates relying on its value.

This PR restores **$JAIL_IP** (and its companion **$JAIL_IP6**).