### PR TITLE
common: Use dynamic epairs for all jail types

### DIFF
--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -138,26 +138,6 @@ check_target_is_stopped() {
     fi
 }
 
-get_bastille_if_count() {
-    if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
-        for _config in /usr/local/etc/bastille/*.conf; do
-            local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-            _bastille_if_list="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_bastille_if_list}")"
-        done
-        _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
-        export _bastille_if_list
-        export _bastille_if_count
-    elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-        for _config in /usr/local/etc/bastille/*.conf; do
-            local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-            _bastille_if_list="$(printf '%s\n%s' "$( (grep -Ehos 'ng[0-9]+_bastille[0-9]+' ${bastille_jailsdir}/*/jail.conf | grep -Eos 'bastille[0-9]+'; ngctl list -n | grep "eiface" | grep -Eos 'ng[0-9]+_bastille[0-9]+' | grep -Eos 'bastille[0-9]+') | grep -Eos '[0-9]+')" "${_bastille_if_list}")"
-        done
-        _bastille_if_count=$(printf '%s' "${_bastille_if_list}" | sort -u | wc -l | awk '{print $1}')
-        export _bastille_if_list
-        export _bastille_if_count
-    fi
-}
-
 get_jail_name() {
     local _JID="${1}"
     local _jailname="$(jls -j ${_JID} name 2>/dev/null)"
@@ -380,34 +360,48 @@ generate_static_mac() {
 }
 
 generate_vnet_jail_netblock() {
+
     local jail_name="${1}"
     local use_unique_bridge="${2}"
     local external_interface="${3}"
     local static_mac="${4}"
-    # Get number of epairs on the system
-    get_bastille_if_count
-    local _bastille_if_num_range=$((_bastille_if_count + 1))
-    if [ -n "${use_unique_bridge}" ]; then
-        for _num in $(seq 0 "${_bastille_if_num_range}"); do
-            if ! echo "${_bastille_if_list}" | grep -oqswx "${_num}"; then
-                if [ "$(echo -n "e${_num}a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
-                    local host_epair=e${_num}a_${jail_name}
-                    local jail_epair=e${_num}b_${jail_name}
-                else
-                    local host_epair=epair${_num}a
-                    local jail_epair=epair${_num}b
-                fi
-                break
+
+    if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+        if [ -n "${use_unique_bridge}" ]; then
+            if [ "$(echo -n "e0a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                local host_epair=e0a_${jail_name}
+                local jail_epair=e0b_${jail_name}
+            else
+	        name_prefix="$(echo ${jail_name} | cut -c1-7)"
+	        name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
+	        local host_epair="e0a_${name_prefix}xx${name_suffix}"
+                local jail_epair="e0b_${name_prefix}xx${name_suffix}"
             fi
-        done
-    else
-        for _num in $(seq 0 "${_bastille_if_num_range}"); do
-            if ! echo "${_bastille_if_list}" | grep -oqswx "${_num}"; then
-                local _jail_if="bastille${_num}"
-                break
-            fi
-        done
+        else
+            if [ "$(echo -n "e0a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+                local host_epair=e0a_${jail_name}
+                local jail_epair=e0b_${jail_name}
+	        local jib_epair=${jail_name}
+            else
+	        name_prefix="$(echo ${jail_name} | cut -c1-7)"
+	        name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
+	        local host_epair="e0a_${name_prefix}xx${name_suffix}"
+                local jail_epair="e0b_${name_prefix}xx${name_suffix}"
+                local jib_epair="${name_prefix}xx${name_suffix}"
+	    fi
+        fi
+    elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+        if [ "$(echo -n "ng0_${jail_name}" | awk '{print length}')" -lt 16 ]; then
+            local ng_if=ng0_${jail_name}
+	    local jng_if=${jail_name}
+        else
+	    name_prefix="$(echo ${jail_name} | cut -c1-7)"
+	    name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
+	    local ng_if="ng0_${name_prefix}xx${name_suffix}"
+            local jng_if="${name_prefix}xx${name_suffix}"
+        fi
     fi
+
     ## If BRIDGE is enabled, generate bridge config, else generate VNET config
     if [ -n "${use_unique_bridge}" ]; then
         if [ -n "${static_mac}" ]; then
@@ -416,10 +410,8 @@ generate_vnet_jail_netblock() {
             cat <<-EOF
   vnet;
   vnet.interface = ${jail_epair};
-  exec.prestart += "ifconfig epair${_num} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
-  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
-  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "epair=\\\$(ifconfig epair create) && ifconfig \\\${epair} up name ${host_epair} && ifconfig \\\${epair%a}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${external_interface} addm ${host_epair}";
   exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
   exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
   exec.prestart += "ifconfig ${host_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
@@ -431,10 +423,8 @@ EOF
             cat <<-EOF
   vnet;
   vnet.interface = ${jail_epair};
-  exec.prestart += "ifconfig epair${_num} create";
-  exec.prestart += "ifconfig ${external_interface} addm epair${_num}a";
-  exec.prestart += "ifconfig epair${_num}a up name ${host_epair}";
-  exec.prestart += "ifconfig epair${_num}b up name ${jail_epair}";
+  exec.prestart += "epair=\\\$(ifconfig epair create) && ifconfig \\\${epair} up name ${host_epair} && ifconfig \\\${epair%a}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${external_interface} addm ${host_epair}";
   exec.prestart += "ifconfig ${host_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
   exec.poststop += "ifconfig ${external_interface} deletem ${host_epair}";
   exec.poststop += "ifconfig ${host_epair} destroy";
@@ -447,21 +437,21 @@ EOF
                 generate_static_mac "${jail_name}" "${external_interface}"
                 cat <<-EOF
   vnet;
-  vnet.interface = e0b_${_jail_if};
-  exec.prestart += "jib addm ${_jail_if} ${external_interface}";
-  exec.prestart += "ifconfig e0a_${_jail_if} ether ${macaddr}a";
-  exec.prestart += "ifconfig e0b_${_jail_if} ether ${macaddr}b";
-  exec.prestart += "ifconfig e0a_${_jail_if} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "jib destroy ${_jail_if}";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "jib addm ${jib_epair} ${external_interface}";
+  exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
+  exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "jib destroy ${jib_epair}";
 EOF
             else
                 ## Generate VNET config without static MAC address
                 cat <<-EOF
   vnet;
-  vnet.interface = e0b_${_jail_if};
-  exec.prestart += "jib addm ${_jail_if} ${external_interface}";
-  exec.prestart += "ifconfig e0a_${_jail_if} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
-  exec.poststop += "jib destroy ${_jail_if}";
+  vnet.interface = ${jail_epair};
+  exec.prestart += "jib addm ${jib_epair} ${external_interface}";
+  exec.prestart += "ifconfig ${host_epair} description \"vnet0 host interface for Bastille jail ${jail_name}\"";
+  exec.poststop += "jib destroy ${jib_epair}";
 EOF
             fi
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
@@ -470,18 +460,18 @@ EOF
                 generate_static_mac "${jail_name}" "${external_interface}"
                 cat <<-EOF
   vnet;
-  vnet.interface = ng0_${_jail_if};
-  exec.prestart += "jng bridge ${_jail_if} ${external_interface}";
-  exec.prestart += "ifconfig ng0_${_jail_if} ether ${macaddr}a";
-  exec.poststop += "jng shutdown ${_jail_if}";
+  vnet.interface = ${ng_if};
+  exec.prestart += "jng bridge ${jng_if} ${external_interface}";
+  exec.prestart += "ifconfig ${ng_if} ether ${macaddr}b";
+  exec.poststop += "jng shutdown ${jng_if}";
 EOF
             else
                 ## Generate VNET config without static MAC address
                 cat <<-EOF
   vnet;
-  vnet.interface = ng0_${_jail_if};
-  exec.prestart += "jng bridge ${_jail_if} ${external_interface}";
-  exec.poststop += "jng shutdown ${_jail_if}";
+  vnet.interface = ${ng_if};
+  exec.prestart += "jng bridge ${jng_if} ${external_interface}";
+  exec.poststop += "jng shutdown ${jng_if}";
 EOF
             fi
         fi


### PR DESCRIPTION
This will solve an issue when using vnet and bridged-vnet jails at the same time on the same system.

It also removes a hectic bit of code (do to now doing this dynamically) that was prone to errors when using both of the above types of jails together.

This is POC and will need testing, and the clone, network, and rename commands will need adjusting with this setup. All three of these will not function currently with this PR.