### PR TITLE
[Enhancement]  'Bastille zfs command'

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -203,9 +203,11 @@ case "${CMD}" in
     # Commands that don't allow parallel mode
     bootstrap| \
     clone| \
+    cmd| \
     console| \
     convert| \
     create| \
+    destroy| \
     edit| \
     etcupdate| \
     export| \
@@ -213,10 +215,13 @@ case "${CMD}" in
     import| \
     limits| \
     list| \
+    migrate| \
     network| \
+    pkg| \
     rcp| \
     rdr| \
     rename| \
+    service| \
     setup| \
     top| \
     update| \
@@ -227,17 +232,12 @@ case "${CMD}" in
         fi
         ;;
     # Commands that allow parallel mode
-    cmd| \
     config| \
     cp| \
-    destroy| \
     jcp| \
     limits| \
-    migrate| \
     mount| \
-    pkg| \
     restart| \
-    service| \
     start| \
     stop| \
     sysrc| \

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION=1.0.20250714
+BASTILLE_VERSION=1.0.1.250714
 
 # Validate config file
 # Copy default when 'setup' is called

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION="0.14.20250420"
+BASTILLE_VERSION=1.0.20250714
 
 # Validate config file
 # Copy default when 'setup' is called

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION=0.14.20250420
+BASTILLE_VERSION="0.14.20250420"
 
 # Validate config file
 # Copy default when 'setup' is called
@@ -114,7 +114,7 @@ Available Commands:
   update      Update container base -pX release.
   upgrade     Upgrade container release to X.Y-RELEASE.
   verify      Compare release against a "known good" index.
-  zfs         Manage (get|set) ZFS attributes on targeted container(s).
+  zfs         Manage (get|set) ZFS attributes or snapshots on targeted container(s).
 
 Use "bastille -v|--version" for version information.
 Use "bastille command -h|--help" for more information about a command.

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -34,7 +34,7 @@
 
 usage() {
     error_notify "Usage: bastille list [option(s)] [RELEASE (-p)] [all] [backup(s)] [export(s)] [import(s)] [ip(s)] [jail(s)] [limit(s)] [log(s)]"
-    error_notify "                                                [path(s)] [port(s)] [prio|priority] [release(s)] [snapshot(s)] [state(s)] [template(s)] [type]"
+    error_notify "                                                [path(s)] [port(s)] [prio|priority] [release(s)] [state(s)] [template(s)] [type]"
     cat << EOF
     Options:
 

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -34,7 +34,7 @@
 
 usage() {
     error_notify "Usage: bastille list [option(s)] [RELEASE (-p)] [all] [backup(s)] [export(s)] [import(s)] [ip(s)] [jail(s)] [limit(s)] [log(s)]"
-    error_notify "                                                [path(s)] [port(s)] [prio|priority] [release(s)] [state(s)] [template(s)]"
+    error_notify "                                                [path(s)] [port(s)] [prio|priority] [release(s)] [snapshot(s)] [state(s)] [template(s)]"
     cat << EOF
     Options:
 
@@ -606,6 +606,20 @@ list_release(){
     fi
 }
 
+list_snapshot(){
+    # TODO: Avility to list snapshot data for a single target.
+    # List snapshots with its usage data for valid bastille jails only.
+    if [ -d "${bastille_jailsdir}" ]; then
+        JAIL_LIST=$(ls --color=never "${bastille_jailsdir}" | sed "s/\n//g")
+        for _JAIL in ${JAIL_LIST}; do
+            if [ -f "${bastille_jailsdir}/${_JAIL}/jail.conf" ]; then
+                info "\n[${_JAIL}]:"
+                zfs list -r -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_JAIL}"
+            fi
+        done
+    fi
+}
+
 list_template(){
     find "${bastille_templatesdir}" -type d -maxdepth 2 | sed "s#${bastille_templatesdir}/##g"
 }
@@ -766,6 +780,10 @@ if [ "$#" -eq 1 ]; then
             ;;
         release|releases)
             list_release "${2}"
+            ;;
+        snapshot|snapshots)
+            list_snapshot
+            exit 0
             ;;
         template|templates)
             list_template

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -233,28 +233,11 @@ snapshot_checks() {
         fi
     fi
 
-    # Check existence for the given snapshot.
-    if [ -n "${SNAP_ROLLBACK}" ] || [ -n "${SNAP_DESTROY}" ]; then
-        if [ -n "${TAG}" ]; then
-            # Early warning about missing required snapshot/parent dataset for reference, this may happen when
-            # more recent snapshots were deleted by either, intentional or automatically when rollback older snapshots.
-            if ! zfs list -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}@${TAG}" >/dev/null 2>&1; then
-                info "\n[${_jail}]:"
-                warn "[WARNING]: Either snapshot '${TAG}' not exist or parent dataset appears to be missing."
-            fi
-        fi
-    elif [ -n "${SNAP_CREATE}" ]; then
-        if zfs list -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}@${TAG}" >/dev/null 2>&1; then
-            info "\n[${_jail}]:"
-            warn "[WARNING]: Looks like the snapshot '${TAG}' already exist, See 'bastille list snapshot'."
-        fi
-    fi
-
     # Generate a relatively short but unique name for the snapshots based on the current date/jail name.
     if [ -n "${SNAP_NAME_GEN}" ]; then
        for _JAIL in ${_jail}; do
             DATE=$(date +%F-%H%M%S)
-            NAME_MD5X6=$(echo "${DATE} ${TARGET}" | md5 | cut -b -6)
+            NAME_MD5X6=$(echo "${DATE} ${_JAIL}" | md5 | cut -b -6)
             SNAPSHOT_NAME="Bastille_${NAME_MD5X6}_${_JAIL}_${DATE}"
             TAG="${SNAPSHOT_NAME}"
         done

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -33,19 +33,32 @@
 . /usr/local/share/bastille/common.sh
 
 usage() {
-    error_notify "Usage: bastille zfs [option(s)] TARGET [destroy_snap|(df|usage)|get|set|(snap|snapshot)] [key=value|date]"
+    
+    error_notify "Usage: bastille zfs [option(s)] TARGET [destroy|(df|usage)|get|set|(snap|snapshot)] [key=value|date]"
     error_notify "                                       [jail pool/dataset /jail/path]"
     error_notify "                                       [unjail pool/dataset]"
 
     cat << EOF
-	
     Options:
 
-    -x | --debug          Enable debug mode.
+    snapshot                Create a ZFS snapshot for the specified container.
+    rollback                Rollback a ZFS snapshot on the specified container.
+    destroy                 Destroy a ZFS snapshot on the specified container.
+    -a | --auto             Auto mode. Start/stop jail(s) if required.
+    -v | --verbose          Be more verbose during the snapshot destroy operation.
+    -n | --dryrun           Do a dry-run(no actual deletion) to determine what data would be deleted.
+    -x | --debug            Enable debug mode.
 
 EOF
     exit 1
 }
+
+AUTO="0"
+SNAP_NAME_GEN=
+SNAP_CREATE=
+SNAP_ROLLBACK=
+SNAP_DESTROY=
+SNAP_VERBOSE=
 
 zfs_jail_dataset() {
 
@@ -121,17 +134,26 @@ zfs_snapshot() {
     info "\n[${_jail}]:"
     # shellcheck disable=SC2140
     zfs snapshot -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
+    _return=$?
+}
+
+zfs_rollback() {
+    info "\n[${_jail}]:"
+    # shellcheck disable=SC2140
+    zfs rollback -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${TARGET}"@"${TAG}"
+    _return=$?
 }
 
 zfs_destroy_snapshot() {
     info "\n[${_jail}]:"
     # shellcheck disable=SC2140
-    zfs destroy -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
+    zfs destroy ${_opts} "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"@"${TAG}"
+    _return=$?
 }
 
 zfs_set_value() {
     info "\n[${_jail}]:"
-    zfs "${ATTRIBUTE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
+    zfs set "${ATTRIBUTE}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
 }
 
 zfs_get_value() {
@@ -144,8 +166,7 @@ zfs_disk_usage() {
     zfs list -t all -o name,used,avail,refer,mountpoint,compress,ratio -r "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}"
 }
 
-# Handle options.
-AUTO=0
+# Handle some options.
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
@@ -153,6 +174,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         -a|--auto)
             AUTO=1
+            shift
+            ;;
+        -v|--verbose)
+            SNAP_VERBOSE="1"
             shift
             ;;
         -x|--debug)
@@ -195,14 +220,116 @@ if [ -z "${bastille_zfs_zpool}" ]; then
     error_exit "[ERROR]: ZFS zpool not defined."
 fi
 
+snapshot_checks() {
+    # Check if jail is running and stop if requested.
+    if [ -z "${SNAP_DESTROY}" ]; then
+        check_target_is_stopped "${_jail}" || \
+        if [ "${AUTO}" -eq 1 ]; then
+            bastille stop "${_jail}"
+        fi
+    fi
+
+    # Check existence for the given snapshot.
+    if [ -n "${SNAP_ROLLBACK}" ] || [ -n "${SNAP_DESTROY}" ]; then
+        if [ -n "${TAG}" ]; then
+            # Early warning about missing snapshot parent dataset for reference, this may happen when
+            # more recent snapshots were deleted by either, intentional or automatically.
+            if ! zfs list -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}@${TAG}" >/dev/null 2>&1; then
+                info "\n[${_jail}]:"
+                warn "[WARNING]: Either snapshot '${TAG}' not exist or parent dataset appears to be missing."
+            fi
+        fi
+    elif [ -n "${SNAP_CREATE}" ]; then
+        if zfs list -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}@${TAG}" >/dev/null 2>&1; then
+            info "\n[${_jail}]:"
+            warn "[WARNING]: Looks like the snapshot '${TAG}' already exist, See 'bastille list snapshot'."
+        fi
+    fi
+
+    # Generate a relatively short but unique name for the snapshots based on the current date/jail name.
+    if [ -n "${SNAP_NAME_GEN}" ]; then
+        DATE=$(date +%F-%H%M%S)
+        NAME_MD5X6=$(echo "${DATE} ${TARGET}" | md5 | cut -b -6)
+        SNAPSHOT_NAME="Bastille_${NAME_MD5X6}_${TARGET}_${DATE}"
+        TAG="${SNAPSHOT_NAME}"
+    fi
+}
+
+snapshot_create() {
+    # Attempt to snapshot the container.
+    # Thiw will create a ZFS snapshot for the specified container with an auto-generated name with the
+    # following format "Bastille_XXXXXX_JAILNAME_YYYY-MM-DD-HHMMSS" unless a name tag is manually entered.
+    SNAP_CREATE="1"
+    if [ -z "${TAG}" ]; then
+        SNAP_NAME_GEN="1"
+    fi
+
+    snapshot_checks
+    zfs_snapshot
+
+    # Check for exit status and notify only for user reference.
+    if [ "${_return}" -ne 0 ]; then
+        error_notify "[ERROR]: Failed to snapshot jail: '${_jail}'"
+    else
+        info "Snapshot for ${_jail} successfully created as '${TAG}'."
+    fi
+
+    # Start the jail after snapshot if requested.
+    if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${_jail}"
+    fi
+}
+
+snapshot_rollback() {
+    # This feature is intended work with snapshots created  by either, bastille or manually created byu the user.
+    # An error about "more recent snapshots or bookmarks exist" will appears if the '-r' flag is not specified.
+    SNAP_ROLLBACK="1"
+    snapshot_checks
+    zfs_rollback
+
+    # Check for exit status and just notify.
+    if [ "${_return}" -ne 0 ]; then
+        error_notify "[ERROR]: Failed to restore '${TAG}' snapshot for '${_jail}'."
+    else
+        info "Snapshot '${TAG}' successfully rolled back for '${_jail}'."
+    fi
+
+    # Start the jail after rollback if requested.
+    if [ "${AUTO}" -eq 1 ]; then
+        bastille start "${_jail}"
+    fi
+}
+
+snapshot_destroy() {
+    # Destroy the user specifier bastille snapshot.
+    SNAP_DESTROY="1"
+    snapshot_checks
+
+    # Set some options.
+    if [ -n "${SNAP_VERBOSE}" ]; then
+        _opts="-v -r"
+    else
+        _opts="-r"
+    fi
+    zfs_destroy_snapshot
+
+    # Check for exit status and just notify.
+    if [ "${_return}" -ne 0 ]; then
+        error_notify "[ERROR]: Failed to destroy '${TAG}' snapshot for '${_jail}'"
+    else
+        info "Snapshot '${TAG}' destroyed successfully."
+        exit 0
+    fi
+}
+
 for _jail in ${JAILS}; do
 
     (
 
     case "${ACTION}" in
-        destroy_snap|destroy_snapshot)
+        destroy|destroy_snap|destroy_snapshot)
             TAG="${3}"
-            zfs_destroy_snapshot
+            snapshot_destroy
             ;;
         df|usage)
             zfs_disk_usage
@@ -216,6 +343,10 @@ for _jail in ${JAILS}; do
             MOUNT="${4}"
             zfs_jail_dataset
             ;;
+        rollback)
+            TAG="${3}"
+            snapshot_rollback
+            ;;
         unjail)
             DATASET="${3}"
             zfs_unjail_dataset
@@ -226,7 +357,7 @@ for _jail in ${JAILS}; do
             ;;
         snap|snapshot)
             TAG="${3}"
-            zfs_snapshot
+            snapshot_create
             ;;
         *)
             usage
@@ -236,6 +367,6 @@ for _jail in ${JAILS}; do
     ) &
 
     bastille_running_jobs "${bastille_process_limit}"
-	
+
 done
 wait

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -54,7 +54,6 @@ EOF
 
 AUTO="0"
 SNAP_NAME_GEN=
-SNAP_CREATE=
 SNAP_ROLLBACK=
 SNAP_DESTROY=
 SNAP_VERBOSE=
@@ -209,7 +208,7 @@ fi
 TARGET="${1}"
 ACTION="${2}"
 
-if [ "${TARGET}" = "ALL" -o "${TARGET}" = "all" ]; then
+if [ "${TARGET}" = "ALL" ] || [ "${TARGET}" = "all" ]; then
     SNAP_BATCH="1"
 fi
 
@@ -272,7 +271,6 @@ snapshot_create() {
     # Attempt to snapshot the container.
     # Thiw will create a ZFS snapshot for the specified container with an auto-generated name with the
     # following format "Bastille_XXXXXX_JAILNAME_YYYY-MM-DD-HHMMSS" unless a name tag is manually entered.
-    SNAP_CREATE="1"
     if [ -z "${TAG}" ]; then
         SNAP_NAME_GEN="1"
     fi

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -58,6 +58,7 @@ SNAP_CREATE=
 SNAP_ROLLBACK=
 SNAP_DESTROY=
 SNAP_VERBOSE=
+SNAP_CHECK=
 SNAP_BATCH=
 
 zfs_jail_dataset() {
@@ -241,6 +242,13 @@ snapshot_checks() {
             SNAPSHOT_NAME="Bastille_${NAME_MD5X6}_${_JAIL}_${DATE}"
             TAG="${SNAPSHOT_NAME}"
         done
+
+        # Check for the generated snapshot name.
+        SNAP_CHECK=$(echo ${TAG} | grep -wo "Bastille_[0-9a-fA-F]\{6\}_${_jail}_[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-[0-9]\{6\}")
+        if [ -z "${SNAP_CHECK}" ]; then
+            info "\n[${_jail}]:"
+            error_notify "[ERROR]: Failed validation for the generated snapshot name."
+        fi
     fi
 }
 
@@ -268,8 +276,8 @@ snapshot_create() {
         bastille start "${_jail}"
     fi
 
-    # Delay a sec for batch snapshot creation safety.
-    if [ -n "${SNAP_BATCH}" ]; then
+    # Delay a sec only for batch snapshot creation when using md5 to generate names.
+    if [ -n "${SNAP_BATCH}" ] && [ -n "${SNAP_CHECK}" ]; then
         sleep 1
     fi
 }

--- a/usr/local/share/bastille/zfs.sh
+++ b/usr/local/share/bastille/zfs.sh
@@ -46,7 +46,6 @@ usage() {
     destroy                 Destroy a ZFS snapshot on the specified container.
     -a | --auto             Auto mode. Start/stop jail(s) if required.
     -v | --verbose          Be more verbose during the snapshot destroy operation.
-    -n | --dryrun           Do a dry-run(no actual deletion) to determine what data would be deleted.
     -x | --debug            Enable debug mode.
 
 EOF
@@ -232,8 +231,8 @@ snapshot_checks() {
     # Check existence for the given snapshot.
     if [ -n "${SNAP_ROLLBACK}" ] || [ -n "${SNAP_DESTROY}" ]; then
         if [ -n "${TAG}" ]; then
-            # Early warning about missing snapshot parent dataset for reference, this may happen when
-            # more recent snapshots were deleted by either, intentional or automatically.
+            # Early warning about missing required snapshot/parent dataset for reference, this may happen when
+            # more recent snapshots were deleted by either, intentional or automatically when rollback older snapshots.
             if ! zfs list -t snapshot "${bastille_zfs_zpool}/${bastille_zfs_prefix}/jails/${_jail}@${TAG}" >/dev/null 2>&1; then
                 info "\n[${_jail}]:"
                 warn "[WARNING]: Either snapshot '${TAG}' not exist or parent dataset appears to be missing."


### PR DESCRIPTION
[Enhancement]  'Bastille zfs command'

Here is the `zfs` comand enhancement proposed here: https://github.com/BastilleBSD/bastille/pull/1163

**Usage:**
```
bastille zfs
Usage: bastille zfs [option(s)] TARGET [destroy|(df|usage)|get|set|(snap|snapshot)] [key=value|date]
                                       [jail pool/dataset /jail/path]
                                       [unjail pool/dataset]
    Options:

    snapshot                Create a ZFS snapshot for the specified container.
    rollback                Rollback a ZFS snapshot on the specified container.
    destroy                 Destroy a ZFS snapshot on the specified container.
    -a | --auto             Auto mode. Start/stop jail(s) if required.
    -v | --verbose          Be more verbose during the snapshot destroy operation.
    -x | --debug            Enable debug mode.
```


**Creating Snapshots:**
```
bastille zfs jail1 snapshot

[jail1]:
Snapshot for jail1 successfully created as 'Bastille_b0984a_jail1_2025-06-27-035703'.

bastille zfs jail1 snapshot Before_Upgrade

[jail1]:
Snapshot for jail1 successfully created as 'Before_Upgrade'.
```

**Listing Snapshots:**
```
bastille list snapshot

[jail1]:
NAME                                                                        USED  AVAIL  REFER  MOUNTPOINT
storage/bastille/jails/jail1@Bastille_b0984a_jail1_2025-06-27-035703          0B      -   108K  -
storage/bastille/jails/jail1@Before_Upgrade                                   0B      -   108K  -
storage/bastille/jails/jail1/root@Bastille_b0984a_jail1_2025-06-27-035703     0B      -   459M  -
storage/bastille/jails/jail1/root@Before_Upgrade                              0B      -   459M  -

[jail2]:
no datasets available

[jellyfin]:
no datasets available

[samba]:
no datasets available
```

**Restoring Snapshots:**
```
bastille zfs jail1 rollback Before_Upgrade

[jail1]:
Snapshot 'Before_Upgrade' successfully rolled back for 'jail1'.

bastille zfs jail2 rollback Bastille_e4bf48_jail2_2025-06-27-040207

[jail2]:
Snapshot 'Bastille_e4bf48_jail2_2025-06-27-040207' successfully rolled back for 'jail2'.
```

**Destroying Snapshots:**
```
bastille zfs jail1 destroy Before_Upgrade

[jail1]:
Snapshot 'Before_Upgrade' destroyed successfully.

bastille zfs jail1 destroy Bastille_b0984a_jail1_2025-06-27-035703

[jail1]:
Snapshot 'Bastille_b0984a_jail1_2025-06-27-035703' destroyed successfully.
```

**Creating/Destroying Snapshots on all Targets:**
```
bastille zfs ALL snapshot Before_Packages 

[jail1]:
Snapshot for jail1 successfully created as 'Before_Packages'.

[jail2]:
Snapshot for jail2 successfully created as 'Before_Packages'.

[jellyfin]:
Snapshot for jellyfin successfully created as 'Before_Packages'.

[samba]:
Snapshot for samba successfully created as 'Before_Packages'.

bastille zfs ALL destroy Before_Packages

[jail1]:
Snapshot 'Before_Packages' destroyed successfully.

[jail2]:
Snapshot 'Before_Packages' destroyed successfully.

[jellyfin]:
Snapshot 'Before_Packages' destroyed successfully.

[samba]:
Snapshot 'Before_Packages' destroyed successfully.

```