### PR TITLE
list: exclude tunnel endpoint (src/dst) addresses

### DIFF
--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -194,8 +194,8 @@ get_jail_info() {
         # Get info if jail is UP
         if [ "$(awk '$1 == "vnet;" { print $1 }' "${bastille_jailsdir}/${JAIL_NAME}/jail.conf" 2> /dev/null)" ]; then
             # Get IP for VNET jails
-            JAIL_IP4="$(jexec -l ${JAIL_NAME} ifconfig -an | grep "inet " | grep -v "127.0.0.1" | awk '{print $2}')"
-            JAIL_IP6="$(jexec -l ${JAIL_NAME} ifconfig -an | grep "inet6" | grep -Ev 'lo[0-9]+| ::1 | fe80::' | awk '{print $2}' | sed 's/%.*//g')"
+            JAIL_IP4="$(jexec -l ${JAIL_NAME} ifconfig -an | grep "^[[:space:]]*inet " | grep -v "127.0.0.1" | awk '{print $2}')"
+            JAIL_IP6="$(jexec -l ${JAIL_NAME} ifconfig -an | grep "^[[:space:]]*inet6" | grep -Ev 'lo[0-9]+| ::1 | fe80::' | awk '{print $2}' | sed 's/%.*//g')"
         else
             # Get IP for standard jails
             JAIL_IP4=$(jls -j ${JAIL_NAME} ip4.addr | sed 's/,/\n/g')


### PR DESCRIPTION
from IP address listing of jails with gif/gre interfaces

Reported at:	#1175

For example:
```
gif0: flags=1008051<UP,POINTOPOINT,RUNNING,MULTICAST,LOWER_UP> metric 0 mtu 1460
        options=80000<LINKSTATE>
        tunnel inet6 2001:db8::cafe:cafe --> 3fff::feed:feed
        inet 192.168.1.1 --> 10.10.10.10 netmask 0xffffffff
        groups: gif
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>

gif1: flags=1008011<UP,POINTOPOINT,MULTICAST,LOWER_UP> metric 0 mtu 1280
        options=80000<LINKSTATE>
        tunnel inet 192.0.2.10 --> 198.51.100.20
        inet 10.0.0.1 --> 10.0.0.2 netmask 0xffffffff
        groups: gif
        nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
```

------

As mentioned in #1175, the `inet6` line is caused by the jail with tunnel interfaces.

```
% bastille list
 JID  Name        Boot  Prio  State  Type   IP Address                  Published Ports  Release          Tags
                                            ipv6:addr:mask:ed::1:5169
                                            ipv6:addr:mask:ed::1010
                                            ipv6:addr:mask:ed::143
                                            ipv6:addr:mask:ed:5a9c:fcff:fe3a:696b
                                            ipv6:addr:mask:ed:5a9c:fcff:fe7a:c0eb
                                            ipv6:addr:mask:ed:64:2fff:feba:8a0b
                                            ipv6:addr:mask:ed:df:74ff:fee1:480b
         THIS ONE IS CAUSED BY TUNNEL  -->  inet6
 1    alcatraz    on    99    Up     thin   10.20.30.40                 -                14.1-RELEASE-p2  -
 2    dslite      on    99    Up     thin   192.168.1.1                 -                14.1-RELEASE-p2  -
 3    flets       on    99    Up     thin   -                           -                14.1-RELEASE-p2  -
 4    flets-vpn   on    99    Up     thin   -                           -                14.2-RELEASE     -
 5    goodmog     on    99    Up     thin   192.168.96.11               -                14.2-RELEASE     -
 6    goodmogdev  on    99    Up     thin   192.168.96.12               -                14.2-RELEASE     -
(snip)
```