### PR TITLE
parallel mode: Remove cmd and service

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -207,6 +207,7 @@ case "${CMD}" in
     console| \
     convert| \
     create| \
+    destroy| \
     edit| \
     etcupdate| \
     export| \
@@ -214,7 +215,9 @@ case "${CMD}" in
     import| \
     limits| \
     list| \
+    migrate| \
     network| \
+    pkg| \
     rcp| \
     rdr| \
     rename| \
@@ -231,12 +234,9 @@ case "${CMD}" in
     # Commands that allow parallel mode
     config| \
     cp| \
-    destroy| \
     jcp| \
     limits| \
-    migrate| \
     mount| \
-    pkg| \
     restart| \
     start| \
     stop| \

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -203,6 +203,7 @@ case "${CMD}" in
     # Commands that don't allow parallel mode
     bootstrap| \
     clone| \
+    cmd| \
     console| \
     convert| \
     create| \
@@ -217,6 +218,7 @@ case "${CMD}" in
     rcp| \
     rdr| \
     rename| \
+    service| \
     setup| \
     top| \
     update| \
@@ -227,7 +229,6 @@ case "${CMD}" in
         fi
         ;;
     # Commands that allow parallel mode
-    cmd| \
     config| \
     cp| \
     destroy| \
@@ -237,7 +238,6 @@ case "${CMD}" in
     mount| \
     pkg| \
     restart| \
-    service| \
     start| \
     stop| \
     sysrc| \

--- a/usr/local/share/bastille/cmd.sh
+++ b/usr/local/share/bastille/cmd.sh
@@ -93,8 +93,6 @@ set_target "${TARGET}"
 
 for _jail in ${JAILS}; do
 
-    (
-
     # Validate jail state
     check_target_is_running "${_jail}" || if [ "${AUTO}" -eq 1 ]; then
         bastille start "${_jail}"
@@ -114,12 +112,7 @@ for _jail in ${JAILS}; do
     fi
 	
     bastille_check_exit_code "${_jail}" "$?"
-
-    ) &
-
-    bastille_running_jobs "${bastille_process_limit}"
 	
 done
-wait
 
 bastille_return_exit_code

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -334,17 +334,7 @@ case "${TARGET}" in
         # Destroy targeted jail(s)
         set_target "${TARGET}" "reverse"
         for _jail in ${JAILS}; do
-            if [ "${AUTO_YES}" -eq 1 ]; then
-                (
-                    destroy_jail "${_jail}"
-                ) &
-            else
-                (
-                    destroy_jail "${_jail}"
-                )
-            fi
-            bastille_running_jobs "${bastille_process_limit}"
+            destroy_jail "${_jail}"
         done
-        wait
         ;;
 esac

--- a/usr/local/share/bastille/migrate.sh
+++ b/usr/local/share/bastille/migrate.sh
@@ -348,8 +348,6 @@ validate_host_status "${USER}" "${HOST}" "${PORT}"
 
 for _jail in ${JAILS}; do
 
-    (
-
     # Validate jail state
     if [ "${LIVE}" -eq 1 ]; then
         if ! check_target_is_running "${_jail}"; then
@@ -371,9 +369,5 @@ for _jail in ${JAILS}; do
 
     info "\nSuccessfully migrated '${_jail}' to '${HOST}'.\n"
 
-    ) &
-
-    bastille_running_jobs "${bastille_process_limit}"
-
 done
-wait
+echo

--- a/usr/local/share/bastille/pkg.sh
+++ b/usr/local/share/bastille/pkg.sh
@@ -140,29 +140,8 @@ pkg_run_command() {
 }
 
 for _jail in ${JAILS}; do
-
-    if [ "${AUTO_YES}" -eq 1 ]; then
-
-        (
-
-        pkg_run_command "$@"
-
-        ) &
-
-    else
-
-        (
-
-        pkg_run_command "$@"
-
-        )
-
-    fi
-
-    bastille_running_jobs "${bastille_process_limit}"
-	
+    pkg_run_command "$@"
 done
-wait
 echo
 
 bastille_return_exit_code

--- a/usr/local/share/bastille/service.sh
+++ b/usr/local/share/bastille/service.sh
@@ -91,8 +91,6 @@ set_target "${TARGET}"
 
 for _jail in ${JAILS}; do
 
-    (
-
     # Validate jail state
     check_target_is_running "${_jail}" || if [ "${AUTO}" -eq 1 ]; then
         bastille start "${_jail}"
@@ -108,12 +106,7 @@ for _jail in ${JAILS}; do
 
     bastille_check_exit_code "${_jail}" "$?"
 	
-    ) &
-	
-    bastille_running_jobs "${bastille_process_limit}"
-	
 done
-wait
 echo
 
 bastille_return_exit_code


### PR DESCRIPTION
This removes "cmd" and "service" from allowing parallel mode, as it causes issues with interactive commands.