### PR TITLE
common: Add option to use “tags” as TARGET

### DIFF
--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -239,7 +239,9 @@ set_target() {
         target_all_jails
     else
         for _jail in ${_TARGET}; do
-            if [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_jail}" | grep -Eq '^[0-9]+$'; then
+            if grep -Eohw "${_jail}" "${bastille_jailsdir}/*/tags"; then
+                _jail="$(bastille tags ALL list ${_jail} | tr '\n' ' ')"
+            elif [ ! -d "${bastille_jailsdir}/${_TARGET}" ] && echo "${_jail}" | grep -Eq '^[0-9]+$'; then
                 if get_jail_name "${_jail}" > /dev/null; then
                     _jail="$(get_jail_name ${_jail})"
                 else


### PR DESCRIPTION
This will allow users to use any tag as the TARGET.