### PR TITLE
Bugfix create cmd for jails with alias IP

### DIFF
--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -69,7 +69,7 @@ validate_name() {
     # Make sure NAME has only allowed characters
     if [ -n "$(echo "${NAME_SANITY}" | awk "/^[-_].*$/" )" ]; then
         error_exit "[ERROR]: Jail names may not begin with (-|_) characters!"
-    elif [ "${VNET_JAIL}" -eq 1 ] && echo "${NAME_VERIFY}" | grep -qE '(-|_)'; then
+    elif [ -n "${VNET_JAIL}" ] && echo "${NAME_VERIFY}" | grep -qE '(-|_)'; then
         error_exit "[ERROR]: VNET jail names may not contain (-|_) characters."
     elif [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
         error_exit "[ERROR]: Jail names may not contain special characters!"


### PR DESCRIPTION
This will fix jail creation error with IP alias (shared IP jails)

**Before the fix:**
```
# bastille create jail1 14.3-release 10.0.0.100 em0

Attempting to create jail: jail1
[: : bad number

Valid: (10.0.0.100).

Valid: (em0).

Creating a thinjail...

```

**After fix:**
```
# bastille create jail1 14.3-release 10.0.0.100 em0

Attempting to create jail: jail1

Valid: (10.0.0.100).

Valid: (em0).

Creating a thinjail...

```
The error is triggered since creating an shared IP jail (no VNET) will leave the ${VNET_JAIL} variable empty, so in this case is better to verify if the variable is set rather that compare, functionality remains the same.