### PR TITLE
make devel bastille version format: branch-hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BASTILLE_BRANCH=$$(git branch --show-current)
 BASTILLE_VERSION=$$(git rev-parse --short HEAD)
 
 .PHONY: all
@@ -8,8 +9,8 @@ install:
 	@echo "Installing Bastille"
 	@echo
 	@echo "Updating Bastille version to match git revision."
-	@echo "BASTILLE_VERSION: ${BASTILLE_VERSION}"
-	@sed -i.orig "s/BASTILLE_VERSION=.*/BASTILLE_VERSION=${BASTILLE_VERSION}/" usr/local/bin/bastille
+	@echo "BASTILLE_VERSION: ${BASTILLE_BRANCH}-${BASTILLE_VERSION}"
+	@sed -i '' "s/BASTILLE_VERSION=.*/BASTILLE_VERSION=${BASTILLE_BRANCH}-${BASTILLE_VERSION}/" usr/local/bin/bastille
 	@cp -Rv usr /
 	@echo
 	@echo "This method is for testing & development."


### PR DESCRIPTION
This patch prefixes the hash-based version string with the name of the current branch. Including this data will be useful to developers to help track not only the revision, but the current testing branch via 'bastille version'

Additionally it removes the .orig extension on the sed command which left artifacts behind.