### PR TITLE
update default firewalls to support ipv6 by default

### DIFF
--- a/docs/chapters/gcp.rst
+++ b/docs/chapters/gcp.rst
@@ -69,7 +69,7 @@ them through the external interface:
   pass out
   
   pass in proto tcp to port {22}
-  pass in inet proto icmp icmp-type { echoreq }
+  pass in proto icmp icmp-type { echoreq }
   pass in on $bridge_if
 
 Restart the host and make sure everything comes up correctly. You should see the

--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -469,7 +469,7 @@ Create the firewall rules:
   block in all
   pass out quick keep state
   antispoof for $ext_if inet
-  pass in inet proto tcp from any to any port ssh flags S/SA modulate state
+  pass in proto tcp from any to any port ssh flags S/SA modulate state
 
 - Make sure to change the ``ext_if`` variable to match your host system
 interface.

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -277,7 +277,7 @@ rdr-anchor "rdr/*"
 block in all
 pass out quick keep state
 antispoof for \$ext_if inet
-pass in inet proto tcp from any to any port ssh flags S/SA keep state
+pass in proto tcp from any to any port ssh flags S/SA keep state
 EOF
     sysrc pf_enable=YES
     warn "pf ruleset created, please review ${bastille_pf_conf} and enable it using 'service pf start'."


### PR DESCRIPTION
This patch updates the default pf.conf to remove the 'inet' reference (which limits to ipv4). By omitting the inet/inet6 declaration it will auto-detect and support both.

This fix is based on a comment made in Discord regarding BastilleBSD distro. The default firewall, as generated by 'bastille setup' allows inbound SSH from only ipv4. This resolves that issue.