### PR TITLE
Wrap $RDR_IF in double quotes

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -363,9 +363,9 @@ while [ "$#" -gt 0 ]; do
                 error_exit "[ERROR]: [-t|--type] must be set when NOT using a table as [-s|--source] or [-d|--destination]."
             elif [ "$#" -eq 3 ]; then
                 check_jail_validity
-                validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
-                persist_rdr_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
-                load_rdr_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+                validate_rdr_rule "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
+                persist_rdr_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
+                load_rdr_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
 		# Temp block to remove old format after new format is loaded the first time
 		while read rules; do
                 if [ "$(echo ${rules} | wc -w)" -lt 6 ]; then
@@ -386,18 +386,18 @@ while [ "$#" -gt 0 ]; do
                             done
                             if [ "${2}" = "(" ] && [ "${last}" = ")" ] ; then
                                 check_jail_validity
-                                validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
-                                persist_rdr_log_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
-                                load_rdr_log_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"                                
+                                validate_rdr_rule "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
+                                persist_rdr_log_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                                load_rdr_log_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"                                
                                 shift $#
                             else
                                 usage
                             fi
                         elif [ $# -eq 1 ]; then
                             check_jail_validity
-                            validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
-                            persist_rdr_log_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
-                            load_rdr_log_rule $RDR_INET $RDR_IF $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                            validate_rdr_rule "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
+                            persist_rdr_log_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
+                            load_rdr_log_rule $RDR_INET "$RDR_IF" $RDR_SRC $RDR_DST $proto $host_port $jail_port "$@"
                             shift 1
                         else
                             usage
@@ -417,13 +417,13 @@ while [ "$#" -gt 0 ]; do
             fi
             if [ "$#" -eq 7 ] && { [ "${5}" = "tcp" ] || [ "${5}" = "udp" ]; } then
                 check_jail_validity
-                validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+                validate_rdr_rule "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
                 persist_rdr_rule "$@"
                 load_rdr_rule "$@"
                 shift "$#"
             elif [ "$#" -ge 8 ] && [ "${8}" = "log" ]; then
                 check_jail_validity
-                validate_rdr_rule $RDR_IF $RDR_SRC $RDR_DST $1 $2 $3
+                validate_rdr_rule "$RDR_IF" $RDR_SRC $RDR_DST $1 $2 $3
                 persist_rdr_log_rule "$@"
                 load_rdr_log_rule "$@"
                 shift "$#"


### PR DESCRIPTION
My pf.conf looks like this, to support multiple interfaces later on:
<img width="238" height="43" alt="image" src="https://github.com/user-attachments/assets/c698ff78-9c06-4095-94e2-02080ec03730" />

When $RDR_IF is not quoted, the resulting validate_rdr_rule, persist_rdr_rule, load_rdr_rule calls will interpret $RDR_IF as 3 separate strings "{", "em0" and "}" when it should be the single string "{ em0 }"

I added some echo statements while troubleshooting to see the values of the args during `bastille rdr` command execution. Here is the failing, split $RDR_IF:
<img width="786" height="245" alt="image" src="https://github.com/user-attachments/assets/2c367db5-50f2-4dd0-84f8-628eb925bcf4" />


and here is the passing, double quoted $RDR_IF:
<img width="786" height="224" alt="image" src="https://github.com/user-attachments/assets/d37b2cbe-a53d-43aa-9ce5-7158ae8a351d" />
