### PR TITLE
Update rename.sh - Fix netgraph interface suffix

### DIFF
--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -211,10 +211,10 @@ update_jailconf_vnet() {
     	        local _new_ngif="ng${_ngif_num}_${name_prefix}xx${name_suffix}"
             fi
 
-            local _new_if_prefix="$(echo ${_if} | awk -F'_' '{print $1}')"
-            local _new_if_suffix="$(echo ${_if} | awk -F'_' '{print $2}')"
+            local _new_if_prefix="$(echo ${_new_ngif} | awk -F'_' '{print $1}')"
+            local _new_if_suffix="$(echo ${_new_ngif} | awk -F'_' '{print $2}')"
 
-            # Replace netgraph interface name                
+            # Replace netgraph interface name
             sed -i '' "s|jng bridge ${_old_if_suffix}|jng bridge ${_new_if_suffix}|g" "${_jail_conf}"
             sed -i '' "s|${_old_ngif} ether|${_new_ngif} ether|g" "${_jail_conf}"
             sed -i '' "s|jng shutdown ${_old_if_suffix}|jng shutdown ${_new_if_suffix}|g" "${_jail_conf}"


### PR DESCRIPTION
Resolves renaming netgraph jails. Previous behavior would "replace" the jng commands with the same old interface then fail to start the newly renamed jail with the following output.

```sh
Attempting to rename 'testjail' to jt...
Renamed 'testjail' to 'jt' successfully.

[jt]:
ng0_testjail
jt: created
ifconfig: interface ng0_jt does not exist
jail: jt: /sbin/ifconfig ng0_jt vnet jt: failed
jt: removed
```

The failure case above required manually creating the netgraph interface with `jng bridge <new ng int suffix> <interface>` and removing the old one `jng shutdown <old ng int suffix>`

~Also remove extraneous sed on `ether` in jail.conf and `epair` in rc.conf. These two lines are only for bridged vnet jails.~