### PR TITLE
Fix destroy single digit on major version releases

### DIFF
--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -261,7 +261,7 @@ case "${TARGET}" in
         ;;
     *-RELEASE|*-RELEASE-I386|*-RELEASE-i386|*-release|*-RC[1-9]|*-rc[1-9]|*-BETA[1-9])
         ## check for FreeBSD releases name
-        NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([1-9]{2,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-9]|-BETA[1-9])$' | tr '[:lower:]' '[:upper:]' | sed 's/I/i/g')
+        NAME_VERIFY=$(echo "${TARGET}" | grep -iwE '^([0-9]{1,2})\.[0-9](-RELEASE|-RELEASE-i386|-RC[1-9]|-BETA[1-9])$' | tr '[:lower:]' '[:upper:]' | sed 's/I/i/g')
         destroy_rel
         ;;
     *-stable-LAST|*-STABLE-last|*-stable-last|*-STABLE-LAST)


### PR DESCRIPTION
This will fix the regex to be able to destroy single digit on major version releases.

**Repository used:**
`bastille_url_freebsd_old="https://archive.freebsd.org/old-releases/"`

```
bastille bootstrap 9.0-release

Bootstrapping release: 9.0-release...

Fetching FreeBSD distfiles...
/mnt/data/bastille/cache/9.0-RELEASE/MANIFEST          782  B 8680 kBps    00s
/mnt/data/bastille/cache/9.0-RELEASE/base.txz           54 MB 5299 kBps    11s

Validated checksum for 9.0-RELEASE: base.txz
MANIFEST: 7a1de94906f98539c70b71f2a9277ff9514fd8134b71f30e3c22f59b7c49ece0
DOWNLOAD: 7a1de94906f98539c70b71f2a9277ff9514fd8134b71f30e3c22f59b7c49ece0
```

**Problem:**
```
bastille destroy 9.0-RELEASE
Usage: bastille destroy [option(s)] JAIL|RELEASE
	
    Options:

    -a | --auto              Auto mode. Start/stop jail(s) if required.
    -c | --no-cache          Do no destroy cache when destroying a release.
    -f | --force             Force unmount any mounted datasets when destroying a jail or release (ZFS only).
    -y | --yes               Do no prompt. Just destroy.
    -x | --debug             Enable debug mode.
```

**This PR Fix Applied:**
```
bastille destroy 9.0-RELEASE

Attempting to destroy release: 9.0-RELEASE
Deleting release base...
```