### PR TITLE
Don't quote ${SH}

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -240,7 +240,7 @@ if [ -f "${SCRIPTPATH}" ]; then
 
     : "${SH:=sh}"
 
-    exec "${SH}" "${SCRIPTPATH}" "$@"
+    exec ${SH} "${SCRIPTPATH}" "$@"
 
 else
     error_exit "${SCRIPTPATH} not found."


### PR DESCRIPTION
When ${SH} is quoted one cannot replace the shell with another shell with arguments, e.g., for debugging purposes: SH="sh -x" bastille ... Don't quote, expect the shell path to never contain a space and be from /etc/shells.