### PR TITLE
Apply version (natural) sort to listings

### DIFF
--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -156,7 +156,7 @@ destroy_rel() {
     BASE_HASCHILD="0"
     if [ -d "${bastille_jailsdir}" ]; then
 
-        JAIL_LIST=$(ls "${bastille_jailsdir}" | sed "s/\n//g")
+        JAIL_LIST=$(ls -v --color=never "${bastille_jailsdir}" | sed "s/\n//g")
 
         for _jail in ${JAIL_LIST}; do
 

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -71,7 +71,7 @@ get_jail_list() {
     if [ -n "${TARGET}" ]; then
         JAIL_LIST="${TARGET}"
     else
-        JAIL_LIST="$(ls --color=never "${bastille_jailsdir}" | sed "s/\n//g")"
+        JAIL_LIST="$(ls -v --color=never "${bastille_jailsdir}" | sed "s/\n//g")"
     fi
 }
 
@@ -584,7 +584,7 @@ list_release(){
     if [ -d "${bastille_releasesdir}" ]; then
         # TODO: Check if this can be changed to `find` as SC2012 suggests.
         # shellcheck disable=SC2012
-        REL_LIST="$(ls "${bastille_releasesdir}" | sed "s/\n//g")"
+        REL_LIST="$(ls -v --color=never "${bastille_releasesdir}" | sed "s/\n//g")"
         for _REL in ${REL_LIST}; do
             if [ -f "${bastille_releasesdir}/${_REL}/root/.profile" ] || [ -d "${bastille_releasesdir}/${_REL}/debootstrap" ]; then
                 if [ "${1}" = "-p" ] && [ -f "${bastille_releasesdir}/${_REL}/bin/freebsd-version" ]; then
@@ -603,7 +603,7 @@ list_snapshot(){
     # TODO: Ability to list snapshot data for a single target.
     # List snapshots with its usage data for valid bastille jails only.
     if [ -d "${bastille_jailsdir}" ]; then
-        JAIL_LIST=$(ls --color=never "${bastille_jailsdir}" | sed "s/\n//g")
+        JAIL_LIST=$(ls -v --color=never "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/jail.conf" ]; then
                 info "\n[${_JAIL}]:"
@@ -619,7 +619,7 @@ list_template(){
 
 list_jail(){
     if [ -d "${bastille_jailsdir}" ]; then
-        JAIL_LIST=$(ls --color=never "${bastille_jailsdir}" | sed "s/\n//g")
+        JAIL_LIST=$(ls -v --color=never "${bastille_jailsdir}" | sed "s/\n//g")
         for _JAIL in ${JAIL_LIST}; do
             if [ -f "${bastille_jailsdir}/${_JAIL}/jail.conf" ]; then
                 echo "${_JAIL}"
@@ -638,7 +638,7 @@ list_limit(){
 
 list_import(){
     # shellcheck disable=SC2010
-    ls "${bastille_backupsdir}" | grep -v ".sha256$"
+    ls -v "${bastille_backupsdir}" | grep -v ".sha256$"
 }
 
 bastille_root_check

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -88,7 +88,7 @@ set_target "${TARGET}" "reverse"
 for _jail in ${JAILS}; do
 
     # Validate that all jails that 'depend' on this one are stopped
-    for _depend_jail in $(ls --color=never ${bastille_jailsdir} | sed -e 's/\n//g'); do
+    for _depend_jail in $(ls -v --color=never ${bastille_jailsdir} | sed -e 's/\n//g'); do
     if ! grep -hoqsw "depend=" ${bastille_jailsdir}/${_depend_jail}/settings.conf; then
         sysrc -q -f ${bastille_jailsdir}/${_depend_jail}/settings.conf depend="" >/dev/null
     fi


### PR DESCRIPTION
When listing jails, releases, or alike sort them version-aware (natural) where 10 comes not after 1, but after 9.

Rationale: When you have a lot of numerically similar jails make then sort numerically.
Before:
```
# bastille list
 JID  Name            Boot  Prio  State  Type   IP Address     Published Ports  Release          Tags
 28   deblndw013x10j  on    99    Up     thick  10.64.105.166  -                13.5-RELEASE-p3  -
 13   deblndw013x1j   on    99    Up     thick  10.64.105.149  -                13.5-RELEASE-p3  -
 11   deblndw013x2j   on    99    Up     thick  10.64.105.150  -                13.5-RELEASE-p3  -
 3    deblndw013x3j   on    99    Up     thick  10.64.105.151  -                13.5-RELEASE-p3  -
 10   deblndw013x4j   on    99    Up     thick  10.64.105.155  -                13.5-RELEASE-p3  -
```
After:
```
# bastille list
 JID  Name            Boot  Prio  State  Type   IP Address     Published Ports  Release          Tags
 13   deblndw013x1j   on    99    Up     thick  10.64.105.149  -                13.5-RELEASE-p3  -
 11   deblndw013x2j   on    99    Up     thick  10.64.105.150  -                13.5-RELEASE-p3  -
 3    deblndw013x3j   on    99    Up     thick  10.64.105.151  -                13.5-RELEASE-p3  -
 10   deblndw013x4j   on    99    Up     thick  10.64.105.155  -                13.5-RELEASE-p3  -
 28   deblndw013x10j  on    99    Up     thick  10.64.105.166  -                13.5-RELEASE-p3  -
```