### PR TITLE
Epair naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,17 @@ dynamically, allowing the use of both types of VNET jails without issue. We
 have also selected a naming scheme that will allow for consistency across
 these jail types. The naming scheme is as follows:
 
-e0a_jailname and e0b_jailname are the default epair interfaces for every
-jail. The a side is on the host, while the b is in the jail. This will
+`e0a_jailname` and `e0b_jailname` are the default epair interfaces for every
+jail. The `e0a` side is on the host, while the `e0b` is in the jail. This will
 allow better management when trying to figure out which jail a given epair is
-linked to. Due to a limitation in how long an interface name can be, Bastille
-will truncate "jailname" to avoid errors if it is too long. So,
-mylongjailname will be e0a_mylongjxxme and e0b_mylongjxxme. The xx
-part is necessary due to another limitation that does not allow dots (.) in
-interface names when using the jib script.
+linked to. Due to a limitations in how long an interface name can be, Bastille
+will name any epairs whose jail names exceed the maximum length, to
+`e0b_bastille1` and `e0b_bastille1` with the `1` incrementing by 1 for
+each new epair. So, mylongjailname will be `e0a_bastille2` and `e0b_bastille2`.
 
 If you decide to add an interface using the network sub-command, they will
-be named e1a_jailname and e1b_jailname respectively. The number included
-will increment by 1 for each interface you add.
+be named `e1a_jailname` and `e1b_jailname` respectively. The number included
+in the prefix `eXa_` will increment by 1 for each interface you add.
 
 Mandatory
 ---------

--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -145,19 +145,20 @@ For the ``inherit`` and ``ip_hostname`` options, you can also specify
 Networking Limitations
 ----------------------
 
-* Bastille handles the epair naming scheme by creating an epair, then naming it
-  ``e0a_JAILNAME`` for host, and ``e0b_JAILNAME`` for the jail. A know limitaion
-  is that interface cannot exceed 16 characters. If it is more that 16 characters,
-  FreeBSD will complain and fail to bring it up. To mitigate this, Bastille will
-  truncate the interface name if it exceeds the character limit in the following
-  manner.
-  If your jail is called ``mylongjailnamehere``, Bastille will truncate the
-  epairs to ``e0a_mylongjxxre`` and ``e0b_mylongjxxre``, by using the first 11
-  characters, then ``xx``, then the last two characters.
-  This can cause issues if your jail naming scheme is similar to the following
-  example...
-  
-  ``nextcloud1jail`` ``nextcloud2jail`` ``nextcloud3jail``
+VNET Jail Interface Names
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* FreeBSD has certain limitations when it comes to interface names. One
+  of these is that interface names cannot be longer than 15 characters.
+  Because of this, Bastille uses a generic name for any epairs created
+  whose corresponding jail name exceeds the maximum length. See below...
+
+  ``e0a_jailname`` and ``e0b_jailname`` are the default epair interfaces for every
+  jail. The ``e0a`` side is on the host, while the ``e0b`` is in the jail. Due
+  to the above mentioned limitations, Bastille will name any epairs whose
+  jail names exceed the maximum length, to ``e0b_bastilleX`` and ``e0b_bastilleX``
+  with the ``X`` starting at ``1`` and incrementing by 1 for each new epair.
+  So, ``mylongjailname`` will be ``e0a_bastille2`` and ``e0b_bastille2``.
 
 Network Scenarios
 -----------------

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -34,10 +34,11 @@ The ``rdr`` command includes 4 additional options:
 
 .. code-block:: shell
 
-    -d | --destination [destination]          Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
-    -i | --interface   [interface]            Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-    -s | --source      [source]               Limit rdr to a source IP or table. Useful to only allow access from certain sources.
-    -t | --type        [ipv4|ipv6]            Specify IP type. Must be used if -s or -d are used. Defaults to both.
+    -d | --destination IP            Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -i | --interface   IF,IF         Specify interface(s) to apply rule to. Comman separated.
+    -s | --source      IP|table      Limit rdr to a source IP or table.
+    -t | --type        ipv4|ipv6     Specify IP type. Must be used if -s or -d are used. Defaults to both.
+    -x | --debug                     Enable debug mode.
 
 .. code-block:: shell
 
@@ -78,8 +79,8 @@ Simply use the table name instead of an IP address or subnet.
 
       Options:
 
-      -d | --destination [destination]             Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
-      -i | --interface   [interface]               Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-      -s | --source      [source]                  Limit rdr to a source IP or table. Useful to only allow access from certain sources.
-      -t | --type        [ipv4|ipv6]               Specify IP type. Must be used if -s or -d are used. Defaults to both.
-      -x | --debug                                 Enable debug mode.
+      -d | --destination IP            Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+      -i | --interface   IF,IF         Specify interface(s) to apply rule to. Comman separated.
+      -s | --source      IP|table      Limit rdr to a source IP or table.
+      -t | --type        ipv4|ipv6     Specify IP type. Must be used if -s or -d are used. Defaults to both.
+      -x | --debug                     Enable debug mode.

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -386,6 +386,7 @@ update_jailconf_vnet() {
             local old_ngif="${if}"
             # Generate new netgraph interface name
             local new_ngif="ng${ngif_num}_${NEWNAME}"
+            # shellcheck disable=SC2046
             local new_if_prefix="$(echo ${if} | awk -F'_' '{print $1}')"
             local new_if_suffix="$(echo ${if} | awk -F'_' '{print $2}')"
 

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -231,212 +231,221 @@ update_jailconf() {
 
 update_jailconf_vnet() {
 
-    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
-    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    local jail_config="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local jail_rc_config="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
 
     # Determine number of interfaces
     if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
-        local _if_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${_jail_conf} | sort -u)"
+        local if_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${jail_config} | sort -u)"
     elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-        local _if_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${_jail_conf} | sort -u)"
+        local if_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${jail_config} | sort -u)"
     fi
 
-    for _if in ${_if_list}; do
+    # We need to following to prevent incremental bastille1, bastille2 etc...
+    local reuse_new_suffix=""
 
-        local _old_if_prefix="$(echo ${_if} | awk -F'_' '{print $1}')"
-        local _old_if_suffix="$(echo ${_if} | awk -F'_' '{print $2}')"
+    for if in ${if_list}; do
+
+        local old_if_prefix="$(echo ${if} | awk -F'_' '{print $1}')"
+        local old_if_suffix="$(echo ${if} | awk -F'_' '{print $2}')"
 
         # For if_bridge network type
         if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
 
-            local _epair_num="$(echo "${_old_if_prefix}" | grep -Eo "[0-9]+")"
-            local _old_host_epair="${_if}"
-            local _old_jail_epair="${_old_if_prefix%a}b_${_old_if_suffix}"
+            local epair_num="$(echo "${old_if_prefix}" | grep -Eo "[0-9]+")"
+            local old_host_epair="${if}"
+            local old_jail_epair="${old_if_prefix%a}b_${old_if_suffix}"
 
-            if [ "$(echo -n "e${_epair_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
+            if [ "$(echo -n "e${epair_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                 # Generate new epair name
-                local _new_host_epair="e${_epair_num}a_${NEWNAME}"
-                local _new_jail_epair="e${_epair_num}b_${NEWNAME}"
+                local new_host_epair="e${epair_num}a_${NEWNAME}"
+                local new_jail_epair="e${epair_num}b_${NEWNAME}"
             else
-                get_bastille_epair_count
-                local epair_num=1
-                while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
-                    epair_num=$((epair_num + 1))
-                done
-                local _new_host_epair="e0a_bastille${epair_num}"
-                local _new_jail_epair="e0b_bastille${epair_num}"
+                if [ -z "${reuse_new_suffix}" ]; then
+                    get_bastille_epair_count
+                    local bastille_epair_num=1
+                    while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${bastille_epair_num}"; do
+                        bastille_epair_num=$((bastille_epair_num + 1))
+                    done
+                    local new_host_epair="e${epair_num}a_bastille${bastille_epair_num}"
+                    local new_jail_epair="e${epair_num}b_bastille${bastille_epair_num}"
+                    local reuse_new_suffix="bastille${bastille_epair_num}"
+                else
+                    local new_host_epair="e${epair_num}a_${reuse_new_suffix}"
+                    local new_jail_epair="e${epair_num}b_${reuse_new_suffix}"
+                fi
             fi
 
-            local _new_if_prefix="$(echo ${_new_host_epair} | awk -F'_' '{print $1}')"
-            local _new_if_suffix="$(echo ${_new_host_epair} | awk -F'_' '{print $2}')"
+            local new_if_prefix="$(echo ${new_host_epair} | awk -F'_' '{print $1}')"
+            local new_if_suffix="$(echo ${new_host_epair} | awk -F'_' '{print $2}')"
 
-            if grep "${_old_if_suffix}" "${_jail_conf}" | grep -oq "jib addm"; then
+            if grep "${old_if_suffix}" "${jail_config}" | grep -oq "jib addm"; then
                 # For -V jails
                 # Replace host epair name in jail.conf
-                sed -i '' "s|jib addm ${_old_if_suffix}|jib addm ${_new_if_suffix}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+                sed -i '' "s|jib addm ${old_if_suffix}|jib addm ${new_if_suffix}|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} ether|${new_host_epair} ether|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} destroy|${new_host_epair} destroy|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} description|${new_host_epair} description|g" "${jail_config}"
 
                 # Replace jail epair name in jail.conf
-                sed -i '' "s|= ${_old_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
-                sed -i '' "s|${_old_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                sed -i '' "s|= ${old_jail_epair};|= ${new_jail_epair};|g" "${jail_config}"
+                sed -i '' "s|${old_jail_epair} ether|${new_jail_epair} ether|g" "${jail_config}"
 
                 # If jail had a static MAC, generate one for clone
-                if grep ether ${_jail_conf} | grep -qoc ${_new_jail_epair}; then
-                    local external_interface="$(grep ${_new_if_suffix} ${_jail_conf} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
+                if grep ether ${jail_config} | grep -qoc ${new_jail_epair}; then
+                    local external_interface="$(grep ${new_if_suffix} ${jail_config} | grep -o 'addm.*' | awk '{print $3}' | sed 's/["|;]//g')"
                     generate_static_mac "${NEWNAME}" "${external_interface}"
-                    sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_jail_epair} ether ${macaddr}a\";|" "${_jail_conf}"
-                    sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
+                    sed -i '' "s|${new_jail_epair} ether.*:.*:.*:.*:.*:.*a\";|${new_jail_epair} ether ${macaddr}a\";|" "${jail_config}"
+                    sed -i '' "s|${new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${new_jail_epair} ether ${macaddr}b\";|" "${jail_config}"
                 fi
 
                 # Replace epair description
-                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${jail_config}"
 
                 # Replace epair name in /etc/rc.conf
-                sed -i '' "/ifconfig/ s|${_old_jail_epair}|${_new_jail_epair}|g" "${_rc_conf}"
+                sed -i '' "/ifconfig/ s|${old_jail_epair}|${new_jail_epair}|g" "${jail_rc_config}"
             else
                 # For -B jails
                 # Replace host epair name in jail.conf
-                sed -i '' "s|up name ${_old_host_epair}|up name ${_new_host_epair}|g" "${_jail_conf}"
-                sed -i '' "s|addm ${_old_host_epair}|addm ${_new_host_epair}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+                sed -i '' "s|up name ${old_host_epair}|up name ${new_host_epair}|g" "${jail_config}"
+                sed -i '' "s|addm ${old_host_epair}|addm ${new_host_epair}|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} ether|${new_host_epair} ether|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} destroy|${new_host_epair} destroy|g" "${jail_config}"
+                sed -i '' "s|${old_host_epair} description|${new_host_epair} description|g" "${jail_config}"
 
                 # Replace jail epair name in jail.conf
-                sed -i '' "s|= ${_old_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
-                sed -i '' "s|up name ${_old_jail_epair}|up name ${_new_jail_epair}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                sed -i '' "s|= ${old_jail_epair};|= ${new_jail_epair};|g" "${jail_config}"
+                sed -i '' "s|up name ${old_jail_epair}|up name ${new_jail_epair}|g" "${jail_config}"
+                sed -i '' "s|${old_jail_epair} ether|${new_jail_epair} ether|g" "${jail_config}"
 
                 # If jail had a static MAC, generate one for clone
-                if grep -q ether ${_jail_conf}; then
-                    local external_interface="$(grep "e${_epair_num}a" ${_jail_conf} | grep -o '[^ ]* addm' | awk '{print $1}')"
+                if grep -q ether ${jail_config}; then
+                    local external_interface="$(grep "e${epair_num}a" ${jail_config} | grep -o '[^ ]* addm' | awk '{print $1}')"
                     generate_static_mac "${NEWNAME}" "${external_interface}"
-                    sed -i '' "s|${_new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${_new_host_epair} ether ${macaddr}a\";|" "${_jail_conf}"
-                    sed -i '' "s|${_new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${_new_jail_epair} ether ${macaddr}b\";|" "${_jail_conf}"
+                    sed -i '' "s|${new_host_epair} ether.*:.*:.*:.*:.*:.*a\";|${new_host_epair} ether ${macaddr}a\";|" "${jail_config}"
+                    sed -i '' "s|${new_jail_epair} ether.*:.*:.*:.*:.*:.*b\";|${new_jail_epair} ether ${macaddr}b\";|" "${jail_config}"
                 fi
 
                 # Replace epair description
-                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${jail_config}"
 
                 # Replace epair name in /etc/rc.conf
-                sed -i '' "/ifconfig/ s|${_old_jail_epair}|${_new_jail_epair}|g" "${_rc_conf}"
+                sed -i '' "/ifconfig/ s|${old_jail_epair}|${new_jail_epair}|g" "${jail_rc_config}"
             fi
 
             # Update /etc/rc.conf
-            local _jail_vnet="$(grep ${_old_jail_epair} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
-            local _jail_vnet_vlan="$(grep "vlans_${_jail_vnet}" "${_rc_conf}" | sed 's/.*=//g')"
-            sed -i '' "s|${_old_jail_epair}_name|${_new_jail_epair}_name|" "${_rc_conf}"
+            local jail_vnet="$(grep ${old_jail_epair} "${jail_rc_config}" | grep -Eo -m 1 "vnet[0-9]+")"
+            local jail_vnet_vlan="$(grep "vlans_${jail_vnet}" "${jail_rc_config}" | sed 's/.*=//g')"
+            sed -i '' "s|${old_jail_epair}_name|${new_jail_epair}_name|" "${jail_rc_config}"
             # IP4
             if [ -n "${IP4_ADDR}" ]; then
-                if grep "vnet0" "${_rc_conf}" | grep -q "${_new_jail_epair}_name"; then
-                    if [ -n "${_jail_vnet_vlan}" ]; then
+                if grep "vnet0" "${jail_rc_config}" | grep -q "${new_jail_epair}_name"; then
+                    if [ -n "${jail_vnet_vlan}" ]; then
                         if [ "${IP4_ADDR}" = "0.0.0.0" ] || [ "${IP4_ADDR}" = "DHCP" ] || [ "${IP4_ADDR}" = "SYNCDHCP" ]; then
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0_${_jail_vnet_vlan}="SYNCDHCP"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0_${jail_vnet_vlan}="SYNCDHCP"
                         else
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0_${_jail_vnet_vlan}="inet ${IP4_ADDR}"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0_${jail_vnet_vlan}="inet ${IP4_ADDR}"
                         fi
                     else
                         if [ "${IP4_ADDR}" = "0.0.0.0" ] || [ "${IP4_ADDR}" = "DHCP" ] || [ "${IP4_ADDR}" = "SYNCDHCP" ]; then
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0="SYNCDHCP"
                         else
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0="inet ${IP4_ADDR}"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0="inet ${IP4_ADDR}"
                         fi
                     fi
                 else
-                    if [ -n "${_jail_vnet_vlan}" ]; then
-                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}_${_jail_vnet_vlan}="SYNCDHCP"
+                    if [ -n "${jail_vnet_vlan}" ]; then
+                        sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_${jail_vnet_vlan}="SYNCDHCP"
                     else
-                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}="SYNCDHCP"
+                        sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="SYNCDHCP"
                     fi
                 fi
             fi
             # IP6
             if [ -n "${IP6_ADDR}" ]; then
-                if grep "vnet0" "${_rc_conf}" | grep -q "${_new_jail_epair}_name"; then
+                if grep "vnet0" "${jail_rc_config}" | grep -q "${new_jail_epair}_name"; then
                     if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                        sysrc -f "${_rc_conf}" ifconfig_vnet0_ipv6="inet6 -ifdisabled accept_rtadv"
+                        sysrc -f "${jail_rc_config}" ifconfig_vnet0_ipv6="inet6 -ifdisabled accept_rtadv"
                     else
-                        sysrc -f "${_rc_conf}" ifconfig_vnet0_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
+                        sysrc -f "${jail_rc_config}" ifconfig_vnet0_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
                     fi
                 else
                     if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
+                        sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
                     fi
                 fi
             fi
 
             # Replace epair description
-            sed -i '' "/${_new_host_epair}/ s|${_jail_vnet} host interface for Bastille jail ${TARGET}|${_jail_vnet} host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+            sed -i '' "/${new_host_epair}/ s|${jail_vnet} host interface for Bastille jail ${TARGET}|${jail_vnet} host interface for Bastille jail ${NEWNAME}|g" "${jail_config}"
 
         # Update netgraph VNET (non-bridged) config
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
 
-            local _ngif_num="$(echo "${_old_if_prefix}" | grep -Eo "[0-9]+")"
-            local _old_ngif="${_if}"
+            local ngif_num="$(echo "${old_if_prefix}" | grep -Eo "[0-9]+")"
+            local old_ngif="${if}"
             # Generate new netgraph interface name
-            local _new_ngif="ng${_ngif_num}_${NEWNAME}"
-            local _new_if_prefix="$(echo ${_if} | awk -F'_' '{print $1}')"
-            local _new_if_suffix="$(echo ${_if} | awk -F'_' '{print $2}')"
+            local new_ngif="ng${ngif_num}_${NEWNAME}"
+            local new_if_prefix="$(echo ${if} | awk -F'_' '{print $1}')"
+            local new_if_suffix="$(echo ${if} | awk -F'_' '{print $2}')"
 
             # Replace netgraph interface name
-            sed -i '' "s|jng bridge ${_old_if_suffix}|jng bridge ${_new_if_suffix}|g" "${_jail_conf}"
-            sed -i '' "s|${_old_ngif} ether|${_new_ngif} ether|g" "${_jail_conf}"
-            sed -i '' "s|jng shutdown ${_old_if_suffix}|jng shutdown ${_new_if_suffix}|g" "${_jail_conf}"
+            sed -i '' "s|jng bridge ${old_if_suffix}|jng bridge ${new_if_suffix}|g" "${jail_config}"
+            sed -i '' "s|${old_ngif} ether|${new_ngif} ether|g" "${jail_config}"
+            sed -i '' "s|jng shutdown ${old_if_suffix}|jng shutdown ${new_if_suffix}|g" "${jail_config}"
 
             # Replace jail epair name in jail.conf
-            sed -i '' "s|= ${_old_ngif};|= ${_new_ngif};|g" "${_jail_conf}"
+            sed -i '' "s|= ${old_ngif};|= ${new_ngif};|g" "${jail_config}"
 
             # Replace epair name in /etc/rc.conf
-            sed -i '' "/ifconfig/ s|${_old_ngif}|${_new_ngif}|g" "${_rc_conf}"
+            sed -i '' "/ifconfig/ s|${old_ngif}|${new_ngif}|g" "${jail_rc_config}"
 
-            local _jail_vnet="$(grep ${_if} "${_rc_conf}" | grep -Eo -m 1 "vnet[0-9]+")"
-            local _jail_vnet_vlan="$(grep "vlans_${_jail_vnet}" "${_rc_conf}" | sed 's/.*=//g')"
+            local jail_vnet="$(grep ${if} "${jail_rc_config}" | grep -Eo -m 1 "vnet[0-9]+")"
+            local jail_vnet_vlan="$(grep "vlans_${jail_vnet}" "${jail_rc_config}" | sed 's/.*=//g')"
 
             # If jail had a static MAC, generate one for clone
-            if grep ether ${_jail_conf} | grep -qoc ${_new_ngif}; then
-                local external_interface="$(grep ${_new_if_suffix} ${_jail_conf} | grep -o 'jng bridge.*' | awk '{print $4}' | sed 's/["|;]//g')"
+            if grep ether ${jail_config} | grep -qoc ${new_ngif}; then
+                local external_interface="$(grep ${new_if_suffix} ${jail_config} | grep -o 'jng bridge.*' | awk '{print $4}' | sed 's/["|;]//g')"
                 generate_static_mac "${NEWNAME}" "${external_interface}"
-                sed -i '' "s|${_new_ngif} ether.*:.*:.*:.*:.*:.*a\";|${_new_ngif} ether ${macaddr}a\";|" "${_jail_conf}"
+                sed -i '' "s|${new_ngif} ether.*:.*:.*:.*:.*:.*a\";|${new_ngif} ether ${macaddr}a\";|" "${jail_config}"
             fi
 
             # Update /etc/rc.conf
-            sed -i '' "s|ifconfig_${_old_ngif}_name|ifconfig_${_new_ngif}_name|" "${_rc_conf}"
+            sed -i '' "s|ifconfig_${old_ngif}_name|ifconfig_${new_ngif}_name|" "${jail_rc_config}"
             # IP4
             if [ -n "${IP4_ADDR}" ]; then
-                if grep "vnet0" "${_rc_conf}" | grep -q "${_new_ngif}_name"; then
-                    if [ -n "${_jail_vnet_vlan}" ]; then
+                if grep "vnet0" "${jail_rc_config}" | grep -q "${new_ngif}_name"; then
+                    if [ -n "${jail_vnet_vlan}" ]; then
                         if [ "${IP4_ADDR}" = "0.0.0.0" ] || [ "${IP4_ADDR}" = "DHCP" ] || [ "${IP4_ADDR}" = "SYNCDHCP" ]; then
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0_${_jail_vnet_vlan}="SYNCDHCP"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0_${jail_vnet_vlan}="SYNCDHCP"
                         else
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0_${_jail_vnet_vlan}="inet ${IP4_ADDR}"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0_${jail_vnet_vlan}="inet ${IP4_ADDR}"
                         fi
                     else
                         if [ "${IP4_ADDR}" = "0.0.0.0" ] || [ "${IP4_ADDR}" = "DHCP" ] || [ "${IP4_ADDR}" = "SYNCDHCP" ]; then
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0="SYNCDHCP"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0="SYNCDHCP"
                         else
-                            sysrc -f "${_rc_conf}" ifconfig_vnet0="inet ${IP4_ADDR}"
+                            sysrc -f "${jail_rc_config}" ifconfig_vnet0="inet ${IP4_ADDR}"
                         fi
                     fi
                 else
-                    if [ -n "${_jail_vnet_vlan}" ]; then
-                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}_${_jail_vnet_vlan}="SYNCDHCP"
+                    if [ -n "${jail_vnet_vlan}" ]; then
+                        sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_${jail_vnet_vlan}="SYNCDHCP"
                     else
-                        sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}="SYNCDHCP"
+                        sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="SYNCDHCP"
                     fi
                 fi
             fi
             # IP6
             if [ -n "${IP6_ADDR}" ]; then
-                if grep "vnet0" "${_rc_conf}" | grep -q "${_new_ngif}_name"; then
+                if grep "vnet0" "${jail_rc_config}" | grep -q "${new_ngif}_name"; then
                     if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                        sysrc -f "${_rc_conf}" ifconfig_vnet0_ipv6="inet6 -ifdisabled accept_rtadv"
+                        sysrc -f "${jail_rc_config}" ifconfig_vnet0_ipv6="inet6 -ifdisabled accept_rtadv"
                     else
-                        sysrc -f "${_rc_conf}" ifconfig_vnet0_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
+                        sysrc -f "${jail_rc_config}" ifconfig_vnet0_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
                     fi
                 else
-                    sysrc -f "${_rc_conf}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
                 fi
             fi
         fi

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -386,7 +386,7 @@ update_jailconf_vnet() {
             local old_ngif="${if}"
             # Generate new netgraph interface name
             local new_ngif="ng${ngif_num}_${NEWNAME}"
-            # shellcheck disable=SC2046
+            # shellcheck disable=SC2034
             local new_if_prefix="$(echo ${if} | awk -F'_' '{print $1}')"
             local new_if_suffix="$(echo ${if} | awk -F'_' '{print $2}')"
 

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -263,8 +263,8 @@ update_jailconf_vnet() {
                 while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
                     epair_num=$((epair_num + 1))
                 done
-                local host_epair="e0a_bastille${epair_num}"
-                local jail_epair="e0b_bastille${epair_num}"
+                local _new_host_epair="e0a_bastille${epair_num}"
+                local _new_jail_epair="e0b_bastille${epair_num}"
             fi
 
             local _new_if_prefix="$(echo ${_new_host_epair} | awk -F'_' '{print $1}')"
@@ -375,16 +375,8 @@ update_jailconf_vnet() {
 
             local _ngif_num="$(echo "${_old_if_prefix}" | grep -Eo "[0-9]+")"
             local _old_ngif="${_if}"
-
-            if [ "$(echo -n "ng${_ngif_num}_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
-                # Generate new netgraph interface name
-                local _new_ngif="ng${_ngif_num}_${NEWNAME}"
-            else
-	        name_prefix="$(echo ${NEWNAME} | cut -c1-7)"
-	        name_suffix="$(echo ${NEWNAME} | rev | cut -c1-2 | rev)"
-    	        local _new_ngif="ng${_ngif_num}_${name_prefix}xx${name_suffix}"
-            fi
-
+            # Generate new netgraph interface name
+            local _new_ngif="ng${_ngif_num}_${NEWNAME}"
             local _new_if_prefix="$(echo ${_if} | awk -F'_' '{print $1}')"
             local _new_if_suffix="$(echo ${_if} | awk -F'_' '{print $2}')"
 

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -124,7 +124,7 @@ check_target_is_stopped() {
 get_bastille_epair_count() {
     for _config in /usr/local/etc/bastille/*.conf; do
         local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
-        BASTILLE_EPAIR_LIST="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_epair_list}")"
+        BASTILLE_EPAIR_LIST="$(printf '%s\n%s' "$( (grep -Ehos "bastille[0-9]+" ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "e[0-9]+a_bastille[0-9]+$" | grep -Eos 'bastille[0-9]+') | sort -u)" "${_epair_list}")"
     done
     BASTILLE_EPAIR_COUNT=$(printf '%s' "${BASTILLE_EPAIR_LIST}" | sort -u | wc -l | awk '{print $1}')
     export BASTILLE_EPAIR_LIST

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -545,10 +545,13 @@ update_jail_syntax_v1() {
             local new_host_epair=e0a_${jail}
             local new_jail_epair=e0b_${jail}
         else
-        name_prefix="$(echo ${jail} | cut -c1-7)"
-        name_suffix="$(echo ${jail} | rev | cut -c1-2 | rev)"
-        local new_host_epair="e0a_${name_prefix}xx${name_suffix}"
-            local new_jail_epair="e0b_${name_prefix}xx${name_suffix}"
+            get_bastille_epair_count
+            local epair_num=1
+            while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
+                epair_num=$((epair_num + 1))
+            done
+            local new_host_epair="e0a_bastille${epair_num}"
+            local new_jail_epair="e0b_bastille${epair_num}"
         fi
 
         # Delete unneeded lines
@@ -581,11 +584,14 @@ update_jail_syntax_v1() {
             local new_jail_epair=e0b_${jail}
             local jib_epair="${jail}"
         else
-        name_prefix="$(echo ${jail} | cut -c1-7)"
-        name_suffix="$(echo ${jail} | rev | cut -c1-2 | rev)"
-        local new_host_epair="e0a_${name_prefix}xx${name_suffix}"
-            local new_jail_epair="e0b_${name_prefix}xx${name_suffix}"
-            local jib_epair="${name_prefix}xx${name_suffix}"
+            get_bastille_epair_count
+            local epair_num=1
+            while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
+                epair_num=$((epair_num + 1))
+            done
+            local new_host_epair="e0a_bastille${epair_num}"
+            local new_jail_epair="e0b_bastille${epair_num}"
+            local jib_epair="bastille${epair_num}"
         fi
 
         # Change jail.conf

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -392,7 +392,7 @@ generate_vnet_jail_netblock() {
                 done
                 local host_epair="e0a_bastille${epair_num}"
                 local jail_epair="e0b_bastille${epair_num}"
-                local jib_epai="bastille${epair_num}"
+                local jib_epair="bastille${epair_num}"
             fi
         elif [ "${interface_type}" = "passthrough" ]; then
             host_epair="${external_interface}"

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -121,6 +121,16 @@ check_target_is_stopped() {
     fi
 }
 
+get_bastille_epair_count() {
+    for _config in /usr/local/etc/bastille/*.conf; do
+        local bastille_jailsdir="$(sysrc -f "${_config}" -n bastille_jailsdir)"
+        BASTILLE_EPAIR_LIST="$(printf '%s\n%s' "$( (grep -Ehos '(epair[0-9]+|bastille[0-9]+)' ${bastille_jailsdir}/*/jail.conf; ifconfig -g epair | grep -Eos "_bastille[0-9]+$"; ifconfig -g epair | grep -vs 'bastille' | grep -Eos 'e[0-9]+a_') | grep -Eos '[0-9]+')" "${_epair_list}")"
+    done
+    BASTILLE_EPAIR_COUNT=$(printf '%s' "${BASTILLE_EPAIR_LIST}" | sort -u | wc -l | awk '{print $1}')
+    export BASTILLE_EPAIR_LIST
+    export BASTILLE_EPAIR_COUNT
+}
+
 get_jail_name() {
     local _JID="${1}"
     local _jailname="$(jls -j ${_JID} name 2>/dev/null)"
@@ -361,10 +371,13 @@ generate_vnet_jail_netblock() {
                 local host_epair=e0a_${jail_name}
                 local jail_epair=e0b_${jail_name}
             else
-                name_prefix="$(echo ${jail_name} | cut -c1-7)"
-                name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
-                local host_epair="e0a_${name_prefix}xx${name_suffix}"
-                local jail_epair="e0b_${name_prefix}xx${name_suffix}"
+                get_bastille_epair_count
+                local epair_num=1
+                while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
+                    epair_num=$((epair_num + 1))
+                done
+                local host_epair="e0a_bastille${epair_num}"
+                local jail_epair="e0b_bastille${epair_num}"
             fi
         elif [ "${interface_type}" = "standard" ]; then
             if [ "$(echo -n "e0a_${jail_name}" | awk '{print length}')" -lt 16 ]; then
@@ -372,26 +385,21 @@ generate_vnet_jail_netblock() {
                 local jail_epair=e0b_${jail_name}
                 local jib_epair=${jail_name}
             else
-                name_prefix="$(echo ${jail_name} | cut -c1-7)"
-                name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
-                local host_epair="e0a_${name_prefix}xx${name_suffix}"
-                local jail_epair="e0b_${name_prefix}xx${name_suffix}"
-                local jib_epair="${name_prefix}xx${name_suffix}"
+                get_bastille_epair_count
+                local epair_num=1
+                while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
+                    epair_num=$((epair_num + 1))
+                done
+                local host_epair="e0a_bastille${epair_num}"
+                local jail_epair="e0b_bastille${epair_num}"
             fi
         elif [ "${interface_type}" = "passthrough" ]; then
             host_epair="${external_interface}"
             jail_epair="${external_interface}"
         fi
     elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-        if [ "$(echo -n "ng0_${jail_name}" | awk '{print length}')" -lt 16 ]; then
-            local ng_if=ng0_${jail_name}
-            local jng_if=${jail_name}
-        else
-            name_prefix="$(echo ${jail_name} | cut -c1-7)"
-            name_suffix="$(echo ${jail_name} | rev | cut -c1-2 | rev)"
-            local ng_if="ng0_${name_prefix}xx${name_suffix}"
-            local jng_if="${name_prefix}xx${name_suffix}"
-        fi
+        local ng_if=ng0_${jail_name}
+        local jng_if=${jail_name}
     fi
 
     # VNET_JAIL_BRIDGE

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -392,6 +392,7 @@ generate_vnet_jail_netblock() {
                 done
                 local host_epair="e0a_bastille${epair_num}"
                 local jail_epair="e0b_bastille${epair_num}"
+                local jib_epai="bastille${epair_num}"
             fi
         elif [ "${interface_type}" = "passthrough" ]; then
             host_epair="${external_interface}"

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -1173,5 +1173,3 @@ if check_target_exists "${NAME}"; then
 fi
 
 create_jail "${NAME}" "${RELEASE}" "${IP}" "${INTERFACE}"
-
-echo

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -76,12 +76,6 @@ validate_name() {
         error_exit "[ERROR]: Jail names may not contain special characters!"
     elif echo "${NAME_VERIFY}" | grep -qE '^[0-9]+$'; then
         error_exit "[ERROR]: Jail names may not contain only digits."
-    elif { [ "${VNET_JAIL_BRIDGE}" -eq 1 ] || [ "${VNET_JAIL_STANDARD}" -eq 1 ]; } && [ "$(echo -n "e0a_${NAME_VERIFY}" | awk '{print length}')" -ge 16 ]; then
-        name_prefix="$(echo ${NAME_VERIFY} | cut -c1-7)"
-        name_suffix="$(echo ${NAME_VERIFY} | rev | cut -c1-2 | rev)"
-        if find "${bastille_jailsdir}"/*/jail.conf -maxdepth 1 -type f -print0 2> /dev/null | xargs -r0 -P0 grep -h -oqs "e0b_${name_prefix}xx${name_suffix}" 2>/dev/null; then
-            error_exit "[ERROR]: The jail name causes a collision with the epair interface naming. See documentation for details."
-        fi
     fi
 }
 

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -34,7 +34,7 @@
 . /usr/local/etc/bastille/bastille.conf
 
 usage() {
-    error_notify "Usage: bastille network [option(s)] TARGET [remove|add] INTERFACE [IP]"
+    error_notify "Usage: bastille network [option(s)] TARGET remove|add INTERFACE [IP]"
     cat << EOF
 
     Options:
@@ -126,6 +126,8 @@ done
 TARGET="${1}"
 ACTION="${2}"
 INTERFACE="${3}"
+
+# Validate options
 if [ "${ACTION}" = "add" ] && [ "${NO_IP}" -eq 0 ] && [ -n "${4}" ]; then
     IP="${4}"
 elif [ "${NO_IP}" -eq 1 ] && [ -n "${4}" ]; then
@@ -204,29 +206,29 @@ validate_ip() {
 
 validate_netif() {
 
-    local _interface="${1}"
+    local interface="${1}"
 
-    if ifconfig -l | grep -qwo ${_interface}; then
-        info "\nValid: (${_interface})."
+    if ifconfig -l | grep -qwo ${interface}; then
+        info "\nValid: (${interface})."
     else
-        error_exit "Invalid: (${_interface})."
+        error_exit "Invalid: (${interface})."
     fi
 
-	# Don't allow dots in INTERFACE if -V
+    # Don't allow dots in INTERFACE if -V
     if [ "${VNET}" -eq 1 ] && [ "${BRIDGE}" -eq 0 ]; then
         if echo "${INTERFACE}" | grep -q "\."; then
-	        error_exit "[ERROR]: [-V|--vnet] does not support dots (.) in interface names."
+            error_exit "[ERROR]: [-V|--vnet] does not support dots (.) in interface names."
         fi
     fi
 }
 
 check_interface_added() {
 
-    local _jailname="${1}"
-    local _if="${2}"
-    local _jail_config="${bastille_jailsdir}/${_jailname}/jail.conf"
+    local jailname="${1}"
+    local if="${2}"
+    local jail_config="${bastille_jailsdir}/${jailname}/jail.conf"
 
-    if grep -qo "${_if}" "${_jail_config}"; then
+    if grep -qo "${if}" "${jail_config}"; then
         return 0
     else
         return 1
@@ -235,399 +237,392 @@ check_interface_added() {
 
 add_interface() {
 
-    local _jailname="${1}"
-    local _if="${2}"
-    local _ip="${3}"
-    local _jail_config="${bastille_jailsdir}/${_jailname}/jail.conf"
-    local _jail_rc_config="${bastille_jailsdir}/${_jailname}/root/etc/rc.conf"
-    local _jail_vnet_count="$(grep -Eo 'vnet[1-9]+' ${_jail_rc_config} | sort -u | wc -l)"
-    local _jail_vnet="vnet$((_jail_vnet_count + 1))"
+    local jailname="${1}"
+    local if="${2}"
+    local ip="${3}"
+    local jail_config="${bastille_jailsdir}/${jailname}/jail.conf"
+    local jail_rc_config="${bastille_jailsdir}/${jailname}/root/etc/rc.conf"
+    local jail_vnet_count="$(grep -Eo 'vnet[1-9]+' ${jail_rc_config} | sort -u | wc -l)"
+    local jail_vnet="vnet$((jail_vnet_count + 1))"
 
     # Determine number of interfaces
     if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
-        local _if_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${_jail_config} | sort -u)"
-        local _epair_count="$(echo "${_if_list}" | grep -Eo "[0-9]+" | wc -l)"
-        local _epair_num_range=$((_epair_count + 1))
+        local epair_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${jail_config} | sort -u)"
+        local epair_suffix="$(grep -m 1 -Eo 'e[0-9]+a_[^;" ]+' ${jail_config} | awk -F"_" '{print $2}')"
     elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-        local _if_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${_jail_config} | sort -u)"
-        local _ngif_count="$(echo "${_if_list}" | grep -Eo "[0-9]+" | wc -l)"
-        local _ngif_num_range=$((_ngif_count + 1))
+        local ng_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${jail_config} | sort -u)"
+        local ng_suffix="$(grep -m 1 -Eo 'ng[0-9]+_[^;" ]+' ${jail_config} | awk -F"_" '{print $2}')"
     fi
 
+    # BRIDGE interface
     if [ "${BRIDGE}" -eq 1 ]; then
-        for _epair_num in $(seq 0 ${_epair_num_range}); do
-            if ! grep -Eoqs "e${_epair_num}a_" "${_jail_config}"; then
-                if [ "$(echo -n "e${_epair_num}a_${_jailname}" | awk '{print length}')" -lt 16 ]; then
-                    local host_epair=e${_epair_num}a_${_jailname}
-                    local jail_epair=e${_epair_num}b_${_jailname}
-                else
-                    get_bastille_epair_count
-                    local global_epair_num=1
-                    while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${global_epair_num}"; do
-                        global_epair_num=$((global_epair_num + 1))
-                    done
-                    local host_epair="e0a_bastille${global_epair_num}"
-                    local jail_epair="e0b_bastille${global_epair_num}"
-                fi
-                # Remove ending brace (it is added again with the netblock)
-                sed -i '' '/^}$/d' "${_jail_config}"
-                if [ "${STATIC_MAC}" -eq 1 ]; then
-                    # Generate NETBLOCK with static MAC
-                    generate_static_mac "${_jailname}" "${_if}"
-                    cat << EOF >> "${_jail_config}"
-  ## ${host_epair} interface
-  vnet.interface += ${jail_epair};
-  exec.prestart += "epair${_epair_num}=\\\$(ifconfig epair create) && ifconfig \\\${epair${_epair_num}} up name ${host_epair} && ifconfig \\\${epair${_epair_num}%a}b up name ${jail_epair}";
-  exec.prestart += "ifconfig ${_if} addm ${host_epair}";
-  exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
-  exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
-  exec.prestart += "ifconfig ${host_epair} description \"${_jail_vnet} host interface for Bastille jail ${_jailname}\"";
-  exec.poststop += "ifconfig ${host_epair} destroy";
-}
-EOF
-                else
-                    # Generate NETBLOCK without static MAC
-                    cat << EOF >> "${_jail_config}"
-  ## ${host_epair} interface
-  vnet.interface += ${jail_epair};
-  exec.prestart += "epair${_epair_num}=\\\$(ifconfig epair create) && ifconfig \\\${epair${_epair_num}} up name ${host_epair} && ifconfig \\\${epair${_epair_num}%a}b up name ${jail_epair}";
-  exec.prestart += "ifconfig ${_if} addm ${host_epair}";
-  exec.prestart += "ifconfig ${host_epair} description \"${_jail_vnet} host interface for Bastille jail ${_jailname}\"";
-  exec.poststop += "ifconfig ${host_epair} destroy";
-}
-EOF
-                fi
 
-                # Add config to /etc/rc.conf
-                sysrc -f "${_jail_rc_config}" ifconfig_${jail_epair}_name="${_jail_vnet}"
-	        if [ -n "${IP6_ADDR}" ]; then
-                    if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                        sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
-                    else
-                        sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
-                    fi
-                elif [ -n "${IP4_ADDR}" ]; then
-                    # If 0.0.0.0 set DHCP, else set static IP address
-                    if [ "${_ip}" = "0.0.0.0" ] || [ "${_ip}" = "DHCP" ] || [ "${_ip}" = "SYNCDHCP" ]; then
-                        sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="SYNCDHCP"
-                    else
-                        sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="inet ${IP4_ADDR}"
-                    fi
-                fi
-                break
-            fi
+        local epair_num=1
+        while echo "${epair_list}" | grep -Eosq "e${epair_num}a_"; do
+            epair_num=$((epair_num + 1))
         done
+        local host_epair=e${epair_num}a_${epair_suffix}
+        local jail_epair=e${epair_num}b_${epair_suffix}
 
-        echo "Added bridge interface: \"${_if}\""
-
-    elif [ "${VNET}" -eq 1 ]; then
-        if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
-            for _epair_num in $(seq 0 ${_epair_num_range}); do
-                if ! grep -Eoqs "e${_epair_num}a_" "${_jail_config}"; then
-                    if [ "$(echo -n "e${_epair_num}a_${_jailname}" | awk '{print length}')" -lt 16 ]; then
-                        local host_epair=e${_epair_num}a_${_jailname}
-                        local jail_epair=e${_epair_num}b_${_jailname}
-                        local jib_epair=${_jailname}
-                    else
-                        get_bastille_epair_count
-                        local global_epair_num=1
-                        while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${global_epair_num}"; do
-                            global_epair_num=$((global_epair_num + 1))
-                        done
-                        local host_epair="e0a_bastille${global_epair_num}"
-                        local jail_epair="e0b_bastille${global_epair_num}"
-                        local jib_epair="bastille${global_epair_num}"
-                    fi
-                    # Remove ending brace (it is added again with the netblock)
-                    sed -i '' '/^}$/d' "${_jail_config}"
-                    if [ "${STATIC_MAC}" -eq 1 ]; then
-                        # Generate NETBLOCK with static MAC
-                        generate_static_mac "${_jailname}" "${_if}"
-                        cat << EOF >> "${_jail_config}"
+        # Remove ending brace (it is added again with the netblock)
+        sed -i '' '/^}$/d' "${jail_config}"
+ 
+         # Generate NETBLOCK with static MAC
+        if [ "${STATIC_MAC}" -eq 1 ]; then
+            generate_static_mac "${jailname}" "${if}"
+            cat << EOF >> "${jail_config}"
   ## ${host_epair} interface
   vnet.interface += ${jail_epair};
-  exec.prestart += "jib addm ${jib_epair} ${_if}";
+  exec.prestart += "epair${epair_num}=\\\$(ifconfig epair create) && ifconfig \\\${epair${epair_num}} up name ${host_epair} && ifconfig \\\${epair${epair_num}%a}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${if} addm ${host_epair}";
   exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
   exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
-  exec.prestart += "ifconfig ${host_epair} description \"${_jail_vnet} host interface for Bastille jail ${_jailname}\"";
+  exec.prestart += "ifconfig ${host_epair} description \"${jail_vnet} host interface for Bastille jail ${jailname}\"";
   exec.poststop += "ifconfig ${host_epair} destroy";
 }
 EOF
-                    else
-                        # Generate NETBLOCK without static MAC
-                        cat << EOF >> "${_jail_config}"
+        else
+            # Generate NETBLOCK without static MAC
+            cat << EOF >> "${jail_config}"
   ## ${host_epair} interface
   vnet.interface += ${jail_epair};
-  exec.prestart += "jib addm ${jib_epair} ${_if}";
-  exec.prestart += "ifconfig ${host_epair} description \"${_jail_vnet} host interface for Bastille jail ${_jailname}\"";
+  exec.prestart += "epair${epair_num}=\\\$(ifconfig epair create) && ifconfig \\\${epair${epair_num}} up name ${host_epair} && ifconfig \\\${epair${epair_num}%a}b up name ${jail_epair}";
+  exec.prestart += "ifconfig ${if} addm ${host_epair}";
+  exec.prestart += "ifconfig ${host_epair} description \"${jail_vnet} host interface for Bastille jail ${jailname}\"";
   exec.poststop += "ifconfig ${host_epair} destroy";
 }
 EOF
-                    fi
-                    # Add config to /etc/rc.conf
-                    sysrc -f "${_jail_rc_config}" ifconfig_${jail_epair}_name="${_jail_vnet}"
-	            if [ -n "${IP6_ADDR}" ]; then
-                        if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
-                        else
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
-                        fi
-                    elif [ -n "${IP4_ADDR}" ]; then
-                        # If 0.0.0.0 set DHCP, else set static IP address
-                        if [ "${_ip}" = "0.0.0.0" ] || [ "${_ip}" = "DHCP" ] || [ "${_ip}" = "SYNCDHCP" ]; then
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="SYNCDHCP"
-                        else
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="inet ${IP4_ADDR}"
-                        fi
-                    fi
-                    break
-                fi
-            done
-
-            echo "Added VNET interface: \"${_if}\""
-
-        elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-            for _ngif_num in $(seq 0 ${_ngif_num_range}); do
-                if ! grep -Eoqs "e${_ngif_num}a_" "${_jail_config}"; then
-                    if [ "$(echo -n "ng${_ngif_num}_${_jailname}" | awk '{print length}')" -lt 16 ]; then
-                        # Generate new netgraph interface name
-                        local _ngif="ng${_ngif_num}_${_jailname}"
-                        local jng_if="${_jailname}"
-                    fi
-                    # Remove ending brace (it is added again with the netblock)
-                    sed -i '' '/^}$/d' "${_jail_config}"
-                    if [ "${STATIC_MAC}" -eq 1 ]; then
-                        # Generate NETBLOCK with static MAC
-                        generate_static_mac "${_jailname}" "${_if}"
-                        cat << EOF >> "${_jail_config}"
-  ## ${_ngif} interface
-  vnet.interface += ${_ngif};
-  exec.prestart += "jng bridge ${jng_if} ${_if}";
-  exec.prestart += "ifconfig ${_ngif} ether ${macaddr}b";
-  exec.poststop += "jng shutdown ${jng_if}";
-}
-EOF
-                    else
-                        # Generate NETBLOCK without static MAC
-                        cat << EOF >> "${_jail_config}"
-  ## ${_ngif} interface
-  vnet.interface += ${_ngif};
-  exec.prestart += "jng bridge ${jng_if} ${_if}";
-  exec.poststop += "jng shutdown ${jng_if}";
-}
-EOF
-                    fi
-                    # Add config to /etc/rc.conf
-                    sysrc -f "${_jail_rc_config}" ifconfig_${_ngif}_name="${_jail_vnet}"
-	           if [ -n "${_ip}" ]; then
-                        # If 0.0.0.0 set DHCP, else set static IP address
-                        if [ "${_ip}" = "0.0.0.0" ] || [ "${_ip}" = "DHCP" ]; then
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="SYNCDHCP"
-                        else
-                            sysrc -f "${_jail_rc_config}" ifconfig_${_jail_vnet}="inet ${_ip}"
-                        fi
-	           fi
-	           break
-	       fi
-	   done
-            echo "Added VNET interface: \"${_if}\""
         fi
 
-    elif [ "${PASSTHROUGH}" -eq 1 ]; then
-        # Remove ending brace (it is added again with the netblock)
-        sed -i '' '/^}$/d' "${_jail_config}"
-        # Generate NETBLOCK (static MAC not used on passthrough)
-        cat << EOF >> "${_jail_config}"
-  ## ${_if} interface
-  vnet.interface += ${_if};
-  exec.prestop += "ifconfig ${_if} -vnet ${_jailname}";
-}
-EOF
         # Add config to /etc/rc.conf
-	    if [ -n "${IP6_ADDR}" ]; then
+        sysrc -f "${jail_rc_config}" ifconfig_${jail_epair}_name="${jail_vnet}"
+	if [ -n "${IP6_ADDR}" ]; then
             if [ "${IP6_ADDR}" = "SLAAC" ]; then
-                sysrc -f "${_jail_rc_config}" ifconfig_${_if}_ipv6="inet6 -ifdisabled accept_rtadv"
+                sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
             else
-                sysrc -f "${_jail_rc_config}" ifconfig_${_if}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
+                sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
             fi
         elif [ -n "${IP4_ADDR}" ]; then
             # If 0.0.0.0 set DHCP, else set static IP address
-            if [ "${_ip}" = "0.0.0.0" ] || [ "${_ip}" = "DHCP" ] || [ "${_ip}" = "SYNCDHCP" ]; then
-                sysrc -f "${_jail_rc_config}" ifconfig_${_if}="SYNCDHCP"
+            if [ "${ip}" = "0.0.0.0" ] || [ "${ip}" = "DHCP" ] || [ "${ip}" = "SYNCDHCP" ]; then
+                sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="SYNCDHCP"
             else
-                sysrc -f "${_jail_rc_config}" ifconfig_${_if}="inet ${IP4_ADDR}"
+                sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="inet ${IP4_ADDR}"
             fi
         fi
-        echo "Added Passthrough interface: \"${_if}\""
+        echo "Added bridge interface: \"${if}\""
+
+    # VNET interface
+    elif [ "${VNET}" -eq 1 ]; then
+
+        # if_bridge
+        if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
+
+            local epair_num=1
+            while echo "${epair_list}" | grep -Eosq "e${epair_num}a_"; do
+                epair_num=$((epair_num + 1))
+            done
+            local host_epair=e${epair_num}a_${epair_suffix}
+            local jail_epair=e${epair_num}b_${epair_suffix}
+            local jib_epair=${epair_suffix}
+
+            # Remove ending brace (it is added again with the netblock)
+            sed -i '' '/^}$/d' "${jail_config}"
+
+            if [ "${STATIC_MAC}" -eq 1 ]; then
+                # Generate NETBLOCK with static MAC
+                generate_static_mac "${jailname}" "${if}"
+                cat << EOF >> "${jail_config}"
+  ## ${host_epair} interface
+  vnet.interface += ${jail_epair};
+  exec.prestart += "jib addm ${jib_epair} ${if}";
+  exec.prestart += "ifconfig ${host_epair} ether ${macaddr}a";
+  exec.prestart += "ifconfig ${jail_epair} ether ${macaddr}b";
+  exec.prestart += "ifconfig ${host_epair} description \"${jail_vnet} host interface for Bastille jail ${jailname}\"";
+  exec.poststop += "ifconfig ${host_epair} destroy";
+}
+EOF
+            else
+                # Generate NETBLOCK without static MAC
+                cat << EOF >> "${jail_config}"
+  ## ${host_epair} interface
+  vnet.interface += ${jail_epair};
+  exec.prestart += "jib addm ${jib_epair} ${if}";
+  exec.prestart += "ifconfig ${host_epair} description \"${jail_vnet} host interface for Bastille jail ${jailname}\"";
+  exec.poststop += "ifconfig ${host_epair} destroy";
+}
+EOF
+            fi
+
+            # Add config to /etc/rc.conf
+            sysrc -f "${jail_rc_config}" ifconfig_${jail_epair}_name="${jail_vnet}"
+
+	    if [ -n "${IP6_ADDR}" ]; then
+                if [ "${IP6_ADDR}" = "SLAAC" ]; then
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled accept_rtadv"
+                else
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
+                fi
+            elif [ -n "${IP4_ADDR}" ]; then
+                # If 0.0.0.0 set DHCP, else set static IP address
+                if [ "${ip}" = "0.0.0.0" ] || [ "${ip}" = "DHCP" ] || [ "${ip}" = "SYNCDHCP" ]; then
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="SYNCDHCP"
+                else
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="inet ${IP4_ADDR}"
+                fi
+            fi
+            echo "Added VNET interface: \"${if}\""
+
+        # netgraph
+        elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
+
+            local ng_num=1
+            while echo "${ng_list}" | grep -Eosq "ng${ng_num}_"; do
+                ng_num=$((ng_num + 1))
+            done
+            local ng_if=ng${ng_num}_${ng_suffix}
+            local jng_if=${ng_suffix}
+
+            # Remove ending brace (it is added again with the netblock)
+            sed -i '' '/^}$/d' "${jail_config}"
+
+            if [ "${STATIC_MAC}" -eq 1 ]; then
+                # Generate NETBLOCK with static MAC
+                generate_static_mac "${jailname}" "${if}"
+                cat << EOF >> "${jail_config}"
+  ## ${ng_if} interface
+  vnet.interface += ${ng_if};
+  exec.prestart += "jng bridge ${jng_if} ${if}";
+  exec.prestart += "ifconfig ${ng_if} ether ${macaddr}b";
+  exec.poststop += "jng shutdown ${jng_if}";
+}
+EOF
+            else
+                # Generate NETBLOCK without static MAC
+                cat << EOF >> "${jail_config}"
+  ## ${ng_if} interface
+  vnet.interface += ${ng_if};
+  exec.prestart += "jng bridge ${jng_if} ${if}";
+  exec.poststop += "jng shutdown ${jng_if}";
+}
+EOF
+            fi
+
+            # Add config to /etc/rc.conf
+            sysrc -f "${jail_rc_config}" ifconfig_${ng_if}_name="${jail_vnet}"
+
+            if [ -n "${ip}" ]; then
+                # If 0.0.0.0 set DHCP, else set static IP address
+                if [ "${ip}" = "0.0.0.0" ] || [ "${ip}" = "DHCP" ]; then
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="SYNCDHCP"
+                else
+                    sysrc -f "${jail_rc_config}" ifconfig_${jail_vnet}="inet ${ip}"
+                fi
+            fi
+            echo "Added VNET interface: \"${if}\""
+
+        fi
+
+    # PASSTHROUGH
+    elif [ "${PASSTHROUGH}" -eq 1 ]; then
+
+        # Remove ending brace (it is added again with the netblock)
+        sed -i '' '/^}$/d' "${jail_config}"
+
+        # Generate NETBLOCK (static MAC not used on passthrough)
+        cat << EOF >> "${jail_config}"
+  ## ${if} interface
+  vnet.interface += ${if};
+  exec.prestop += "ifconfig ${if} -vnet ${jailname}";
+}
+EOF
+        # Add config to /etc/rc.conf
+	if [ -n "${IP6_ADDR}" ]; then
+            if [ "${IP6_ADDR}" = "SLAAC" ]; then
+                sysrc -f "${jail_rc_config}" ifconfig_${if}_ipv6="inet6 -ifdisabled accept_rtadv"
+            else
+                sysrc -f "${jail_rc_config}" ifconfig_${if}_ipv6="inet6 -ifdisabled ${IP6_ADDR}"
+            fi
+        elif [ -n "${IP4_ADDR}" ]; then
+            # If 0.0.0.0 set DHCP, else set static IP address
+            if [ "${ip}" = "0.0.0.0" ] || [ "${ip}" = "DHCP" ] || [ "${ip}" = "SYNCDHCP" ]; then
+                sysrc -f "${jail_rc_config}" ifconfig_${if}="SYNCDHCP"
+            else
+                sysrc -f "${jail_rc_config}" ifconfig_${if}="inet ${IP4_ADDR}"
+            fi
+        fi
+        echo "Added Passthrough interface: \"${if}\""
 
     elif [ "${STANDARD}" -eq 1 ]; then
         if [ -n "${IP6_ADDR}" ]; then
-            sed -i '' "s/interface = .*/&\n  ip6.addr += ${_if}|${_ip};/" ${_jail_config}
+            sed -i '' "s/interface = .*/&\n  ip6.addr += ${if}|${ip};/" ${jail_config}
         else
-            sed -i '' "s/interface = .*/&\n  ip4.addr += ${_if}|${_ip};/" ${_jail_config}
+            sed -i '' "s/interface = .*/&\n  ip4.addr += ${if}|${ip};/" ${jail_config}
         fi
     fi
 }
 
 remove_interface() {
 
-    local _jailname="${1}"
-    local _if="${2}"
-    local _jail_config="${bastille_jailsdir}/${_jailname}/jail.conf"
-    local _jail_rc_config="${bastille_jailsdir}/${_jailname}/root/etc/rc.conf"
+    local jailname="${1}"
+    local if="${2}"
+    local jail_config="${bastille_jailsdir}/${jailname}/jail.conf"
+    local jail_rc_config="${bastille_jailsdir}/${jailname}/root/etc/rc.conf"
 
     # Skip next block in case of standard jail
     if [ "$(bastille config ${TARGET} get vnet)" != "not set" ]; then
 
-        if grep -q "vnet.interface.*${_if};" ${_jail_config}; then
+        if grep -q "vnet.interface.*${if};" ${jail_config}; then
 
-            local _if_jail="${_if}"
-            local _if_type="passthrough"
+            local if_jail="${if}"
+            local if_type="passthrough"
 
         elif [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
 
-            local _jib_epair="$(grep "jib addm.*${_if}" ${_jail_config} | awk '{print $3}')"
-            local _if_type="if_bridge"
+            local jib_epair="$(grep "jib addm.*${if}" ${jail_config} | awk '{print $3}')"
+            local if_type="if_bridge"
 
-            if [ -n "${_jib_epair}" ]; then
-                local _epaira="$(grep -m 1 -A 1 "${_if}" ${_jail_config} | grep -Eo "e[0-9]+a_${_jib_epair}")"
-                local _epairb="$(echo ${_epaira} | sed 's/a_/b_/')"
-                local _if_jail="${_epairb}"
+            if [ -n "${jib_epair}" ]; then
+                local epaira="$(grep -m 1 -A 1 "${if}" ${jail_config} | grep -Eo "e[0-9]+a_${jib_epair}")"
+                local epairb="$(echo ${epaira} | sed 's/a_/b_/')"
+                local if_jail="${epairb}"
             else
-                local _epaira="$(grep -m 1 "${_if}" ${_jail_config} | grep -Eo 'e[0-9]+a_[^;" ]+')"
-                local _epairb="$(echo ${_epaira} | sed 's/a_/b_/')"
-                local _if_jail="${_epairb}"
+                local epaira="$(grep -m 1 "${if}" ${jail_config} | grep -Eo 'e[0-9]+a_[^;" ]+')"
+                local epairb="$(echo ${epaira} | sed 's/a_/b_/')"
+                local if_jail="${epairb}"
             fi
 
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
 
-            local _jng_if="$(grep "jng bridge.*${_if}" ${_jail_config} | awk '{print $3}')"
-            local _if_jail="$(grep "ng[0-9]+_${_jng_if}" ${_jail_config})"
-            local _if_type="netgraph"
+            local jng_if="$(grep "jng bridge.*${if}" ${jail_config} | awk '{print $3}')"
+            local if_jail="$(grep "ng[0-9]+_${jng_if}" ${jail_config})"
+            local if_type="netgraph"
 
         else
-            error_exit "[ERROR]: Could not find interface inside jail: \"${_if_jail}\""
+            error_exit "[ERROR]: Could not find interface inside jail: \"${if_jail}\""
         fi
 
         # Get vnetX value from rc.conf
-        if [ "${_if_type}" = "if_bridge" ]; then
-            if grep -oq "${_if_jail}" ${_jail_config}; then
-                local _if_vnet="$(grep "${_if_jail}" ${_jail_rc_config} | grep -Eo 'vnet[0-9]+')"
+        if [ "${if_type}" = "if_bridge" ]; then
+            if grep -oq "${if_jail}" ${jail_config}; then
+                local if_vnet="$(grep "${if_jail}" ${jail_rc_config} | grep -Eo 'vnet[0-9]+')"
             else
-                error_exit "[ERROR]: Interface not found: ${_if_jail}"
+                error_exit "[ERROR]: Interface not found: ${if_jail}"
             fi
-        elif [ "${_if_type}" = "netgraph" ]; then
-            if grep -oq "${_if_jail}" ${_jail_config}; then
-                local _if_vnet="${_if_jail}"
+        elif [ "${if_type}" = "netgraph" ]; then
+            if grep -oq "${if_jail}" ${jail_config}; then
+                local if_vnet="${if_jail}"
             else
-                error_exit "[ERROR]: Interface not found: ${_if_jail}"
+                error_exit "[ERROR]: Interface not found: ${if_jail}"
             fi
-        elif [ "${_if_type}" = "passthrough" ]; then
-            if grep -oq "${_if_jail}" ${_jail_config}; then
-                local _if_vnet="${_if_jail}"
+        elif [ "${if_type}" = "passthrough" ]; then
+            if grep -oq "${if_jail}" ${jail_config}; then
+                local if_vnet="${if_jail}"
             else
-                error_exit "[ERROR]: Interface not found: ${_if_jail}"
+                error_exit "[ERROR]: Interface not found: ${if_jail}"
             fi
         fi
 
         # Do not allow removing default vnet0 interface
-        if [ "${_if_vnet}" = "vnet0" ]; then
+        if [ "${if_vnet}" = "vnet0" ]; then
             error_exit "[ERROR]: Default interface cannot be removed."
         fi
 
         # Avoid removing entire file contents if variables aren't set for some reason
-        if [ -z "${_if_jail}" ]; then
+        if [ -z "${if_jail}" ]; then
             error_exit "[ERROR]: Could not find specifed interface."
         fi
 
         # Remove interface from /etc/rc.conf
-        if [ "${_if_type}" = "if_bridge" ]; then
-            if [ -n "${_if_vnet}" ] && echo ${_if_vnet} | grep -Eoq 'vnet[0-9]+'; then
-                sed -i '' "/.*${_if_vnet}.*/d" "${_jail_rc_config}"
+        if [ "${if_type}" = "if_bridge" ]; then
+            if [ -n "${if_vnet}" ] && echo ${if_vnet} | grep -Eoq 'vnet[0-9]+'; then
+                sed -i '' "/.*${if_vnet}.*/d" "${jail_rc_config}"
             else
                 error_exit "[ERROR]: Failed to remove interface from /etc/rc.conf"
             fi
-        elif [ "${_if_type}" = "netgraph" ]; then
-            if [ -n "${_if_vnet}" ] && echo ${_if_vnet} | grep -Eoq 'vnet[0-9]+'; then
-                sed -i '' "/.*${_if_vnet}.*/d" "${_jail_rc_config}"
+        elif [ "${if_type}" = "netgraph" ]; then
+            if [ -n "${if_vnet}" ] && echo ${if_vnet} | grep -Eoq 'vnet[0-9]+'; then
+                sed -i '' "/.*${if_vnet}.*/d" "${jail_rc_config}"
             else
                 error_exit "[ERROR]: Failed to remove interface from /etc/rc.conf"
             fi
-        elif [ "${_if_type}" = "passthrough" ]; then
-            if [ -n "${_if_vnet}" ]; then
-                sed -i '' "/.*${_if_vnet}.*/d" "${_jail_rc_config}"
+        elif [ "${if_type}" = "passthrough" ]; then
+            if [ -n "${if_vnet}" ]; then
+                sed -i '' "/.*${if_vnet}.*/d" "${jail_rc_config}"
             else
                 error_exit "[ERROR]: Failed to remove interface from /etc/rc.conf"
             fi
         fi
 
         # Remove VNET interface from jail.conf (VNET)
-        if [ -n "${_if_jail}" ]; then
-            if [ "${_if_type}" = "if_bridge" ]; then
-                sed -i '' "/.*${_epaira}.*/d" "${_jail_config}"
-                sed -i '' "/.*${_epairb}.*/d" "${_jail_config}"
-                sed -i '' "/.*${_if}.*/d" "${_jail_config}"
-            elif [ "${_if_type}" = "netgraph" ]; then
-                sed -i '' "/.*${_if_jail}.*/d" "${_jail_config}"
-                sed -i '' "/.*${_if}.*/d" "${_jail_config}"
-            elif [ "${_if_type}" = "passthrough" ]; then
-                sed -i '' "/.*${_if_jail}.*/d" "${_jail_config}"
+        if [ -n "${if_jail}" ]; then
+            if [ "${if_type}" = "if_bridge" ]; then
+                sed -i '' "/.*${epaira}.*/d" "${jail_config}"
+                sed -i '' "/.*${epairb}.*/d" "${jail_config}"
+                sed -i '' "/.*${if}.*/d" "${jail_config}"
+            elif [ "${if_type}" = "netgraph" ]; then
+                sed -i '' "/.*${if_jail}.*/d" "${jail_config}"
+                sed -i '' "/.*${if}.*/d" "${jail_config}"
+            elif [ "${if_type}" = "passthrough" ]; then
+                sed -i '' "/.*${if_jail}.*/d" "${jail_config}"
             fi
         else
             error_exit "[ERROR]: Failed to remove interface from jail.conf"
         fi
     else
         # Remove interface from jail.conf (non-VNET)
-        if [ -n "${_if}" ]; then
-            if grep ${_if} ${_jail_config} 2>/dev/null | grep -qo " = "; then
+        if [ -n "${if}" ]; then
+            if grep ${if} ${jail_config} 2>/dev/null | grep -qo " = "; then
                 error_exit "[ERROR]: Default interface cannot be removed."
             else
-                sed -i '' "/.*${_if}.*/d" "${_jail_config}"
+                sed -i '' "/.*${if}.*/d" "${jail_config}"
             fi
         else
             error_exit "[ERROR]: Failed to remove interface from jail.conf"
         fi
     fi
-
-    echo "Removed interface: \"${_if}\""
+    echo "Removed interface: \"${if}\""
 }
 
 add_vlan() {
 
-    local _jailname="${1}"
-    local _interface="${2}"
-    local _ip="${3}"
-    local _vlan_id="${4}"
-    local _jail_config="${bastille_jailsdir}/${_jailname}/jail.conf"
-    local _jail_rc_config="${bastille_jailsdir}/${_jailname}/root/etc/rc.conf"
+    local jailname="${1}"
+    local interface="${2}"
+    local ip="${3}"
+    local vlan_id="${4}"
+    local jail_config="${bastille_jailsdir}/${jailname}/jail.conf"
+    local jail_rc_config="${bastille_jailsdir}/${jailname}/root/etc/rc.conf"
 
     if [ "${VNET}" -eq 1 ]; then
-        local _jib_epair="$(grep "jib addm.*${_if}" ${_jail_config} | awk '{print $3}')"
-        local _jail_epair="$(grep "e[0-9]+b_${_jib_epair}" ${_jail_config})"
-	local _jail_vnet="$(grep "${_jail_epair}_name" ${_jail_rc_config} | grep -Eo "vnet[0-9]+")"
+        local jib_epair="$(grep "jib addm.*${if}" ${jail_config} | awk '{print $3}')"
+        local jail_epair="$(grep "e[0-9]+b_${jib_epair}" ${jail_config})"
+	local jail_vnet="$(grep "${jail_epair}_name" ${jail_rc_config} | grep -Eo "vnet[0-9]+")"
     elif [ "${BRIDGE}" -eq 1 ]; then
-        local _jail_epair="$(grep 'e[0-9]+b_[^;" ]+' ${_jail_config})"
-	local _jail_vnet="$(grep "${_jail_epair}_name" ${_jail_rc_config} | grep -Eo "vnet[0-9]+")"
+        local jail_epair="$(grep 'e[0-9]+b_[^;" ]+' ${jail_config})"
+	local jail_vnet="$(grep "${jail_epair}_name" ${jail_rc_config} | grep -Eo "vnet[0-9]+")"
     elif [ "${PASSTHROUGH}" -eq 1 ]; then
-        local _jail_vnet="${_interface}"
+        local _jail_vnet="${interface}"
     fi
-    if grep -Eq "ifconfig_${_jail_vnet}_${_vlan_id}" "${bastille_jailsdir}/${_jailname}/root/etc/rc.conf"; then
-        error_exit "[ERROR]: VLAN has already been added: VLAN ${_vlan_id}"
+    if grep -Eq "ifconfig_${jail_vnet}_${vlan_id}" "${bastille_jailsdir}/${jailname}/root/etc/rc.conf"; then
+        error_exit "[ERROR]: VLAN has already been added: VLAN ${vlan_id}"
     else
-        bastille start "${_jailname}"
-        bastille template "${_jailname}" ${bastille_template_vlan} --arg VLANID="${_vlan_id}" --arg IFCONFIG="inet ${_ip}" --arg JAIL_VNET="${_jail_vnet}"
-        bastille restart "${_jailname}"
+        bastille start "${jailname}"
+        bastille template "${jailname}" ${bastille_template_vlan} --arg VLANID="${vlan_id}" --arg IFCONFIG="inet ${ip}" --arg JAIL_VNET="${jail_vnet}"
+        bastille restart "${jailname}"
     fi
 
-    echo "Added VLAN ${_vlan_id} to interface: \"${_jail_vnet}\""
+    echo "Added VLAN ${vlan_id} to interface: \"${jail_vnet}\""
 }
 
 info "\n[${TARGET}]:"
 
 case "${ACTION}" in
+
     add)
+
         validate_netconf
         validate_netif "${INTERFACE}"
+
         if check_interface_added "${TARGET}" "${INTERFACE}" && [ -z "${VLAN_ID}" ]; then
             error_exit "Interface is already added: \"${INTERFACE}\""
         elif { [ "${VNET}" -eq 1 ] || [ "${BRIDGE}" -eq 1 ] || [ "${PASSTHROUGH}" -eq 1 ]; } && [ -n "${VLAN_ID}" ]; then
@@ -635,10 +630,12 @@ case "${ACTION}" in
             echo
             exit 0
         fi
+
         ## validate IP if not empty
         if [ -n "${IP}" ]; then
             validate_ip "${IP}"
         fi
+
         if [ "${VNET}" -eq 1 ]; then
             if [ "$(bastille config ${TARGET} get vnet)" = "not set" ]; then
                 error_exit "[ERROR]: ${TARGET} is not a VNET jail."
@@ -653,6 +650,7 @@ case "${ACTION}" in
                     bastille start "${TARGET}"
                 fi
             fi
+
         elif [ "${BRIDGE}" -eq 1 ]; then
             if [ "$(bastille config ${TARGET} get vnet)" = "not set" ]; then
                 error_exit "[ERROR]: ${TARGET} is not a VNET jail."
@@ -667,6 +665,7 @@ case "${ACTION}" in
                     bastille start "${TARGET}"
                 fi
             fi
+
         elif [ "${PASSTHROUGH}" -eq 1 ]; then
             if [ "$(bastille config ${TARGET} get vnet)" = "not set" ]; then
                 error_exit "[ERROR]: ${TARGET} is not a VNET jail."
@@ -679,6 +678,7 @@ case "${ACTION}" in
             if [ "${AUTO}" -eq 1 ]; then
                 bastille start "${TARGET}"
             fi
+
         elif [ "${STANDARD}" -eq 1 ]; then
             if [ "$(bastille config ${TARGET} get vnet)" != "not set" ]; then
                 error_exit "[ERROR]: ${TARGET} is a VNET jail."
@@ -690,7 +690,9 @@ case "${ACTION}" in
             fi
         fi
         ;;
+
     remove|delete)
+
         check_interface_added "${TARGET}" "${INTERFACE}" || error_exit "Interface not found in jail.conf: \"${INTERFACE}\""
         validate_netif "${INTERFACE}"
         if ! grep -q "${INTERFACE}" ${bastille_jailsdir}/${TARGET}/jail.conf; then

--- a/usr/local/share/bastille/network.sh
+++ b/usr/local/share/bastille/network.sh
@@ -167,7 +167,7 @@ set_target_single "${TARGET}"
 check_target_is_stopped "${TARGET}" || if [ "${AUTO}" -eq 1 ]; then
     bastille stop "${TARGET}"
 else
-    info "\n[${_jail}]:"
+    info "\n[${TARGET}]:"
     error_notify "Jail is running."
     error_exit "Use [-a|--auto] to auto-stop the jail."
 fi

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -38,11 +38,11 @@ usage() {
 
     Options:
 
-    -d | --destination [destination]          Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
-    -i | --interface   [interface]            Set the interface to create the rdr rule on. Useful if you have multiple interfaces.
-    -s | --source      [source]               Limit rdr to a source IP or table. Useful to only allow access from certain sources.
-    -t | --type        [ipv4|ipv6]            Specify IP type. Must be used if -s or -d are used. Defaults to both.
-    -x | --debug                              Enable debug mode.
+    -d | --destination IP            Limit rdr to a destination IP. Useful if you have multiple IPs on one interface.
+    -i | --interface   IF,IF         Specify interface(s) to apply rule to. Comman separated.
+    -s | --source      IP|table      Limit rdr to a source IP or table.
+    -t | --type        ipv4|ipv6     Specify IP type. Must be used if -s or -d are used. Defaults to both.
+    -x | --debug                     Enable debug mode.
 
 EOF
     exit 1

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -105,18 +105,18 @@ validate_name() {
 update_jailconf() {
 
     # Update jail.conf
-    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
-    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    local jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
 
-    if [ -f "${_jail_conf}" ]; then
-        if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${_jail_conf}"; then
-            sed -i '' "s|host.hostname.*=.*${TARGET};|host.hostname = ${NEWNAME};|" "${_jail_conf}"
-            sed -i '' "s|exec.consolelog.*=.*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${_jail_conf}"
-            sed -i '' "s|path.*=.*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${_jail_conf}"
-            sed -i '' "s|mount.fstab.*=.*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${_jail_conf}"
-            sed -i '' "s|^${TARGET}.*{$|${NEWNAME} {|" "${_jail_conf}"
+    if [ -f "${jail_conf}" ]; then
+        if ! grep -qw "path = ${bastille_jailsdir}/${NEWNAME}/root;" "${jail_conf}"; then
+            sed -i '' "s|host.hostname.*=.*${TARGET};|host.hostname = ${NEWNAME};|" "${jail_conf}"
+            sed -i '' "s|exec.consolelog.*=.*;|exec.consolelog = ${bastille_logsdir}/${NEWNAME}_console.log;|" "${jail_conf}"
+            sed -i '' "s|path.*=.*;|path = ${bastille_jailsdir}/${NEWNAME}/root;|" "${jail_conf}"
+            sed -i '' "s|mount.fstab.*=.*;|mount.fstab = ${bastille_jailsdir}/${NEWNAME}/fstab;|" "${jail_conf}"
+            sed -i '' "s|^${TARGET}.*{$|${NEWNAME} {|" "${jail_conf}"
         fi
-        if grep -qo "vnet;" "${_jail_conf}"; then
+        if grep -qo "vnet;" "${jail_conf}"; then
             update_jailconf_vnet
         fi
     fi
@@ -124,103 +124,106 @@ update_jailconf() {
 
 update_jailconf_vnet() {
 
-    local _jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
-    local _rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
+    local jail_conf="${bastille_jailsdir}/${NEWNAME}/jail.conf"
+    local jail_rc_conf="${bastille_jailsdir}/${NEWNAME}/root/etc/rc.conf"
 
-    # Change bastille interface name (only needed for bridged epairs)
-    # We still gather interface names for JIB and JNG managed interfaces (for future use)
     if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
-        local _if_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${_jail_conf} | sort -u)"
+        local if_list="$(grep -Eo 'e[0-9]+a_[^;" ]+' ${jail_conf} | sort -u)"
     elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
-        local _if_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${_jail_conf} | sort -u)"
+        local if_list="$(grep -Eo 'ng[0-9]+_[^;" ]+' ${jail_conf} | sort -u)"
     fi
 
-    for _if in ${_if_list}; do
+    for if in ${if_list}; do
 
-        local _old_if_prefix="$(echo ${_if} | awk -F'_' '{print $1}')"
-        local _old_if_suffix="$(echo ${_if} | awk -F'_' '{print $2}')"
+        local old_if_prefix="$(echo ${if} | awk -F'_' '{print $1}')"
+        local old_if_suffix="$(echo ${if} | awk -F'_' '{print $2}')"
 
         # For if_bridge network type
         if [ "${bastille_network_vnet_type}" = "if_bridge" ]; then
 
-            local _epair_num="$(echo "${_old_if_prefix}" | grep -Eo "[0-9]+")"
-            local _old_host_epair="${_if}"
-            local _old_jail_epair="${_old_if_prefix%a}b_${_old_if_suffix}"
+            local epair_num="$(echo "${old_if_prefix}" | grep -Eo "[0-9]+")"
+            local old_host_epair="${if}"
+            local old_jail_epair="${old_if_prefix%a}b_${old_if_suffix}"
 
-            if [ "$(echo -n "e${_epair_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
+            if [ "$(echo -n "e${epair_num}a_${NEWNAME}" | awk '{print length}')" -lt 16 ]; then
                 # Generate new epair name
-                local _new_host_epair="e${_epair_num}a_${NEWNAME}"
-                local _new_jail_epair="e${_epair_num}b_${NEWNAME}"
+                local new_host_epair="e${epair_num}a_${NEWNAME}"
+                local new_jail_epair="e${epair_num}b_${NEWNAME}"
             else
-                get_bastille_epair_count
-                local epair_num=1
-                while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
-                    epair_num=$((epair_num + 1))
-                done
-                local _new_host_epair="e0a_bastille${epair_num}"
-                local _new_jail_epair="e0b_bastille${epair_num}"
+                if echo "${old_if_suffix}" | grep -Eosq "bastille[0-9]+"; then
+                    local new_host_epair="e${epair_num}a_${old_if_suffix}"
+                    local new_jail_epair="e${epair_num}b_${old_if_suffix}"
+                else
+                    get_bastille_epair_count
+                    local bastille_epair_num=1
+                    while echo "${BASTILLE_EPAIR_LIST}" | grep -oq "bastille${epair_num}"; do
+                        bastille_epair_num=$((epair_num + 1))
+                    done
+                    local new_host_epair="e${epair_num}a_bastille${bastille_epair_num}"
+                    local new_jail_epair="e${epair_num}b_bastille${bastille_epair_num}"
+                fi
             fi
 
-            local _new_if_prefix="$(echo ${_new_host_epair} | awk -F'_' '{print $1}')"
-            local _new_if_suffix="$(echo ${_new_host_epair} | awk -F'_' '{print $2}')"
+            local new_if_prefix="$(echo ${new_host_epair} | awk -F'_' '{print $1}')"
+            local new_if_suffix="$(echo ${new_host_epair} | awk -F'_' '{print $2}')"
 
-            if grep "${_old_if_suffix}" "${_jail_conf}" | grep -oq "jib addm"; then
+            if grep "${old_if_suffix}" "${jail_conf}" | grep -oq "jib addm"; then
                 # For -V jails
                 # Replace host epair name in jail.conf
-                sed -i '' "s|jib addm ${_old_if_suffix}|jib addm ${_new_if_suffix}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+                sed -i '' "s|jib addm ${old_if_suffix}|jib addm ${new_if_suffix}|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} ether|${new_host_epair} ether|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} destroy|${new_host_epair} destroy|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} description|${new_host_epair} description|g" "${jail_conf}"
 
                 # Replace jail epair name in jail.conf
-                sed -i '' "s|= ${_old_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
-                sed -i '' "s|${_old_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                sed -i '' "s|= ${old_jail_epair};|= ${new_jail_epair};|g" "${jail_conf}"
+                sed -i '' "s|${old_jail_epair} ether|${new_jail_epair} ether|g" "${jail_conf}"
 
                 # Replace epair description
-                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${jail_conf}"
 
                 # Replace epair name in /etc/rc.conf
-                sed -i '' "/ifconfig/ s|${_old_jail_epair}|${_new_jail_epair}|g" "${_rc_conf}"
+                sed -i '' "/ifconfig/ s|${old_jail_epair}|${new_jail_epair}|g" "${jail_rc_conf}"
             else
                 # For -B jails
                 # Replace host epair name in jail.conf
-                sed -i '' "s|up name ${_old_host_epair}|up name ${_new_host_epair}|g" "${_jail_conf}"
-                sed -i '' "s|addm ${_old_host_epair}|addm ${_new_host_epair}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} ether|${_new_host_epair} ether|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} destroy|${_new_host_epair} destroy|g" "${_jail_conf}"
-                sed -i '' "s|${_old_host_epair} description|${_new_host_epair} description|g" "${_jail_conf}"
+                sed -i '' "s|up name ${old_host_epair}|up name ${new_host_epair}|g" "${jail_conf}"
+                sed -i '' "s|addm ${old_host_epair}|addm ${new_host_epair}|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} ether|${new_host_epair} ether|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} destroy|${new_host_epair} destroy|g" "${jail_conf}"
+                sed -i '' "s|${old_host_epair} description|${new_host_epair} description|g" "${jail_conf}"
 
                 # Replace jail epair name in jail.conf
-                sed -i '' "s|= ${_old_jail_epair};|= ${_new_jail_epair};|g" "${_jail_conf}"
-                sed -i '' "s|up name ${_old_jail_epair}|up name ${_new_jail_epair}|g" "${_jail_conf}"
-                sed -i '' "s|${_old_jail_epair} ether|${_new_jail_epair} ether|g" "${_jail_conf}"
+                sed -i '' "s|= ${old_jail_epair};|= ${new_jail_epair};|g" "${jail_conf}"
+                sed -i '' "s|up name ${old_jail_epair}|up name ${new_jail_epair}|g" "${jail_conf}"
+                sed -i '' "s|${old_jail_epair} ether|${new_jail_epair} ether|g" "${jail_conf}"
 
                 # Replace epair description
-                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${_jail_conf}"
+                sed -i '' "s|host interface for Bastille jail ${TARGET}|host interface for Bastille jail ${NEWNAME}|g" "${jail_conf}"
 
                 # Replace epair name in /etc/rc.conf
-                sed -i '' "/ifconfig/ s|${_old_jail_epair}|${_new_jail_epair}|g" "${_rc_conf}"
+                sed -i '' "/ifconfig/ s|${old_jail_epair}|${new_jail_epair}|g" "${jail_rc_conf}"
             fi
         # For netgraph network type
         elif [ "${bastille_network_vnet_type}" = "netgraph" ]; then
 
-            local _ngif_num="$(echo "${_old_if_prefix}" | grep -Eo "[0-9]+")"
-            local _old_ngif="${_if}"
+            local ngif_num="$(echo "${old_if_prefix}" | grep -Eo "[0-9]+")"
+            local old_ngif="${if}"
             # Generate new netgraph interface name
-            local _new_ngif="ng${_ngif_num}_${NEWNAME}"
-            local _new_if_prefix="$(echo ${_new_ngif} | awk -F'_' '{print $1}')"
-            local _new_if_suffix="$(echo ${_new_ngif} | awk -F'_' '{print $2}')"
+            local new_ngif="ng${ngif_num}_${NEWNAME}"
+            local new_if_prefix="$(echo ${new_ngif} | awk -F'_' '{print $1}')"
+            local new_if_suffix="$(echo ${new_ngif} | awk -F'_' '{print $2}')"
 
             # Replace netgraph interface name
-            sed -i '' "s|jng bridge ${_old_if_suffix}|jng bridge ${_new_if_suffix}|g" "${_jail_conf}"
-            sed -i '' "s|${_old_ngif} ether|${_new_ngif} ether|g" "${_jail_conf}"
-            sed -i '' "s|jng shutdown ${_old_if_suffix}|jng shutdown ${_new_if_suffix}|g" "${_jail_conf}"
+            sed -i '' "s|jng bridge ${old_if_suffix}|jng bridge ${new_if_suffix}|g" "${jail_conf}"
+            sed -i '' "s|${old_ngif} ether|${new_ngif} ether|g" "${jail_conf}"
+            sed -i '' "s|jng shutdown ${old_if_suffix}|jng shutdown ${new_if_suffix}|g" "${jail_conf}"
 
             # Replace jail epair name in jail.conf
-            sed -i '' "s|= ${_old_ngif};|= ${_new_ngif};|g" "${_jail_conf}"
+            sed -i '' "s|= ${old_ngif};|= ${new_ngif};|g" "${jail_conf}"
 
             # Replace epair name in /etc/rc.conf
-            sed -i '' "/ifconfig/ s|${_old_ngif}|${_new_ngif}|g" "${_rc_conf}"
+            sed -i '' "/ifconfig/ s|${old_ngif}|${new_ngif}|g" "${jail_rc_conf}"
         fi
     done
 }

--- a/usr/local/share/bastille/rename.sh
+++ b/usr/local/share/bastille/rename.sh
@@ -211,6 +211,7 @@ update_jailconf_vnet() {
             local old_ngif="${if}"
             # Generate new netgraph interface name
             local new_ngif="ng${ngif_num}_${NEWNAME}"
+            # shellcheck disable=SC2034
             local new_if_prefix="$(echo ${new_ngif} | awk -F'_' '{print $1}')"
             local new_if_suffix="$(echo ${new_ngif} | awk -F'_' '{print $2}')"
 


### PR DESCRIPTION
@michael-o 

This PR changes the way epair names are handled when jail names exceed 16 characters.

Default behavior will be retained with all epair names (-V or -B jails) where the naming scheme is `e0a_jailname` and `e0b_jailname`.

The only difference is that we are now generically naming all epairs that exceed the maximum allowed length as `e0a_bastille1` and `e0b_bastille1` with the `1` incrementing for each one.

Tested: create, clone, rename, network all function properly for me