### PR TITLE
persist, eval quotes on rdr $if when necessary

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -144,6 +144,10 @@ persist_rdr_rule() {
     local host_port="${6}"
     local jail_port="${7}"
 
+    if echo "$if" | grep -qs " "; then
+        if=\"$if\"
+    fi
+
     if ! grep -qs "$inet $if $src $dst $proto $host_port $jail_port" "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
         echo "$inet $if $src $dst $proto $host_port $jail_port" >> "${bastille_jailsdir}/${TARGET}/rdr.conf"
     fi
@@ -160,6 +164,10 @@ persist_rdr_log_rule() {
     local jail_port="${7}"
     shift 7;
     log=$@;
+
+    if echo "$if" | grep -qs " "; then
+        if=\"$if\"
+    fi
 
     if ! grep -qs "$inet $if $src $dst $proto $host_port $jail_port $log" "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
         echo "$inet $if $src $dst $proto $host_port $jail_port $log" >> "${bastille_jailsdir}/${TARGET}/rdr.conf"

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -211,7 +211,7 @@ for _jail in ${JAILS}; do
     # Add rdr rules
     if [ -s "${bastille_jailsdir}/${_jail}/rdr.conf" ]; then
         while read _rules; do
-            bastille rdr ${_jail} ${_rules}
+            eval "bastille rdr ${_jail} ${_rules}"
         done < "${bastille_jailsdir}/${_jail}/rdr.conf"
     fi
 


### PR DESCRIPTION
Previously, after restarting a jail on a system with support for multiple interfaces, `bastille rdr` does not create the persisted redirects. Num arg debug statements have been added:
<img width="701" height="685" alt="Screenshot from 2025-09-28 13-11-29" src="https://github.com/user-attachments/assets/32971ded-7942-40ac-acbd-6c443209fde1" />
<img width="582" height="288" alt="Screenshot from 2025-09-28 13-11-55" src="https://github.com/user-attachments/assets/d66fb5bb-db2e-40db-8c67-6bd6ffcde059" />
<img width="555" height="74" alt="Screenshot from 2025-09-28 13-12-32" src="https://github.com/user-attachments/assets/0cb84ba4-0a8d-41f4-ae3a-e6d0fe8cc906" />
<img width="567" height="106" alt="Screenshot from 2025-09-28 13-12-47" src="https://github.com/user-attachments/assets/73d25c35-8448-413d-bcc9-b89932dae2c2" />
<img width="567" height="66" alt="Screenshot from 2025-09-28 13-13-02" src="https://github.com/user-attachments/assets/d4be1e82-916c-49c3-b354-275a45ef7787" />
<img width="1234" height="611" alt="Screenshot from 2025-09-28 13-13-49" src="https://github.com/user-attachments/assets/b98a74ac-6061-4174-aba9-b2dc98d9f753" />

rdr.sh changes:
Changes to persist functions wrap the `$if` arg in quotes when a space is detected:

<img width="535" height="63" alt="Screenshot from 2025-10-04 09-21-33" src="https://github.com/user-attachments/assets/68cbf8fe-af7e-4cf9-b341-77bb1ce1c9d6" />
<img width="634" height="100" alt="Screenshot from 2025-10-04 09-21-19" src="https://github.com/user-attachments/assets/2489f198-c03d-4dc3-ab17-faa43d465979" />
<img width="547" height="60" alt="Screenshot from 2025-10-04 09-20-59" src="https://github.com/user-attachments/assets/7f7d1431-4c51-4442-bde9-f7dca1b62b1f" />

start.sh changes:
From testing, Bourne shell's `read` built-in does not perform word-splitting correctly when the output is passed directly into the `bastille rdr` command and fails to parse quoted interface `"{ em0 }"` into a single arg, instead creating multiple args `""{"`, `"em0"`, `"}""` This has been fixed by passing the command, jail name, and rdr args into the `eval` built-in, which does its own word-splitting
