### PR TITLE
fix bootstrap with pkgbase

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -272,7 +272,7 @@ bootstrap_pkgbase_release() {
                      -o ASSUME_ALWAYS_YES="yes" \
                      -o FINGERPRINTS="${fingerprints}" \
                      install -r "${repo_name}" \
-                     freebsd-set-"${package}"; then
+                     FreeBSD-set-"${package}"; then
 
                 ERROR_COUNT=$((ERROR_COUNT + 1))
             fi

--- a/usr/local/share/bastille/etcupdate.sh
+++ b/usr/local/share/bastille/etcupdate.sh
@@ -75,7 +75,7 @@ bootstrap_etc_release_pkgbase() {
                   -o ASSUME_ALWAYS_YES="yes" \
                   -o FINGERPRINTS="${fingerprints}" \
                   install -r "${repo_name}" \
-                  freebsd-set-src; then
+                  FreeBSD-set-src; then
             error_exit "[ERROR]: Failed to install package set: FreeBSD-set-src"
         fi
     else


### PR DESCRIPTION
So i just setup my pkgbase repo with 15.0-RELEASE and i try to bootstrap it:

```
Bootstrapping release: 15.0-RELEASE...

Using PkgBase...
pkg: Setting ABI requires setting OSVERSION, guessing the OSVERSION as: 1500000
Updating FreeBSD-base-release-0 repository catalogue...
FreeBSD-base-release-0 repository is up to date.
FreeBSD-base-release-0 is up to date.
pkg: Setting ABI requires setting OSVERSION, guessing the OSVERSION as: 1500000
Updating FreeBSD-base-release-0 repository catalogue...
FreeBSD-base-release-0 repository is up to date.
FreeBSD-base-release-0 is up to date.
pkg: No packages available to install matching 'freebsd-set-base-jail' have been found in the repositories
[ERROR]: Bootstrap failed.
```

I just change the case of the FreeBSD-set package name and i can bootstrap:

```
# bastille bootstrap --pkgbase 15.0-RELEASE
Bootstrapping release: 15.0-RELEASE...

Using PkgBase...
...
FreeBSD-base-release-0 is up to date.
The following 183 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
        FreeBSD-acct: 15.0 [FreeBSD-base-release-0]
        FreeBSD-at: 15.0 [FreeBSD-base-release-0]
...
Bootstrap successful.
See 'bastille --help' for available commands.
```