### PR TITLE
list now displays all jails, not just only running ones

### DIFF
--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -93,7 +93,7 @@ Available Commands:
   import      Import a specified container.
   jcp         cp(1) files from a jail to jail(s).
   limits      Apply resources limits to targeted container(s). See rctl(8).
-  list        List containers (running).
+  list        List containers.
   migrate     Migrate targetted jail(s) to a remote system.
   mount       Mount a volume inside the targeted container(s).
   network     Add/remove network interfaces from targeted container.


### PR DESCRIPTION
Starting with v1.0, the `list` subcommand without any options displays all jails.