### PR TITLE
feat(unbound): Add support for unbound entries for started jails

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -79,6 +79,9 @@ bastille_network_pf_table="jails"                                     ## default
 bastille_network_shared=""                                            ## default: ""
 bastille_network_gateway=""                                           ## default: ""
 bastille_network_gateway6=""                                          ## default: ""
+bastille_network_use_local_unbound="NO"                               ## default: "NO"
+bastille_network_use_unbound="NO"                                     ## default: "NO"
+bastille_network_unbound_zone="bastille"                              ## default: "bastille"
 
 ## Default Templates
 bastille_template_base="default/base"                                 ## default: "default/base"

--- a/usr/local/share/bastille/lib/network.sh
+++ b/usr/local/share/bastille/lib/network.sh
@@ -267,3 +267,80 @@ check_fib() {
     fi
     export SETFIB
 }
+
+unbound_enabled(){
+    if checkyesno bastille_network_use_unbound; then
+        # Check unbound-control executable presence
+        if command -v unbound-control >/dev/null 2>&1; then
+            # Check unbound status
+            if unbound-control status >/dev/null 2>&1; then
+                # Check/add bastille local unbound zone
+                if [ -n "${bastille_network_unbound_zone}" ]; then
+                    if ! unbound-control list_local_zones | grep -qE "^${bastille_network_unbound_zone}. static$"; then
+                        unbound-control local_zone "${bastille_network_unbound_zone}" static >/dev/null 2>&1
+                    fi
+                fi
+                return 0
+            else
+                warn "bastille_network_use_unbound is set, but unbound is not enabled in system"
+            fi
+        else
+            warn "bastille_network_use_unbound is set, but couldn't find the 'unbound-control' executable"
+        fi
+    fi
+    return 1
+}
+
+local_unbound_enabled(){
+    if checkyesno bastille_network_use_local_unbound; then
+        # Check local-unbound-control executable presence
+        if command -v local-unbound-control >/dev/null 2>&1; then
+            # Check local unbound status
+            if local-unbound-control status >/dev/null 2>&1; then
+                # Check/add bastille local unbound zone
+                if [ -n "${bastille_network_unbound_zone}" ]; then
+                    if ! local-unbound-control list_local_zones | grep -qE "^${bastille_network_unbound_zone}. static$"; then
+                        local-unbound-control local_zone "${bastille_network_unbound_zone}" static >/dev/null 2>&1
+                    fi
+                fi
+                return 0
+            else
+                warn "bastille_network_use_local_unbound is set, but unbound is not enabled in system"
+            fi
+        else
+            warn "bastille_network_use_local_unbound is set, but couldn't find the 'local-unbound-control' executable"
+        fi
+    fi
+    return 1
+}
+
+unbound_update() {
+    local name="${1}"
+    local entry="${2}"
+
+    if [ -n "${bastille_network_unbound_zone}" ]; then
+        name="${name}.${bastille_network_unbound_zone}."
+    fi
+
+    if unbound_enabled; then
+        unbound-control "local_data" "${name}" "${entry}" >/dev/null 2>&1
+    fi
+    if local_unbound_enabled; then
+        local-unbound-control "local_data" "${name}" "${entry}" >/dev/null 2>&1
+    fi
+}
+
+unbound_clear() {
+    local name="${1}"
+
+    if [ -n "${bastille_network_unbound_zone}" ]; then
+        name="${name}.${bastille_network_unbound_zone}."
+    fi
+
+    if unbound_enabled; then
+        unbound-control "local_data_remove" "${name}" >/dev/null 2>&1
+    fi
+    if local_unbound_enabled; then
+        local-unbound-control "local_data_remove" "${name}" >/dev/null 2>&1
+    fi
+}

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -151,6 +151,8 @@ for jail in ${JAILS}; do
                     if route -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
+                    # If unbound or local-unbound is enabled in conf, add entry dynamically
+                    unbound_update "${jail}" "A ${ip}"
                 else
                     error_continue "[ERROR]: ${if} interface does not exist."
                 fi
@@ -174,6 +176,8 @@ for jail in ${JAILS}; do
                     if route -6 -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
+                    # If unbound or local-unbound is enabled in conf, add entry dynamically
+                    unbound_update "${jail}" "AAAA ${ip}"
                 else
                     error_continue "[ERROR]: ${if} interface does not exist."
                 fi

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -142,6 +142,8 @@ for jail in ${JAILS}; do
                     if route -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
+                    # If unbound or local-unbound is enabled in conf, add entry dynamically
+                    unbound_update "${jail}" "A ${ip}"
                 else
                     error_continue "[ERROR]: ${if} interface does not exist."
                 fi
@@ -165,6 +167,8 @@ for jail in ${JAILS}; do
                     if route -6 -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
+                    # If unbound or local-unbound is enabled in conf, add entry dynamically
+                    unbound_update "${jail}" "AAAA ${ip}"
                 else
                     error_continue "[ERROR]: ${if} interface does not exist."
                 fi

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -124,6 +124,9 @@ for jail in ${JAILS}; do
         bastille limits "${jail}" clear
     fi
 
+    # Remove unbound rules (if set)
+    unbound_clear "${jail}"
+
     # Stop jail
     jail ${OPTION} -f "${bastille_jailsdir}/${jail}/jail.conf" -r "${jail}"
 

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -126,6 +126,9 @@ for jail in ${JAILS}; do
         bastille limits "${jail}" clear
     fi
 
+    # Remove unbound rules (if set)
+    unbound_clear "${jail}"
+
     # Stop jail
     if [ "${FORCE}" -eq 1 ]; then
         prestop_cmds="$(grep 'exec.prestop' "${bastille_jailsdir}/${jail}/jail.conf" 2>/dev/null | sed -E 's%^.*= "(.*)";$%\1%')"


### PR DESCRIPTION
Add support for a custom zone and local_data entries in unbound/local-unbound
- Starting a new jail adds the configured bastille zone in unbound/local-unbound + the jail IP(s) entry(ies)
- Stopping a jail removes that(ose) entry(ies) from unbound/local-unbound
- Usage for unbound and local-unbound is disabled by default in bastille.conf
- Custom bastille zone is configurable in bastille.conf (default is 'bastille.')