### PR TITLE
Fix every export is reported as RAW image

### DIFF
--- a/usr/local/share/bastille/export.sh
+++ b/usr/local/share/bastille/export.sh
@@ -143,7 +143,7 @@ if [ -n "${bastille_export_options}" ]; then
             -x)
                 enable_debug
                 ;;
-            -*) 
+            -*)
                 error_notify "[ERROR]: Unknown Option: \"${1}\""
                 usage
                 ;;
@@ -354,7 +354,7 @@ export_check() {
             EXPORT_TYPE="archive"
         fi
 
-        if [ -n "${RAW_EXPORT}" ]; then
+        if [ "${RAW_EXPORT}" -eq 1 ]; then
             EXPORT_INFO="to a raw ${EXPORT_TYPE}"
         else
             EXPORT_INFO="to a compressed ${FILE_EXT} ${EXPORT_TYPE}"
@@ -510,8 +510,8 @@ jail_export() {
             # Generate container checksum file
             cd "${bastille_backupsdir}" || error_exit "[ERROR]: Failed to change to directory: ${bastille_backupsdir}"
             if ! sha256 -q "${TARGET}_${DATE}${FILE_EXT}" > "${TARGET}_${DATE}.sha256"; then
-	        error_exit "[ERROR]: Failed to generate sha256 file."
-	    fi
+            error_exit "[ERROR]: Failed to generate sha256 file."
+        fi
             info "\nExported '${bastille_backupsdir}/${TARGET}_${DATE}${FILE_EXT}' successfully."
         fi
     fi


### PR DESCRIPTION
Fix that every export is reported as RAW image, cleanup tabs for code consistency.

**Export issue:**
```
root@nas-mserver: ~# bastille export TEST_JAIL
Default export option(s): '--auto --gz'

Exporting 'TEST_JAIL' to a raw image...

Creating temporary ZFS snapshot for export...

Sending ZFS data stream...
 64.2%

Exported '/mnt/storage/zbackups/bastille/backups/TEST_JAIL_2025-12-27-001401.gz' successfully.
```

**Wanted behavior:**
```
root@nas-mserver: ~# bastille export TEST_JAIL
Default export option(s): '--auto --gz'

Exporting 'TEST_JAIL' to a compressed .gz image...

Creating temporary ZFS snapshot for export...

Sending ZFS data stream...
 64.2%

Exported '/mnt/storage/zbackups/bastille/backups/TEST_JAIL_2025-12-27-003159.gz' successfully.
```