### PR TITLE
template: skip ARG if no value is given

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -365,7 +365,7 @@ for jail in ${JAILS}; do
                     arg_value=$(get_arg_value "${args}" "$@")
                     if [ -z "${arg_value}" ]; then
                         warn "[WARNING]: No value provided for arg: ${arg_name}"
-						SCRIPT=$(printf '%s\n' "$SCRIPT" | grep -Ev "^.*${arg_name}.*$")
+						SCRIPT=$(printf '%s\n' "${SCRIPT}" | grep -Fv "\${${arg_name}}")
                     else
                         # Build a list of sed commands like this: -e 's/${username}/root/g' -e 's/${domain}/example.com/g'
                         ARG_REPLACEMENTS="${ARG_REPLACEMENTS} -e 's/\${${arg_name}}/${arg_value}/g'"


### PR DESCRIPTION
If any ARG is not populated, do not attempt to execute any lines containing it.