### PR TITLE
Allow line_in_file to create a file

### DIFF
--- a/usr/local/share/bastille/template.sh
+++ b/usr/local/share/bastille/template.sh
@@ -137,13 +137,16 @@ line_in_file() {
     eval set -- "${2}"
     local line="${1}"
     local file_path="${2}"
+    local file_in_jail_path="${jail_path}/${file_path}"
+    local file_in_jail_dir="$(dirname "${file_in_jail_path}")"
 
-    if [ -f "${jail_path}/${file_path}" ]; then
-        if ! grep -qxF "${line}" "${jail_path}/${file_path}"; then
-            echo "${line}" >> "${jail_path}/${file_path}"
+    if [ -f "${file_in_jail_path}" ]; then
+        if ! grep -qxF "${line}" "${file_in_jail_path}"; then
+            echo "${line}" >> "${file_in_jail_path}"
 	fi
     else
-        warn "[WARNING]: Path not found for line_in_file: ${file_path}"
+        mkdir -p "${file_in_jail_dir}"
+        echo "${line}" > "${file_in_jail_path}"
     fi
 }
 


### PR DESCRIPTION
This allows to apply quick customizations to e.g., /etc/make.conf w/o needing to CP a local file or anything else.