### PR TITLE
Accept IPv6 addresses as destination option in redirects

### DIFF
--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -258,7 +258,7 @@ while [ "$#" -gt 0 ]; do
             usage
             ;;
         -d|--destination)
-            if ifconfig | grep -owq "inet ${2}"; then
+            if ifconfig | grep -owq "inet6\? ${2}"; then
                 OPTION_DST=1
                 RDR_DST="${2}"
                 shift 2


### PR DESCRIPTION
When using --destination option for redirects, IPv6 addresses always rejected with `not an IP on this system`.
Option value check only looks for `inet` addresses, ignoring `inet6`.