### PR TITLE
Change default 'pf' file to /usr/local/etc/bastille/pf.conf

### DIFF
--- a/docs/chapters/configuration.rst
+++ b/docs/chapters/configuration.rst
@@ -27,7 +27,7 @@ This is the default `bastille.conf` file.
   bastille_logsdir="/var/log/bastille"                                  ## default: "/var/log/bastille"
 
   ## pf configuration path
-  bastille_pf_conf="/etc/pf.conf"                                       ## default: "/etc/pf.conf"
+  bastille_pf_conf="/usr/local/etc/bastille/pf.conf"                    ## default: "/usr/local/etc/bastille/pf.conf"
 
   ## Bastille commands directory (assumed by bastille pkg)
   bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"

--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -12,7 +12,7 @@ bastille_templatesdir="${bastille_prefix}/templates"                  ## default
 bastille_logsdir="/var/log/bastille"                                  ## default: "/var/log/bastille"
 
 ## pf configuration path
-bastille_pf_conf="/etc/pf.conf"                                       ## default: "/etc/pf.conf"
+bastille_pf_conf="/usr/local/etc/bastille/pf.conf"                    ## default: "/usr/local/etc/bastille/pf.conf"
 
 ## Bastille commands directory (assumed by bastille pkg)
 bastille_sharedir="/usr/local/share/bastille"                         ## default: "/usr/local/share/bastille"

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -357,11 +357,15 @@ pass out quick keep state
 antispoof for \$ext_if
 pass in proto tcp from any to any port ssh flags S/SA keep state
 EOF
-    if ! grep -qo "include \"${bastille_pf_conf}\"" "/etc/pf.conf"; then
-        sed -i '' "1s/^/include \"${bastille_pf_conf}\"\n/" "/etc/pf.conf"
+    if [ -f "/etc/pf.conf" ]; then
+        if ! grep -qo "include \"${bastille_pf_conf}\"" "/etc/pf.conf"; then
+            sed -i '' "1s/^/include \"${bastille_pf_conf}\"\n/" "/etc/pf.conf"
+        fi
+    else
+        echo "include \"${bastille_pf_conf}\"" > "/etc/pf.conf"
     fi
     sysrc pf_enable=YES
-    warn 1 "pf ruleset created, please review ${bastille_pf_conf} and enable it using 'service pf start'."        
+    warn 1 "Bastille pf ruleset created. Please review '${bastille_pf_conf}' and enable pf using 'service pf start'."        
 else
     info 1 "\nFirewall (pf) has already been configured!"
 fi

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -335,8 +335,7 @@ configure_pf() {
 # shellcheck disable=SC2154
 if [ ! -f "${bastille_pf_conf}" ]; then
     # shellcheck disable=SC3043
-    local ext_if
-    ext_if=$(netstat -rn | awk '/default/ {print $4}' | head -n1)
+    local ext_if=$(netstat -rn | awk '/default/ {print $4}' | head -n1)
     info 1 "\nDetermined default network interface: ($ext_if)"
     info 2 "${bastille_pf_conf} does not exist: creating..."
 
@@ -358,8 +357,11 @@ pass out quick keep state
 antispoof for \$ext_if
 pass in proto tcp from any to any port ssh flags S/SA keep state
 EOF
+    if ! grep -qo "include \"${bastille_pf_conf}\""; then
+        sed -i '' '1s/^/include \"${bastille_pf_conf}\"\n/' "/etc/pf.conf"
+    fi
     sysrc pf_enable=YES
-    warn 1 "pf ruleset created, please review ${bastille_pf_conf} and enable it using 'service pf start'."
+    warn 1 "pf ruleset created, please review ${bastille_pf_conf} and enable it using 'service pf start'."        
 else
     info 1 "\nFirewall (pf) has already been configured!"
 fi

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -358,7 +358,7 @@ antispoof for \$ext_if
 pass in proto tcp from any to any port ssh flags S/SA keep state
 EOF
     if ! grep -qo "include \"${bastille_pf_conf}\"" "/etc/pf.conf"; then
-        sed -i '' '1s/^/include \"${bastille_pf_conf}\"\n/' "/etc/pf.conf"
+        sed -i '' "1s/^/include \"${bastille_pf_conf}\"\n/" "/etc/pf.conf"
     fi
     sysrc pf_enable=YES
     warn 1 "pf ruleset created, please review ${bastille_pf_conf} and enable it using 'service pf start'."        

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -335,7 +335,7 @@ configure_pf() {
 # shellcheck disable=SC2154
 if [ ! -f "${bastille_pf_conf}" ]; then
     # shellcheck disable=SC3043
-    local ext_if=$(netstat -rn | awk '/default/ {print $4}' | head -n1)
+    local ext_if="$(netstat -rn | awk '/default/ {print $4}' | head -n1)"
     info 1 "\nDetermined default network interface: ($ext_if)"
     info 2 "${bastille_pf_conf} does not exist: creating..."
 

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -357,7 +357,7 @@ pass out quick keep state
 antispoof for \$ext_if
 pass in proto tcp from any to any port ssh flags S/SA keep state
 EOF
-    if ! grep -qo "include \"${bastille_pf_conf}\""; then
+    if ! grep -qo "include \"${bastille_pf_conf}\"" "/etc/pf.conf"; then
         sed -i '' '1s/^/include \"${bastille_pf_conf}\"\n/' "/etc/pf.conf"
     fi
     sysrc pf_enable=YES

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -148,7 +148,7 @@ for jail in ${JAILS}; do
                         warn 1 "[WARNING]: IP address (${ip}) already in use, continuing..."
                     fi
                     ## add ip to firewall table if it is not reachable through local interface (assumes NAT/rdr is needed)
-                    if route -n get ${ip} | grep "gateway" >/dev/null && [ -f "${bastille_pf_conf}" ]; then
+                    if route -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
                 else
@@ -171,7 +171,7 @@ for jail in ${JAILS}; do
                         warn 1 "[WARNING]: IP address (${ip}) already in use, continuing..."
                     fi
                     ## add ip to firewall table if it is not reachable through local interface (assumes NAT/rdr is needed)
-                    if route -6 -n get ${ip} | grep "gateway" >/dev/null && [ -f "${bastille_pf_conf}" ]; then
+                    if route -6 -n get ${ip} | grep "gateway" >/dev/null; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
                 else

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -148,7 +148,7 @@ for jail in ${JAILS}; do
                         warn 1 "[WARNING]: IP address (${ip}) already in use, continuing..."
                     fi
                     ## add ip to firewall table if it is not reachable through local interface (assumes NAT/rdr is needed)
-                    if route -n get ${ip} | grep "gateway" >/dev/null; then
+                    if route -n get ${ip} | grep "gateway" >/dev/null && [ -f "${bastille_pf_conf}" ]; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
                 else
@@ -171,7 +171,7 @@ for jail in ${JAILS}; do
                         warn 1 "[WARNING]: IP address (${ip}) already in use, continuing..."
                     fi
                     ## add ip to firewall table if it is not reachable through local interface (assumes NAT/rdr is needed)
-                    if route -6 -n get ${ip} | grep "gateway" >/dev/null; then
+                    if route -6 -n get ${ip} | grep "gateway" >/dev/null && [ -f "${bastille_pf_conf}" ]; then
                         pfctl -q -t "${bastille_network_pf_table}" -T add "${ip}"
                     fi
                 else


### PR DESCRIPTION
This should fix an issue with users who already have pf configured. It puts the default file into the bastille config directory, and adds an include statement in the main pf.conf file at the very top. 

Since pf is a last rule wins firewall, the bastille rules should not override the already configured ones.

When testing, be sure to change the `bastille_pf_conf` variable to the one in the sample file, which should be `/usr/local/etc/bastille/pf.conf`

@koplenov