### PR TITLE
Patch 2

### DIFF
--- a/usr/local/share/bastille/bootstrap.sh
+++ b/usr/local/share/bastille/bootstrap.sh
@@ -451,7 +451,7 @@ bootstrap_release_linux() {
         case "${LINUX_FLAVOR}" in
             bionic|focal|jammy|buster|bullseye|bookworm|noble)
             info 1 "Increasing APT::Cache-Start"
-            info 2 "APT::Cache-Start 251658240;" > "${bastille_releasesdir}"/${RELEASE}/etc/apt/apt.conf.d/00aptitude
+            info 2 "APT::Cache-Start 536870912;" > "${bastille_releasesdir}"/${RELEASE}/etc/apt/apt.conf.d/00aptitude
             ;;
         esac
     fi

--- a/usr/local/share/bastille/templates/default/linux/Bastillefile
+++ b/usr/local/share/bastille/templates/default/linux/Bastillefile
@@ -10,4 +10,4 @@ MOUNT /tmp            tmp      nullfs          rw                      0       0
 MOUNT /home           home     nullfs          rw                      0       0
 
 CMD mkdir etc/apt/apt.conf.d/00aptitude
-CMD echo "APT::Cache-Start 251658240;" > etc/apt/apt.conf.d/00aptitude
+CMD echo "APT::Cache-Start 536870912;" > etc/apt/apt.conf.d/00aptitude


### PR DESCRIPTION
Increase APT::Cache-Start to 512MB

Fixes errors
````
Error: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Start. Current value: 25165824. (man 5 apt.conf)
Reading package lists... Error!
Error: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Start. Current value: 25165824. (man 5 apt.conf)
Error: Error occurred while processing ont-fast5-api (NewVersion2)
````