### PR TITLE
Documentation formatting fixes

### DIFF
--- a/docs/chapters/gcp.rst
+++ b/docs/chapters/gcp.rst
@@ -8,10 +8,11 @@ Bastille VNET runs on GCP with a few small tweaks. In summary, they are:
 - configure host pf to NAT and allow bridge traffic
 - set defaultrouter and nameserver in the host
 
-## Change MTU in the jib script
+Change MTU in the jib script
+----------------------------
 
-GCP uses ``vtnet`` with MTU 1460, which [jib fails
-on](https://github.com/BastilleBSD/bastille/issues/538).
+GCP uses ``vtnet`` with MTU 1460, which `jib fails
+on <https://github.com/BastilleBSD/bastille/issues/538>`_.
 
 Apply the below patch to set the correct MTU. You may need to ``cp
 /usr/share/examples/jails/jib /usr/local/bin/`` first.
@@ -19,6 +20,7 @@ Apply the below patch to set the correct MTU. You may need to ``cp
 ``patch /usr/local/bin/jib jib.patch``
 
 .. code-block:: text
+
   --- /usr/local/bin/jib	2022-07-31 03:27:04.163245000 +0000
   +++ jib.fixed	2022-07-31 03:41:16.710401000 +0000
   @@ -299,14 +299,14 @@
@@ -39,23 +41,27 @@ Apply the below patch to set the correct MTU. You may need to ``cp
 
    		# Rename the new interface
 
-## Configure bridge interface
+Configure bridge interface
+--------------------------
 
 Configure the bridge interface in /etc/rc.conf so it is available in the
 firewall rules.
 
 .. code-block:: shell
+
   sysrc cloned_interfaces="bridge0"
   sysrc ifconfig_bridge0="inet 192.168.1.1/24 mtu 1460 addm vtnet0 name vtnet0bridge up"
   sysrc gateway_enable="yes"
   sysrc pf_enable="yes"
 
-## Configure host pf
+Configure host pf
+-----------------
 
 This basic /etc/pf.conf allow incoming packets on the bridge interface, and NATs
 them through the external interface:
 
 .. code-block:: text
+
   ext_if="vtnet0"
   bridge_if="vtnet0bridge"
 
@@ -76,6 +82,7 @@ Restart the host and make sure everything comes up correctly. You should see the
 following ifconfig:
 
 .. code-block:: text
+
   vtnet0bridge: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1460
   	ether 58:9c:fc:10:ff:90
   	inet 192.168.1.1 netmask 0xffffff00 broadcast 192.168.1.255
@@ -86,12 +93,14 @@ following ifconfig:
   	        ifmaxaddr 0 port 1 priority 128 path cost 2000
   	groups: bridge
 
-## Configure router and resolver for new jails
+Configure router and resolver for new jails
+-------------------------------------------
 
 Set the default network gateway for new jails as described in the Networking
 chapter, and configure a default resolver.
 
 .. code-block:: shell
+
   sysrc -f /usr/local/etc/bastille/bastille.conf bastille_network_gateway="192.168.1.1"
   echo "nameserver 8.8.8.8" > /usr/local/etc/bastille/resolv.conf
   sysrc -f /usr/local/etc/bastille/bastille.conf bastille_resolv_conf="/usr/local/etc/bastille/resolv.conf"

--- a/docs/chapters/hardened-bsd.rst
+++ b/docs/chapters/hardened-bsd.rst
@@ -85,7 +85,7 @@ the new release.
 Limitations
 -----------
 
-Bastille tries its best to determine which *BSD you are using. It is possible to
+Bastille tries its best to determine which ``*BSD`` you are using. It is possible to
 mix and match any of the supported BSD distributions, but it is up to the end
 user to ensure the correct environment/tools when doing so. See below...
 

--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -610,7 +610,7 @@ Create the firewall rules:
   pass in proto tcp from any to any port ssh flags S/SA modulate state
 
 - Make sure to change the ``ext_if`` variable to match your host system
-interface.
+  interface.
 - Make sure to include the last line (``port ssh``) or you'll end up locked out.
 
 Note: if you have an existing firewall, the key lines for in/out traffic

--- a/docs/chapters/subcommands/destroy.rst
+++ b/docs/chapters/subcommands/destroy.rst
@@ -14,7 +14,7 @@ Use the ``-y|--yes`` option to bypass this prompt.
   /var/log/bastille/folsom_console.log-YYYY-MM-DD
 
 Release can be destroyed provided there are no child jails. The ``-c|--no-cache``
-option will retain the release cache (*.txz file), if you choose to keep it.
+option will retain the release cache (``*.txz`` file), if you choose to keep it.
 
 .. code-block:: shell
 

--- a/docs/chapters/subcommands/index.rst
+++ b/docs/chapters/subcommands/index.rst
@@ -37,6 +37,7 @@ Bastille sub-commands
    stop
    sysrc
    tags
+   template
    top
    umount
    update

--- a/docs/chapters/template.rst
+++ b/docs/chapters/template.rst
@@ -3,6 +3,8 @@ Templates
 
 Looking for ready made CI/CD validated `Bastille Templates`_?
 
+.. _Bastille Templates: https://github.com/bastillebsd/templates
+
 Bastille features a template system, allowing you to automate just about anything
 from executing arbitrary commands to copying files all with a simple file called a
 Bastillefile. A template is applied by running ``bastille template TARGET project/template``

--- a/docs/chapters/zfs-support.rst
+++ b/docs/chapters/zfs-support.rst
@@ -12,6 +12,7 @@ for ZFS.  As of Bastille 0.13 you no longer need to do these steps manually. The
 setup program when you run:
 
 .. code-block:: shell
+
    bastille setup
 
 will create the zfs settings for you IF you are running zfs.  This section is

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+import os
+
 # -- Project information -----------------------------------------------------
 
 project = 'Bastille'
@@ -15,7 +17,10 @@ extensions = ['sphinx_rtd_theme','sphinx_rtd_dark_mode']
 
 templates_path = ['_templates']
 
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'restructuredtext',
+}
 
 #from recommonmark.parser import CommonMarkParser
 #source_parsers = {
@@ -29,7 +34,7 @@ pygments_style = None
 # -- Options for HTML output -------------------------------------------------
 html_logo = 'images/bastille.jpeg'
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_static_path = ['_static'] if os.path.isdir('_static') else []
 
 html_theme_options = {
     'collapse_navigation': True,
@@ -58,6 +63,8 @@ htmlhelp_basename = 'Bastilledoc'
 
 latex_elements = {
 }
+
+latex_logo = 'images/bastille.jpeg'
 
 latex_documents = [
     (master_doc, 'Bastille.tex', 'Bastille Documentation',


### PR DESCRIPTION
Just some doc fixes for issues I ran into while building a PDF.

I'm on MacOS 26.5.1, and built with `make clean latexpdf SPHINXBUILD=../.venv-docs/bin/sphinx-build` in case that matters.

Mainly it's missing mandatory newlines after directives and some markdown that got mixed in by mistake I assume, along with a couple missing things. The changes to conf.py were mainly to eliminate some build warnings, but it also adds in the logo on the cover page so it looks nice.