### PR TITLE
Secure RDR by splitting the dynamic rules into rdr+filter

### DIFF
--- a/docs/chapters/networking.rst
+++ b/docs/chapters/networking.rst
@@ -607,6 +607,8 @@ Create the firewall rules:
   block in all
   pass out quick keep state
   antispoof for $ext_if inet
+
+  anchor "bastille/*"
   pass in proto tcp from any to any port ssh flags S/SA modulate state
 
 - Make sure to change the ``ext_if`` variable to match your host system

--- a/docs/chapters/subcommands/rdr.rst
+++ b/docs/chapters/subcommands/rdr.rst
@@ -3,7 +3,8 @@ rdr
 
 ``bastille rdr`` allows you to configure dynamic rdr rules for your containers
 without modifying pf.conf (assuming you are using the ``bastille0`` interface
-for a private network and have enabled ``rdr-anchor 'rdr/*'`` in /etc/pf.conf as
+for a private network and have enabled ``rdr-anchor 'rdr/*'`` as well
+as ``anchor 'bastille/*'`` in /etc/pf.conf as
 described in the Networking section).
 
 Note: you need to be careful if host services are configured to run on all
@@ -24,11 +25,14 @@ interface they run on in rc.conf (or other config files)
     IPv4 udp/2053:53 on em0
 
     # bastille rdr dev1 list
-    rdr pass on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
-    rdr pass on em0 inet proto udp from any to any port = 2053 -> 10.17.89.1 port 53
+    rdr on em0 inet proto tcp from any to any port = 2001 -> 10.17.89.1 port 22
+    pass in on bge0 inet proto tcp from any to 10.17.89.1 port = 22 flags S/SA keep state
+    rdr on em0 inet proto tcp from any to any port = 2053 -> 10.17.89.1 port 53
+    pass in on bge0 inet proto tcp from any to 10.17.89.1 port = 53 flags S/SA keep state
 
     # bastille rdr dev1 clear
     nat cleared
+    rules cleared
 
 The ``rdr`` command includes 4 additional options:
 
@@ -59,10 +63,14 @@ The ``rdr`` command includes 4 additional options:
     IPv4 tcp/9000:9000 on vtnet0
 
     # bastille rdr dev1 list
-    rdr pass on vtnet0 inet proto udp from any to any port = 2001 -> 10.17.89.1 port 22
-    rdr pass on em0 inet proto tcp from 192.168.0.1 to any port = 8080 -> 10.17.89.1 port 81
-    rdr pass on em0 inet proto tcp from any to 192.168.0.84 port = 8082 -> 10.17.89.1 port 82
-    rdr pass on vtnet0 inet proto tcp from any to 192.168.0.45 port = 9000 -> 10.17.89.1 port 9000
+    rdr on vtnet0 inet proto udp from any to any port = 2001 -> 10.17.89.1 port 22
+    pass in on bge0 inet proto tcp from any to 10.17.89.1 port = 22 flags S/SA keep state
+    rdr on em0 inet proto tcp from 192.168.0.1 to any port = 8080 -> 10.17.89.1 port 81
+    pass in on bge0 inet proto tcp from 192.168.0.1 to 10.17.89.1 port = 81 flags S/SA keep state
+    rdr on em0 inet proto tcp from any to 192.168.0.84 port = 8082 -> 10.17.89.1 port 82
+    pass in on bge0 inet proto tcp from any to 10.17.89.1 port = 82 flags S/SA keep state
+    rdr on vtnet0 inet proto tcp from any to 192.168.0.45 port = 9000 -> 10.17.89.1 port 9000
+    pass in on bge0 inet proto tcp from any to 10.17.89.1 port = 9000 flags S/SA keep state
 
 The options can be used together, as seen above.
 
@@ -75,7 +83,7 @@ Simply use the table name instead of an IP address or subnet.
 .. code-block:: shell
 
   # bastille rdr --help
-  Usage: bastille rdr [option(s)] TARGET tcp|udp HOST_PORT JAIL_PORT [log LOG_OPTIONS]
+  Usage: bastille rdr [option(s)] TARGET tcp|udp HOST_PORT JAIL_PORT [log LOG,OPTIONS]
                                   TARGET clear|reset|list
 
       Options:

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -220,10 +220,12 @@ get_jail_info() {
         JAIL_HOSTNAME=$(/usr/sbin/jls -j ${JAIL_NAME} host.hostname 2> /dev/null)
 
         # Get jail ports (active)
-        JAIL_PROTO=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'proto.*' | awk '{print $2}')
-        JAIL_HOST_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'port = [0-9]+' | awk '{print $3}')
-        JAIL_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'port [0-9]+$' | awk '{print $2}')
-        JAIL_PORTS=$(printf "%s/%s:%s"",",${JAIL_PROTO},${JAIL_HOST_PORT},${JAIL_PORT} | sed "s/,$//")
+        JAIL_PROTO=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'proto.*' | awk '{print $2}')
+        JAIL_HOST_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'port = [0-9]+' | awk '{print $3}')
+        JAIL_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'port [0-9]+$' | awk '{print $2}')
+        if [ -n "${JAIL_PROTO}" ] && [ -n "${JAIL_HOST_PORT}" ] && [ -n "${JAIL_PORT}" ]; then
+            JAIL_PORTS=$(printf "%s/%s:%s"",",${JAIL_PROTO},${JAIL_HOST_PORT},${JAIL_PORT} | sed "s/,$//")
+        fi
 
         # Get release (FreeBSD or Linux)
         if [ "${IS_FREEBSD_JAIL}" -eq 1 ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -220,7 +220,10 @@ get_jail_info() {
         JAIL_HOSTNAME=$(/usr/sbin/jls -j ${JAIL_NAME} host.hostname 2> /dev/null)
 
         # Get jail ports (active)
-        JAIL_PORTS=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | awk '{ printf "%s/%s:%s"",",$7,$14,$18 }' | sed "s/,$//")
+        JAIL_PROTO=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'proto.*' | awk '{print $2}')
+        JAIL_HOST_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'port = [0-9]+' | awk '{print $3}')
+        JAIL_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | grep -Eo 'port [0-9]+$' | awk '{print $2}')
+        JAIL_PORTS=$(printf "%s/%s:%s"",",${JAIL_PROTO},${JAIL_HOST_PORT},${JAIL_PORT} | sed "s/,$//")
 
         # Get release (FreeBSD or Linux)
         if [ "${IS_FREEBSD_JAIL}" -eq 1 ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -254,7 +254,7 @@ get_jail_info() {
         JAIL_HOSTNAME=$(sed -n "s/^[ ]*host.hostname[ ]*=[ ]*\(.*\);$/\1/p" "${bastille_jailsdir}/${JAIL_NAME}/jail.conf" 2> /dev/null)
 
         # Get jail ports (inactive)
-        if [ -f "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf" ]; then JAIL_PORTS=$(awk '$1 ~ /^[tcp|udp]/ { printf "%s/%s:%s,",$1,$2,$3 }' "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf" 2> /dev/null | sed "s/,$//"); else JAIL_PORTS=""; fi
+        if [ -f "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf" ]; then JAIL_PORTS=$(awk '{ for(i=1; i<=NF; i++) if($i == "tcp" || $i == "udp") printf "%s/%s:%s ", $i, $(i+1), $(i+2) }' "${bastille_jailsdir}/${JAIL_NAME}/rdr.conf" 2> /dev/null | sed "s/,$//"); else JAIL_PORTS=""; fi
 
         # Get jail release (FreeBSD or Linux)
         if [ -n "${JAIL_PATH}" ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -220,12 +220,7 @@ get_jail_info() {
         JAIL_HOSTNAME=$(/usr/sbin/jls -j ${JAIL_NAME} host.hostname 2> /dev/null)
 
         # Get jail ports (active)
-        JAIL_PROTO=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'proto.*' | awk '{print $2}')
-        JAIL_HOST_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'port = [0-9]+' | awk '{print $3}')
-        JAIL_PORT=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2>/dev/null | grep -Eo 'port [0-9]+$' | awk '{print $2}')
-        if [ -n "${JAIL_PROTO}" ] && [ -n "${JAIL_HOST_PORT}" ] && [ -n "${JAIL_PORT}" ]; then
-            JAIL_PORTS=$(printf "%s/%s:%s"",",${JAIL_PROTO},${JAIL_HOST_PORT},${JAIL_PORT} | sed "s/,$//")
-        fi
+        JAIL_PORTS=$(pfctl -a "rdr/${JAIL_NAME}" -Psn 2> /dev/null | awk '{ printf "%s/%s:%s"",",$6,$13,$17 }' | sed "s/,$//")
 
         # Get release (FreeBSD or Linux)
         if [ "${IS_FREEBSD_JAIL}" -eq 1 ]; then

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -199,7 +199,7 @@ load_rdr_rule() {
     if [ -n "${JAIL_IP6}" ] && { [ "${inet}" = "ipv6" ] || [ "${inet}" = "dual" ]; } then
         if ! ( pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null;
             printf '%s\nrdr on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
-            | pfctl -a "bastille/${TARGET}" -f-; then
+            | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         fi
         if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -33,7 +33,7 @@
 . /usr/local/share/bastille/common.sh
 
 usage() {
-    error_notify "Usage: bastille rdr [option(s)] TARGET tcp|udp HOST_PORT JAIL_PORT [log LOG_OPTIONS]"
+    error_notify "Usage: bastille rdr [option(s)] TARGET tcp|udp HOST_PORT JAIL_PORT [log LOG,OPTIONS]"
     error_notify "                                TARGET clear|reset|list"
     cat << EOF
 
@@ -353,6 +353,7 @@ while [ "$#" -gt 0 ]; do
             else
                 check_jail_validity
                 pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null
+                pfctl -a "bastille/${TARGET}" -Psr 2>/dev/null
             fi
             shift
             ;;
@@ -364,6 +365,7 @@ while [ "$#" -gt 0 ]; do
             else
                 check_jail_validity
                 pfctl -a "rdr/${TARGET}" -Fn
+                pfctl -a "bastille/${TARGET}" -Fr
             fi
             shift
             ;;
@@ -375,6 +377,7 @@ while [ "$#" -gt 0 ]; do
             else
                 check_jail_validity
                 pfctl -a "rdr/${TARGET}" -Fn
+                pfctl -a "bastille/${TARGET}" -Fr
                 if rm -f "${bastille_jailsdir}/${TARGET}/rdr.conf"; then
                     info 2 "rdr.conf removed"
                 fi

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -81,7 +81,7 @@ check_jail_validity() {
     # Check if rdr-anchor is defined in pf.conf
     if ! (pfctl -sn | grep rdr-anchor | grep 'rdr/\*' >/dev/null); then
         error_exit "[ERROR]: rdr-anchor not found in pf.conf"
-    elif ! (pfctl -sn | grep anchor | grep 'bastille/\*' >/dev/null); then
+    elif ! (pfctl -sr | grep anchor | grep 'bastille/\*' >/dev/null); then
         error_exit "[ERROR]: bastille filtering achor not found in pf.conf"
     fi
 }

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -189,7 +189,7 @@ load_rdr_rule() {
             | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         fi
-        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+        if ! ( pfctl -a "bastille/${TARGET}" -Psr 2>/dev/null;
             printf '%s\npass in on $%s inet proto %s from %s to %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP" "$jail_port" ) \
             | pfctl -a "bastille/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv4 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
@@ -204,7 +204,7 @@ load_rdr_rule() {
             | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
         fi
-        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+        if ! ( pfctl -a "bastille/${TARGET}" -Psr 2>/dev/null;
             printf '%s\npass in on $%s inet6 proto %s from %s to %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "bastille/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv6 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -183,23 +183,31 @@ load_rdr_rule() {
     # shellcheck disable=SC2193
     if { [ "${inet}" = "ipv4" ] || [ "${inet}" = "dual" ]; } then
         if ! ( pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null;
-            printf '%s\nrdr pass on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
+            printf '%s\nrdr on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
             | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-        else
-            info 2 "IPv4 ${proto}/${host_port}:${jail_port} on ${if_raw}"
         fi
+        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+            printf '%s\npass in on $%s inet proto %s from %s to %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP" "$jail_port" ) \
+            | pfctl -a "bastille/${TARGET}" -f-; then
+            error_exit "[ERROR]: Failed to create IPv4 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        fi
+        info 2 "IPv4 ${proto}/${host_port}:${jail_port} on ${if_raw}"
     fi
     # Create IPv6 rdr rule (if ip6.addr is enabled)
     # shellcheck disable=SC2193
     if [ -n "${JAIL_IP6}" ] && { [ "${inet}" = "ipv6" ] || [ "${inet}" = "dual" ]; } then
-        if ! ( pfctl -a "rdr/${TARGET}" -Psn;
-            printf '%s\nrdr pass on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
-            | pfctl -a "rdr/${TARGET}" -f-; then
+        if ! ( pfctl -a "rdr/${TARGET}" -Psn 2>/dev/null;
+            printf '%s\nrdr on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            | pfctl -a "bastille/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-        else
-            info 2 "IPv6 ${proto}/${host_port}:${jail_port} on ${if_raw}"
         fi
+        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+            printf '%s\npass in on $%s inet6 proto %s from %s to %s port %s\n' "$if" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP6" "$jail_port" ) \
+            | pfctl -a "bastille/${TARGET}" -f-; then
+            error_exit "[ERROR]: Failed to create IPv6 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        fi
+        info 2 "IPv6 ${proto}/${host_port}:${jail_port} on ${if_raw}"
     fi
 }
 
@@ -277,14 +285,14 @@ while [ "$#" -gt 0 ]; do
             shift 2
             ;;
         -s|--source)
-	    if echo "${2}" | grep -Eoq "([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|.*:.*)"; then
-            check_rdr_ip_validity "${2}"
-            RDR_SRC="${2}"
-	    else
-            check_rdr_table_validity "${2}"
-            OPT_SRC_TABLE=1
-            RDR_SRC="$(echo "${2}" | sed -e 's/^/</' -e 's/$/>/')"
-	    fi
+            if echo "${2}" | grep -Eoq "([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|.*:.*)"; then
+                check_rdr_ip_validity "${2}"
+                RDR_SRC="${2}"
+            else
+                check_rdr_table_validity "${2}"
+                OPT_SRC_TABLE=1
+                RDR_SRC="$(echo "${2}" | sed -e 's/^/</' -e 's/$/>/')"
+            fi
             OPTION_SRC=1
             shift 2
             ;;
@@ -325,9 +333,7 @@ set_target_single "${TARGET}"
 
 while [ "$#" -gt 0 ]; do
     case "${1}" in
-
         list)
-
             if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
                 error_exit "[ERROR]: Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
@@ -338,9 +344,7 @@ while [ "$#" -gt 0 ]; do
             fi
             shift
             ;;
-
         clear)
-
             if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
                 error_exit "[ERROR]: Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
@@ -351,9 +355,7 @@ while [ "$#" -gt 0 ]; do
             fi
             shift
             ;;
-
         reset)
-
             if [ "${OPTION_IF}" -eq 1 ] || [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] || [ "${OPTION_INET_TYPE}" -eq 1 ];then
                 error_exit "[ERROR]: Command \"${1}\" cannot be used with options."
 	        elif [ -n "${2}" ]; then
@@ -367,9 +369,7 @@ while [ "$#" -gt 0 ]; do
             fi
             shift
             ;;
-
         tcp|udp)
-
             if [ "$#" -lt 3 ]; then
                 usage
             elif [ "${OPTION_SRC}" -eq 1 ] || [ "${OPTION_DST}" -eq 1 ] && [ "${OPTION_INET_TYPE}" -ne 1 ] && [ "${OPT_SRC_TABLE}" -eq 0 ];then
@@ -422,9 +422,7 @@ while [ "$#" -gt 0 ]; do
                 esac
             fi
             ;;
-
         *)
-
             if [ "${1}" = "dual" ] || [ "${1}" = "ipv4" ] || [ "${1}" = "ipv6" ]; then
                 RDR_INET="${1}"
             else

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -341,8 +341,6 @@ shift
 bastille_root_check
 set_target_single "${TARGET}"
 
-info 1 "[${TARGET}]:"
-
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         list)

--- a/usr/local/share/bastille/rdr.sh
+++ b/usr/local/share/bastille/rdr.sh
@@ -81,6 +81,8 @@ check_jail_validity() {
     # Check if rdr-anchor is defined in pf.conf
     if ! (pfctl -sn | grep rdr-anchor | grep 'rdr/\*' >/dev/null); then
         error_exit "[ERROR]: rdr-anchor not found in pf.conf"
+    elif ! (pfctl -sn | grep anchor | grep 'bastille/\*' >/dev/null); then
+        error_exit "[ERROR]: bastille filtering achor not found in pf.conf"
     fi
 }
 
@@ -229,24 +231,32 @@ load_rdr_log_rule() {
     # shellcheck disable=SC2193
     if { [ "${inet}" = "ipv4" ] || [ "${inet}" = "dual" ]; } then
         if ! ( pfctl -a "rdr/${TARGET}" -Psn;
-            printf '%s\nrdr pass %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
+            printf '%s\nrdr %s on $%s inet proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP" "$jail_port" ) \
             | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create logged IPv4 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-        else
-            info 2 "IPv4 ${proto}/${host_port}:${jail_port} on ${if_raw}"
         fi
+        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+            printf '%s\npass in %s on $%s inet proto %s from %s to %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP" "$jail_port" ) \
+            | pfctl -a "bastille/${TARGET}" -f-; then
+            error_exit "[ERROR]: Failed to create logged IPv4 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        fi
+        info 2 "IPv4 ${proto}/${host_port}:${jail_port} on ${if_raw}"
     fi
 
     # Create IPv6 rdr rule with log (if ip6.addr is enabled)
     # shellcheck disable=SC2193
     if [ -n "${JAIL_IP6}" ] && { [ "${inet}" = "ipv6" ] || [ "${inet}" = "dual" ]; } then
         if ! ( pfctl -a "rdr/${TARGET}" -Psn;
-            printf '%s\nrdr pass %s on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
+            printf '%s\nrdr %s on $%s inet6 proto %s from %s to %s port %s -> %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$dst" "$host_port" "$JAIL_IP6" "$jail_port" ) \
             | pfctl -a "rdr/${TARGET}" -f-; then
             error_exit "[ERROR]: Failed to create logged IPv6 rdr rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
-        else
-            info 2 "IPv6 ${proto}/${host_port}:${jail_port} on ${if_raw}"
         fi
+        if ! ( pfctl -a "bastille/${TARGET}" -Psn 2>/dev/null;
+            printf '%s\npass in %s on $%s inet6 proto %s from %s to %s port %s\n' "$if" "$log" "${bastille_network_pf_ext_if}" "$proto" "$src" "$JAIL_IP6" "$jail_port" ) \
+            | pfctl -a "bastille/${TARGET}" -f-; then
+            error_exit "[ERROR]: Failed to create logged IPv6 filter rule \"${if_name} ${src} ${dst} ${proto} ${host_port} ${jail_port}\""
+        fi
+        info 2 "IPv6 ${proto}/${host_port}:${jail_port} on ${if_raw}"
     fi
 }
 
@@ -330,6 +340,8 @@ shift
 
 bastille_root_check
 set_target_single "${TARGET}"
+
+info 1 "[${TARGET}]:"
 
 while [ "$#" -gt 0 ]; do
     case "${1}" in

--- a/usr/local/share/bastille/setup.sh
+++ b/usr/local/share/bastille/setup.sh
@@ -356,6 +356,8 @@ rdr-anchor "rdr/*"
 block in all
 pass out quick keep state
 antispoof for \$ext_if
+
+anchor "bastille/*"
 pass in proto tcp from any to any port ssh flags S/SA keep state
 ## Bastille firewall configuration - end
 EOF
@@ -384,6 +386,8 @@ rdr-anchor \"rdr/*\"\\
 block in all\\
 pass out quick keep state\\
 antispoof for \$ext_if\\
+\\
+anchor \"bastille/*\"\\
 pass in proto tcp from any to any port ssh flags S/SA keep state\\
 ## Bastille firewall configuration - end\\
 \\


### PR DESCRIPTION
Previous to this, rdr rules would always bypass all block rules because of the sturcture of the pf.conf file.

This PR addresses this by splitting it into two parts. The rdr anchor now simply handle the translation of the address, and the filtering anchor handles the actual passing of traffic. This should allow block rules to work properly.