### PR TITLE
feat(vm): add bhyve VM support as a jail peer (RFC/draft)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@ Christer Edwards [christer.edwards@gmail.com]
 - Eric Borisch
 - Kevet Duncombe
 - Victor Tschetter
+- Sasha Karcz
 
 ### Special thanks
 Software doesn't happen in a vacuum. Thank you to the following people who may

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -54,8 +54,8 @@ Verb reference
 - ``BOOTROM spec`` -- ``uefi`` (default), ``uefi-csm``, or a firmware path.
 - ``DISK name size [zfsprop=val ...]`` -- creates and attaches a virtio-blk
   zvol in declaration order.
-- ``NIC bridge`` -- creates a persistently named tap (``vm-<name>-<n>``) and
-  adds it to the named bridge (default: ``bastille_vm_bridge``).
+- ``NIC bridge`` attaches the guest NIC to the named bridge (default:
+  ``bastille_vm_bridge``). See "Networking modes" below.
 - ``ISO url|path`` -- attaches installation media as an ahci-cd device. Remote
   URLs are fetched into the Bastille cache.
 - ``ADDRESS ip`` -- records the guest address (required for ``RDR``).
@@ -64,6 +64,21 @@ Verb reference
 
 Jail-only verbs (``PKG``, ``SYSRC``, ``CP``, ``CMD``, ``SERVICE`` ...) are
 errors in a VM template; a template is one brand.
+
+Networking modes
+~~~~~~~~~~~~~~~~
+
+A VM's networking has two modes, chosen at create time the way jails choose
+theirs:
+
+- **shared** (default): the guest's tap is a member of the named host bridge,
+  the pattern vm-bhyve uses. Simple, and the guest address is configured inside
+  the guest.
+- **VNET** (``bastille create --vm -V``): the supervision jail becomes a VNET
+  jail, and the guest's tap lives inside the jail's own network stack, uplinked
+  to the host bridge through an epair. The host sees only the a-side of the
+  epair, so the VM's networking is fully contained in its jail, exactly like a
+  VNET jail. This is the mode that makes "a VM is a jail" complete.
 
 Lifecycle
 ---------

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -52,8 +52,13 @@ Verb reference
 - ``CPU n`` -- virtual CPU count (``bhyve -c``).
 - ``MEM size`` -- guest memory, e.g. ``8G`` (``bhyve -m``).
 - ``BOOTROM spec`` -- ``uefi`` (default), ``uefi-csm``, or a firmware path.
-- ``DISK name size [zfsprop=val ...]`` -- creates and attaches a virtio-blk
-  zvol in declaration order.
+- ``DISK name size [source=image] [zfsprop=val ...]`` creates and attaches a
+  virtio-blk zvol in declaration order. With ``source=<url or path>`` Bastille
+  populates the disk from a cloud/disk image at create time: a raw image is
+  written with ``dd`` (no dependency), a qcow2 image is converted straight onto
+  the zvol with ``qemu-img`` (``sysutils/qemu-tools``). This is how you boot a
+  pre-built cloud image and let cloud-init provision it, instead of installing
+  from an ISO.
 - ``NIC bridge`` attaches the guest NIC to the named bridge (default:
   ``bastille_vm_bridge``). See "Networking modes" below.
 - ``ISO url|path`` -- attaches installation media as an ahci-cd device. Remote
@@ -64,11 +69,17 @@ Verb reference
   (``alpine-virt-3.21.iso`` becomes ``Alpine-3.21``). Falls back to
   ``uefi-guest``.
 - ``CLOUDINIT file`` takes a path (relative to the template directory, or
-  absolute) to a cloud-init user-data file. Bastille builds a NoCloud ``CIDATA`` seed ISO
-  from it (plus an auto-generated meta-data with the VM's instance-id and
-  hostname) and attaches it as a CD. A cloud-init-enabled guest applies it at
-  first boot: users, SSH keys, packages, ``runcmd``, network, and so on. Uses
-  base ``makefs(8)``, no ports dependency.
+  absolute) to a cloud-init user-data file. Bastille builds a NoCloud ``CIDATA``
+  seed from it (plus an auto-generated meta-data with the VM's instance-id and
+  hostname) and attaches it as a virtio-blk disk. A cloud-init-enabled guest
+  applies it at first boot: users, SSH keys, packages, ``runcmd``, and so on.
+  Uses base ``makefs(8)``, no ports dependency. The seed is virtio-blk (not an
+  optical device) so it is visible when the guest's cloud-init ``ds-identify``
+  runs early in boot.
+- ``NETWORK_CONFIG file`` adds a cloud-init network-config (v1 or v2) to the
+  seed, so the guest gets a deterministic (for example static) address at first
+  boot. Renderer-agnostic: cloud-init applies it as netplan on Ubuntu or
+  systemd-networkd on Debian.
 - ``RDR proto host_port vm_port`` -- recorded for a future release; pf wiring
   for VMs is not yet enabled.
 

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -63,6 +63,12 @@ Verb reference
   (e.g. ``Ubuntu 24.04``). Optional; if omitted it is guessed from the ISO name
   (``alpine-virt-3.21.iso`` becomes ``Alpine-3.21``). Falls back to
   ``uefi-guest``.
+- ``CLOUDINIT file`` takes a path (relative to the template directory, or
+  absolute) to a cloud-init user-data file. Bastille builds a NoCloud ``CIDATA`` seed ISO
+  from it (plus an auto-generated meta-data with the VM's instance-id and
+  hostname) and attaches it as a CD. A cloud-init-enabled guest applies it at
+  first boot: users, SSH keys, packages, ``runcmd``, network, and so on. Uses
+  base ``makefs(8)``, no ports dependency.
 - ``RDR proto host_port vm_port`` -- recorded for a future release; pf wiring
   for VMs is not yet enabled.
 

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -78,8 +78,15 @@ Verb reference
   runs early in boot.
 - ``NETWORK_CONFIG file`` adds a cloud-init network-config (v1 or v2) to the
   seed, so the guest gets a deterministic (for example static) address at first
-  boot. Renderer-agnostic: cloud-init applies it as netplan on Ubuntu or
-  systemd-networkd on Debian.
+  boot. cloud-init renders it to whatever the guest uses: netplan or
+  systemd-networkd on Debian/Ubuntu, ifupdown (``/etc/network/interfaces``) on
+  Alpine. One portability caveat: the netplan-style ``match`` selector is only
+  honored by the netplan/networkd renderers. The ifupdown renderer uses the
+  ``ethernets`` key as the literal interface name, so for those guests name the
+  device directly (``eth0``) instead of a logical name plus ``match``. For
+  example, ``ethernets: {eth0: {addresses: [...]}}`` works everywhere, whereas
+  ``ethernets: {primary: {match: {name: "e*"}, ...}}`` only works on
+  netplan/networkd guests.
 - ``RDR proto host_port vm_port`` -- recorded for a future release; pf wiring
   for VMs is not yet enabled.
 

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -1,0 +1,121 @@
+Virtual Machines (bhyve)
+========================
+
+Bastille can manage `bhyve(8)` virtual machines as a peer instance type
+alongside jails. A VM is defined by a git-trackable template, provisioned with
+the existing template workflow, and driven by the same lifecycle verbs as
+jails: ``create``, ``start``, ``stop``, ``console``, ``list`` and ``destroy``.
+
+The goal is a single management plane for every workload on a FreeBSD host,
+whether it runs on the host kernel (a jail) or brings its own kernel (a VM).
+
+Requirements
+------------
+
+VM support is amd64-only and requires hardware virtualization (VT-x/EPT). On
+the host:
+
+.. code-block:: shell
+
+  pkg install edk2-bhyve
+  kldload vmm nmdm if_bridge if_tap
+
+VMs require ZFS. Set ``bastille_zfs_enable=YES`` and ``bastille_zfs_zpool`` in
+``bastille.conf``. See the ``VM (bhyve) options`` block in the sample config
+for the tunables (firmware path, default bridge, shutdown timeout, disk/NIC
+device models, and the supervision-jail devfs ruleset).
+
+The VM template
+---------------
+
+A VM template is an ordinary Bastille template whose ``Bastillefile`` opens
+with the ``VM`` verb. The verbs after it configure the guest rather than a
+jail:
+
+.. code-block:: shell
+
+  # Template: sasha/forgejo-runner-vm
+  VM
+  CPU 4
+  MEM 8G
+  BOOTROM uefi                 # uefi | uefi-csm | path to firmware
+  DISK disk0 40G               # name + size; a zvol is created on create
+  DISK disk1 200G volmode=dev  # extra disks; zfs props pass through
+  NIC bridge0                  # a tap is created and added to bridge0
+  ISO https://.../rocky-9.iso  # installation media (first boot)
+  ADDRESS 10.0.0.40            # guest address (used by RDR)
+
+Verb reference
+~~~~~~~~~~~~~~
+
+- ``VM`` -- switches the template into VM mode. Must be the first verb.
+- ``CPU n`` -- virtual CPU count (``bhyve -c``).
+- ``MEM size`` -- guest memory, e.g. ``8G`` (``bhyve -m``).
+- ``BOOTROM spec`` -- ``uefi`` (default), ``uefi-csm``, or a firmware path.
+- ``DISK name size [zfsprop=val ...]`` -- creates and attaches a virtio-blk
+  zvol in declaration order.
+- ``NIC bridge`` -- creates a persistently named tap (``vm-<name>-<n>``) and
+  adds it to the named bridge (default: ``bastille_vm_bridge``).
+- ``ISO url|path`` -- attaches installation media as an ahci-cd device. Remote
+  URLs are fetched into the Bastille cache.
+- ``ADDRESS ip`` -- records the guest address (required for ``RDR``).
+- ``RDR proto host_port vm_port`` -- recorded for a future release; pf wiring
+  for VMs is not yet enabled.
+
+Jail-only verbs (``PKG``, ``SYSRC``, ``CP``, ``CMD``, ``SERVICE`` ...) are
+errors in a VM template; a template is one brand.
+
+Lifecycle
+---------
+
+.. code-block:: shell
+
+  bastille create --vm builder sasha/forgejo-runner-vm
+  bastille start builder
+  bastille console builder        # serial console; detach with ~.
+  bastille list                   # VMs appear with Type 'vm'
+  bastille stop builder
+  bastille destroy builder
+
+``bastille list`` grows a VM row per VM with a ``Type`` column of ``vm``;
+``bastille list vms`` shows only VMs.
+
+How it works
+------------
+
+Each VM's ``bhyve`` process runs inside a minimal, auto-generated
+*supervision jail* with ``allow.vmm``. This gives the VM a real jail ID -- so
+``jls`` and ``rctl`` treat it as a peer of jails -- while layering jail
+confinement (namespace + rctl limits) on top of bhyve's Capsicum sandbox.
+
+.. note::
+
+   The v1 supervision jail uses ``path=/`` and shares the host's ``/dev``. A
+   restrictive per-VM devfs ruleset that exposes only the VM's own vmm/tap/nmdm
+   devices is the intended additional hardening, but it requires giving the
+   jail its own root so its ``/dev`` is isolated from the host's -- deferred to
+   a follow-up. The ``bastille_vm_devfs_ruleset`` config key is reserved for it.
+
+The instance layout mirrors a jail's:
+
+.. code-block:: text
+
+  ${bastille_vmdir}/<name>/
+    vm.conf          # canonical VM definition (edit this)
+    supervisor.conf  # generated supervision jail.conf
+    bhyve.args       # materialized bhyve(8) argument vector (read/diff this)
+    vm-run.sh        # generated supervisor entry point
+    settings.conf    # boot/priority (shared convention with jails)
+    console          # symlink to the nmdm console
+
+Disks are zvols under ``${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/<name>``
+so ``zfs snapshot -r`` of the Bastille tree stays meaningful and VMs inherit
+the clone/rollback story jails already enjoy.
+
+Status
+------
+
+This is an initial implementation. Suspend/resume, live migration, cloud-init
+seeding, graphical (VNC) consoles, Windows guests, and PCI passthrough are out
+of scope for this release. The ``bhyve.args`` file is the debuggable boundary
+between the manifest and the hypervisor: if a VM misbehaves, read and diff it.

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -171,11 +171,28 @@ confinement (namespace + rctl limits) on top of bhyve's Capsicum sandbox.
 
 .. note::
 
-   The v1 supervision jail uses ``path=/`` and shares the host's ``/dev``. A
-   restrictive per-VM devfs ruleset that exposes only the VM's own vmm/tap/nmdm
-   devices is the intended additional hardening, but it requires giving the
-   jail its own root so its ``/dev`` is isolated from the host's -- deferred to
-   a follow-up. The ``bastille_vm_devfs_ruleset`` config key is reserved for it.
+   **Supervision-jail hardening (on by default).** With
+   ``bastille_vm_isolated_devfs=YES`` (the default), the supervision jail runs
+   in its own root -- a read-only nullfs skeleton of only the userland bhyve
+   needs -- with a **private devfs** whose per-VM ruleset exposes just that
+   VM's own nodes: its ``vmm``/``vmm.io`` instance, ``nmdm`` console, tap, and
+   zvols, plus ``null``/``zero``/``random`` and ``pci`` (bhyve reads host PCI
+   config to build the guest's ACPI tables). ``/dev/mem``, ``/dev/kmem``, raw
+   host disks (``ada*``/``da*``/``nvme*``), and every other VM's nodes are
+   hidden, so a device-model escape sees one VM and nothing else. The jail also
+   gets its own vnet -- empty in shared mode (the guest's tap stays on the host
+   bridge and bhyve drives it through the ``/dev/tap`` node), full in VNET
+   mode -- so ``ifconfig`` inside it never shows host interfaces or other VMs'
+   taps. bhyve's own Capsicum sandbox composes on top. Set
+   ``bastille_vm_isolated_devfs=NO`` to fall back to a ``path=/`` jail that
+   shares the host ``/dev``.
+
+.. note::
+
+   VM disks are always created with ``volmode=dev``. A zvol left at the system
+   default (commonly ``geom``) is tasted by GEOM, and tasting a guest GPT can
+   panic the host kernel; avoid ``zfs set volmode=geom`` on a VM disk for the
+   same reason.
 
 The instance layout mirrors a jail's:
 

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -93,8 +93,17 @@ Lifecycle
   bastille start builder
   bastille console builder        # serial console; detach with ~.
   bastille list                   # VMs appear with Type 'vm'
+  bastille clone builder ci-1 10.0.0.41   # near-instant golden-image clone
   bastille stop builder
   bastille destroy builder
+
+Cloning is a ``zfs clone`` of the VM's zvols plus a manifest rewrite, so it is
+near-instant and space-efficient: provision one base VM, then clone it per
+worker. The clone shares unwritten blocks with the source (copy-on-write), so
+the source cannot be destroyed while clones of it exist, which is the correct
+golden-image behavior. The optional third argument sets the clone's ``ADDRESS``;
+the guest's in-VM network config is copied as-is and should be reconfigured
+inside the clone.
 
 ``bastille list`` grows a VM row per VM with a ``Type`` column of ``vm``;
 ``bastille list vms`` shows only VMs.

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -66,7 +66,11 @@ Verb reference
   ``bastille_vm_bridge``). See "Networking modes" below.
 - ``ISO url|path`` -- attaches installation media as an ahci-cd device. Remote
   URLs are fetched into the Bastille cache.
-- ``ADDRESS ip`` -- records the guest address (required for ``RDR``).
+- ``ADDRESS ip`` -- records the guest address in the manifest (used by ``RDR``
+  and the ``bastille list`` IP column). When a ``NETWORK_CONFIG`` is present the
+  address is derived from it, so you do not repeat it here. Use ``ADDRESS`` for
+  a guest with no cloud-init network-config (a DHCP or ISO-install VM) where you
+  still want the metadata recorded.
 - ``OS label`` -- guest OS label shown in the ``bastille list`` Release column
   (e.g. ``Ubuntu 24.04``). Optional; if omitted it is guessed from the ISO name
   (``alpine-virt-3.21.iso`` becomes ``Alpine-3.21``). Falls back to
@@ -81,7 +85,9 @@ Verb reference
   runs early in boot.
 - ``NETWORK_CONFIG file`` adds a cloud-init network-config (v1 or v2) to the
   seed, so the guest gets a deterministic (for example static) address at first
-  boot. cloud-init renders it to whatever the guest uses: netplan or
+  boot. Bastille derives the VM's ``ADDRESS`` metadata from the first address in
+  this file, so the guest's address is declared once, here, rather than repeated
+  in an ``ADDRESS`` verb. cloud-init renders it to whatever the guest uses: netplan or
   systemd-networkd on Debian/Ubuntu, ifupdown (``/etc/network/interfaces``) on
   Alpine. One portability caveat: the netplan-style ``match`` selector is only
   honored by the netplan/networkd renderers. The ifupdown renderer uses the

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -59,6 +59,10 @@ Verb reference
 - ``ISO url|path`` -- attaches installation media as an ahci-cd device. Remote
   URLs are fetched into the Bastille cache.
 - ``ADDRESS ip`` -- records the guest address (required for ``RDR``).
+- ``OS label`` -- guest OS label shown in the ``bastille list`` Release column
+  (e.g. ``Ubuntu 24.04``). Optional; if omitted it is guessed from the ISO name
+  (``alpine-virt-3.21.iso`` becomes ``Alpine-3.21``). Falls back to
+  ``uefi-guest``.
 - ``RDR proto host_port vm_port`` -- recorded for a future release; pf wiring
   for VMs is not yet enabled.
 

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -142,7 +142,20 @@ is refused if it is already in use, and both the ``network-config`` and the
 workflow. (Note: ``/etc/machine-id`` is still inherited from the source; a
 future ``--clean`` will reset it.)
 
-``bastille list`` grows a VM row per VM with a ``Type`` column of ``vm``;
+``bastille list`` grows a VM row per VM with a ``Type`` column of ``vm``. For a
+VM the ``Release`` column shows the guest's Linux distribution and version (the
+``OS`` label, or the value guessed from the ISO/image name), not a FreeBSD
+release, so jails and VMs read uniformly in one listing:
+
+.. code-block:: none
+
+   JID  Name      State  Type  IP Address     Release       Tags
+   3    nebula    Up     thin  192.168.1.56   15.0-RELEASE  -
+   7    debian12  Up     vm    192.168.1.229  Debian-12     -
+   8    alpine1   Up     vm    192.168.1.240  Alpine-3.21   -
+
+(columns trimmed for brevity). A VM with no ``OS`` label and no guessable image
+name falls back to ``uefi-guest`` (or ``uefi-csm`` for a CSM/BIOS guest).
 ``bastille list vms`` shows only VMs.
 
 How it works

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -125,9 +125,22 @@ Cloning is a ``zfs clone`` of the VM's zvols plus a manifest rewrite, so it is
 near-instant and space-efficient: provision one base VM, then clone it per
 worker. The clone shares unwritten blocks with the source (copy-on-write), so
 the source cannot be destroyed while clones of it exist, which is the correct
-golden-image behavior. The optional third argument sets the clone's ``ADDRESS``;
-the guest's in-VM network config is copied as-is and should be reconfigured
-inside the clone.
+golden-image behavior. By default the clone is an identical twin: the optional
+third argument sets the clone's ``ADDRESS`` metadata, but the guest's in-VM
+network config is copied as-is, so a plain clone should be reconfigured inside
+the clone to avoid an address conflict with the source.
+
+``--reseed`` makes the clone a distinct instance instead. It rebuilds the
+cloud-init seed with a fresh ``instance-id``, so cloud-init treats the clone as
+a new instance and re-runs its per-instance provisioning at first boot: it
+applies the new address (``bastille clone --reseed src new 10.0.0.42``), sets
+the hostname (``--hostname NAME``, default the clone name), re-applies users and
+SSH keys, and regenerates the guest's SSH host keys. A new ``--reseed`` address
+is refused if it is already in use, and both the ``network-config`` and the
+``ADDRESS`` metadata are updated together so they cannot diverge. This is the
+"stamp N distinct instances from one golden image at copy-on-write speed"
+workflow. (Note: ``/etc/machine-id`` is still inherited from the source; a
+future ``--clean`` will reset it.)
 
 ``bastille list`` grows a VM row per VM with a ``Type`` column of ``vm``;
 ``bastille list vms`` shows only VMs.

--- a/docs/chapters/vm.rst
+++ b/docs/chapters/vm.rst
@@ -18,7 +18,10 @@ the host:
 .. code-block:: shell
 
   pkg install edk2-bhyve
-  kldload vmm nmdm if_bridge if_tap
+  kldload vmm nmdm if_bridge if_tap if_epair
+
+(``if_epair`` is only needed for VNET-mode VMs; add these to
+``kld_list`` in ``/etc/rc.conf`` to load them at boot.)
 
 VMs require ZFS. Set ``bastille_zfs_enable=YES`` and ``bastille_zfs_zpool`` in
 ``bastille.conf``. See the ``VM (bhyve) options`` block in the sample config
@@ -193,7 +196,11 @@ the clone/rollback story jails already enjoy.
 Status
 ------
 
-This is an initial implementation. Suspend/resume, live migration, cloud-init
-seeding, graphical (VNC) consoles, Windows guests, and PCI passthrough are out
-of scope for this release. The ``bhyve.args`` file is the debuggable boundary
-between the manifest and the hypervisor: if a VM misbehaves, read and diff it.
+This is an initial implementation. Supported: the full create/start/stop/
+console/list/destroy/clone lifecycle, **shared and VNET networking** (see
+"Networking modes"), and **cloud-init seeding** (``CLOUDINIT`` user-data,
+``NETWORK_CONFIG``, ``DISK source=`` cloud-image import, and ``clone --reseed``;
+see the "Verb reference"). Suspend/resume, live migration, graphical (VNC)
+consoles, Windows guests, and PCI passthrough are out of scope for this release.
+The ``bhyve.args`` file is the debuggable boundary between the manifest and the
+hypervisor: if a VM misbehaves, read and diff it.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ https://docs.bastillebsd.org.
    chapters/template
    chapters/hardened-bsd
    chapters/linux-jails
+   chapters/vm
    chapters/pkgbase
    chapters/zfs-support
 

--- a/tests/vm-tests/alpine-vm/Bastillefile
+++ b/tests/vm-tests/alpine-vm/Bastillefile
@@ -1,0 +1,17 @@
+# Example Bastille VM template.
+#
+# A VM template is an ordinary template whose Bastillefile opens with the VM
+# verb. Apply it with:
+#
+#   bastille create --vm alpine tests/vm-tests/alpine-vm
+#
+# Requires: ZFS, sysutils/edk2-bhyve, and the vmm/nmdm/if_bridge/if_tap kmods.
+
+VM
+CPU 2
+MEM 2G
+BOOTROM uefi
+DISK disk0 20G
+NIC bridge0
+ADDRESS 10.0.0.40
+ISO https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-virt-3.20.0-x86_64.iso

--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -91,14 +91,14 @@ bastille_template_vnet="default/vnet"                                 ## default
 bastille_template_vlan="default/vlan"                                 ## default: "default/vlan"
 
 ## VM (bhyve) options
-## Requires: vmm(4), nmdm(4), if_bridge(4), if_tap(4) and sysutils/edk2-bhyve.
+## Requires: vmm(4), nmdm(4), if_bridge(4), if_tap(4), if_epair(4) (VNET) and sysutils/edk2-bhyve.
 bastille_vm_enable="NO"                                                                        ## default: "NO"
 bastille_vm_bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI.fd"                             ## default: edk2-bhyve UEFI firmware
 bastille_vm_bridge="bridge0"                                                                   ## default: bridge for VM NICs
 bastille_vm_shutdown_timeout="30"                                                              ## default: graceful ACPI poweroff timeout (seconds)
 bastille_vm_disk_type="virtio-blk"                                                             ## default: "virtio-blk" (or "ahci-hd", "nvme")
 bastille_vm_nic_type="virtio-net"                                                              ## default: "virtio-net" (or "e1000")
-bastille_vm_devfs_ruleset="100"                                                                ## reserved: devfs ruleset for future VM /dev isolation (unused in v1)
+bastille_vm_isolated_devfs="YES"                                                               ## default: "YES" (own jail root + restricted per-VM devfs + network isolation); "NO" shares host /dev
 
 ## Monitoring
 bastille_monitor_cron_path="/usr/local/etc/cron.d/bastille-monitor"                           ## default: "/usr/local/etc/cron.d/bastille-monitor"

--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -9,6 +9,7 @@ bastille_cachedir="${bastille_prefix}/cache"                          ## default
 bastille_jailsdir="${bastille_prefix}/jails"                          ## default: "${bastille_prefix}/jails"
 bastille_releasesdir="${bastille_prefix}/releases"                    ## default: "${bastille_prefix}/releases"
 bastille_templatesdir="${bastille_prefix}/templates"                  ## default: "${bastille_prefix}/templates"
+bastille_vmdir="${bastille_prefix}/vms"                               ## default: "${bastille_prefix}/vms"
 bastille_logsdir="/var/log/bastille"                                  ## default: "/var/log/bastille"
 
 ## PF firewall configuration path
@@ -88,6 +89,16 @@ bastille_template_clone="default/clone"                               ## default
 bastille_template_thin="default/thin"                                 ## default: "default/thin"
 bastille_template_vnet="default/vnet"                                 ## default: "default/vnet"
 bastille_template_vlan="default/vlan"                                 ## default: "default/vlan"
+
+## VM (bhyve) options
+## Requires: vmm(4), nmdm(4), if_bridge(4), if_tap(4) and sysutils/edk2-bhyve.
+bastille_vm_enable="NO"                                                                        ## default: "NO"
+bastille_vm_bootrom="/usr/local/share/uefi-firmware/BHYVE_UEFI.fd"                             ## default: edk2-bhyve UEFI firmware
+bastille_vm_bridge="bridge0"                                                                   ## default: bridge for VM NICs
+bastille_vm_shutdown_timeout="30"                                                              ## default: graceful ACPI poweroff timeout (seconds)
+bastille_vm_disk_type="virtio-blk"                                                             ## default: "virtio-blk" (or "ahci-hd", "nvme")
+bastille_vm_nic_type="virtio-net"                                                              ## default: "virtio-net" (or "e1000")
+bastille_vm_devfs_ruleset="100"                                                                ## reserved: devfs ruleset for future VM /dev isolation (unused in v1)
 
 ## Monitoring
 bastille_monitor_cron_path="/usr/local/etc/cron.d/bastille-monitor"                           ## default: "/usr/local/etc/cron.d/bastille-monitor"

--- a/usr/local/etc/rc.d/bastille
+++ b/usr/local/etc/rc.d/bastille
@@ -43,6 +43,16 @@ list_jails() {
         priority="$(sysrc -f ${jailsdir}/${jail}/settings.conf -n priority)"
         echo "${jail} ${priority}"
     done
+    # Include bhyve VMs so they boot/shut down alongside jails, ordered by
+    # the same priority setting. VM lifecycle brand-dispatches in bastille.
+    local vmdir=$(. $bastille_conf; echo ${bastille_vmdir:-${bastille_prefix}/vms})
+    if [ -n "${vmdir}" ] && [ -d "${vmdir}" ]; then
+        local vm_list=$(find ${vmdir}/* -mindepth 1 -maxdepth 1 -type f -name vm.conf 2>/dev/null | xargs -n1 dirname | xargs -n1 basename)
+        for vm in ${vm_list}; do
+            priority="$(sysrc -f ${vmdir}/${vm}/settings.conf -n priority)"
+            echo "${vm} ${priority}"
+        done
+    fi
 }
 
 sort_jails() {

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -372,6 +372,163 @@ vm_destroy_vnet() {
 }
 
 # ----------------------------------------------------------------------------
+# Supervision-jail hardening: skeleton root + restricted devfs (opt-in)
+#
+# Default (v1): the supervision jail uses path=/ and shares the host /dev.
+# With bastille_vm_isolated_devfs=YES the jail instead gets its own root -- a
+# read-only nullfs skeleton of just the host userland bhyve needs, plus a
+# private devfs whose per-VM ruleset exposes only this VM's nodes (its vmm
+# instance, console, disks, tap, and null/zero/random) and hides /dev/mem,
+# /dev/kmem, and raw host disks. A device-model escape then lands in a jail
+# that can reach one VM and nothing else. A dedicated root is required because
+# a restrictive devfs over path=/ would mask the host's own /dev (Phase 0).
+# ----------------------------------------------------------------------------
+
+# Read-only host dirs nullfs-mounted into the skeleton: rtld + libs + the
+# binaries the run script and bhyve exec (sh, cat, ifconfig, bhyve, bhyvectl,
+# daemon) + the UEFI firmware. None exposes /etc, /usr/home, or host secrets.
+BASTILLE_VM_SKEL_DIRS="/bin /sbin /lib /libexec /usr/lib /usr/sbin /usr/local/share"
+
+vm_hardened() {
+    ## True unless isolated-devfs hardening is explicitly disabled. Default on:
+    ## the supervision jail gets its own root and a restricted devfs. Set
+    ## bastille_vm_isolated_devfs=NO to fall back to the shared-host-/dev jail.
+    case "${bastille_vm_isolated_devfs:-YES}" in
+        [Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]|0) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+vm_jail_root() {
+    echo "${bastille_vmdir}/${1}/root"
+}
+
+vm_devfs_ruleset_num() {
+    ## Ruleset number for a VM's private devfs, assigned once and stored in the
+    ## manifest. VM rulesets live at/above 1000 to avoid the system (1-5) and
+    ## Bastille jail rulesets.
+    local vm_name="${1}"
+    local num="$(vm_get "${vm_name}" devfs_ruleset)"
+    if [ -z "${num}" ]; then
+        local used="$(devfs rule showsets 2>/dev/null)"
+        num=1000
+        while echo "${used}" | grep -qx "${num}"; do
+            num=$((num + 1))
+        done
+        vm_set "${vm_name}" devfs_ruleset "${num}"
+    fi
+    echo "${num}"
+}
+
+vm_load_devfs_ruleset() {
+    ## (Re)build the VM's devfs ruleset from the current tap/disk set: hide
+    ## everything, then unhide only this VM's nodes. Echoes the ruleset number.
+    local vm_name="${1}"
+    local rs="$(vm_devfs_ruleset_num "${vm_name}")"
+    local vms_ds="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}"
+
+    devfs rule -s "${rs}" delset >/dev/null 2>&1
+    devfs rule -s "${rs}" add hide >/dev/null 2>&1
+    local n
+    for n in null zero random urandom; do
+        devfs rule -s "${rs}" add path "${n}" unhide >/dev/null 2>&1
+    done
+    # bhyve reads host PCI config (/dev/pci) to locate the LPC bridge selector
+    # when building the guest's ACPI tables.
+    devfs rule -s "${rs}" add path pci unhide >/dev/null 2>&1
+    # bhyve control + this VM's vmm instance (vmmctl on releases that route VM
+    # creation through it).
+    devfs rule -s "${rs}" add path vmm unhide >/dev/null 2>&1
+    devfs rule -s "${rs}" add path "vmm/${vm_name}" unhide >/dev/null 2>&1
+    if [ -e /dev/vmmctl ]; then
+        devfs rule -s "${rs}" add path vmmctl unhide >/dev/null 2>&1
+    fi
+    # bhyve maps the bootrom (and, with a framebuffer, the fbuf) as devmem
+    # segments that appear under /dev/vmm.io/<name>.*; without them the guest
+    # cannot initialize its bootrom.
+    devfs rule -s "${rs}" add path vmm.io unhide >/dev/null 2>&1
+    devfs rule -s "${rs}" add path "vmm.io/${vm_name}.*" unhide >/dev/null 2>&1
+    # console. nmdm's cloned nodes only match a glob here (an exact
+    # nmdm-<name>.1A path does not unhide), so allow both this VM's ends; bhyve
+    # uses .1A, bastille console uses .1B.
+    devfs rule -s "${rs}" add path "nmdm-${vm_name}.*" unhide >/dev/null 2>&1
+    # this VM's taps.
+    local tap
+    for tap in $(cat "$(vm_taps_file "${vm_name}")" 2>/dev/null); do
+        devfs rule -s "${rs}" add path "${tap}" unhide >/dev/null 2>&1
+    done
+    # this VM's zvols: unhide each intermediate path component, then the leaf.
+    local acc="zvol" comp
+    devfs rule -s "${rs}" add path zvol unhide >/dev/null 2>&1
+    for comp in $(echo "${vms_ds}" | tr '/' ' '); do
+        acc="${acc}/${comp}"
+        devfs rule -s "${rs}" add path "${acc}" unhide >/dev/null 2>&1
+    done
+    devfs rule -s "${rs}" add path "${acc}/*" unhide >/dev/null 2>&1
+    echo "${rs}"
+}
+
+vm_setup_jail_root() {
+    ## Build the skeleton root and mount everything the hardened supervision
+    ## jail needs: ro-nullfs userland, the private restricted devfs, and the
+    ## runtime files (bhyve.args, vm-run.sh, seed) placed inside the root with
+    ## jail-relative paths. Idempotent enough to survive a re-start.
+    local vm_name="${1}"
+    local root="$(vm_jail_root "${vm_name}")"
+    local vmdir="${bastille_vmdir}/${vm_name}"
+
+    vm_teardown_jail_root "${vm_name}"
+    mkdir -p "${root}"
+    local d
+    for d in ${BASTILLE_VM_SKEL_DIRS}; do
+        mkdir -p "${root}${d}"
+        mount -t nullfs -o ro "${d}" "${root}${d}"
+    done
+
+    # Minimal /etc: jail(8) resolves the exec user (root) via getpwnam, which
+    # needs a passwd db in the jail. A generated one-user /etc keeps host
+    # secrets (master.passwd hashes, ssh keys) out of the jail entirely.
+    mkdir -p "${root}/etc"
+    printf 'root:*:0:0::0:0:root:/root:/bin/sh\n' > "${root}/etc/master.passwd"
+    printf 'wheel:*:0:root\n' > "${root}/etc/group"
+    pwd_mkdb -p -d "${root}/etc" "${root}/etc/master.passwd" >/dev/null 2>&1
+    # Writable /tmp: bhyve's ACPI table builder needs a temp file.
+    mkdir -p "${root}/tmp"
+    chmod 1777 "${root}/tmp"
+    mkdir -p "${root}/dev"
+    local rs="$(vm_load_devfs_ruleset "${vm_name}")"
+    mount -t devfs -o ruleset="${rs}" devfs "${root}/dev"
+
+    # Runtime files inside the root, with jail-relative paths (the seed is the
+    # only instance-dir path in bhyve.args; the firmware and zvols resolve via
+    # the nullfs firmware mount and the private devfs).
+    sed "s#${vmdir}/seed.iso#/seed.iso#g" "${vmdir}/bhyve.args" > "${root}/bhyve.args"
+    sed "s#${vmdir}/bhyve.args#/bhyve.args#g" "${vmdir}/vm-run.sh" > "${root}/vm-run.sh"
+    chmod 0700 "${root}/vm-run.sh"
+    if [ -f "${vmdir}/seed.iso" ]; then
+        cp "${vmdir}/seed.iso" "${root}/seed.iso"
+    fi
+}
+
+vm_teardown_jail_root() {
+    ## Unmount everything under the skeleton root (devfs and nullfs) so the
+    ## dataset is not busy at destroy, then drop the ruleset. Idempotent.
+    local vm_name="${1}"
+    local root="$(vm_jail_root "${vm_name}")"
+    if [ -d "${root}" ]; then
+        # Deepest mounts first.
+        local mp
+        for mp in $(mount | awk -v r="${root}/" '$3 ~ ("^" r) {print length($3), $3}' | sort -rn | awk '{print $2}'); do
+            umount -f "${mp}" >/dev/null 2>&1
+        done
+    fi
+    local rs="$(vm_get "${vm_name}" devfs_ruleset)"
+    if [ -n "${rs}" ]; then
+        devfs rule -s "${rs}" delset >/dev/null 2>&1
+    fi
+}
+
+# ----------------------------------------------------------------------------
 # bhyve argument generation
 # ----------------------------------------------------------------------------
 
@@ -479,9 +636,9 @@ while :; do
     # Destroy any prior vmm instance first. bhyve does not tear down
     # /dev/vmm/<name> on exit, so this must run before every boot -- including
     # a guest-requested reboot -- or the next bhyve would fail "already in use".
-    bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
+    /usr/sbin/bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
     # shellcheck disable=SC2046
-    bhyve \$(cat "\${args_file}")
+    /usr/sbin/bhyve \$(/bin/cat "\${args_file}")
     rc=\$?
     # 0 = guest requested reboot; anything else = power off / halt / error.
     if [ "\${rc}" -ne 0 ]; then
@@ -489,7 +646,7 @@ while :; do
     fi
 done
 
-bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
+/usr/sbin/bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
 EOF
     chmod 0700 "${run_script}"
 }
@@ -500,14 +657,11 @@ vm_generate_supervisor_conf() {
     ## guest RAM is accounted for, giving the VM a real JID that jls and rctl
     ## treat as a peer of jails.
     ##
-    ## NOTE: this v1 jail uses path=/ and shares the host's /dev. It does NOT
-    ## use mount.devfs + a restrictive devfs_ruleset: with path=/ that would
-    ## stack a locked-down devfs over the host's own /dev and hide host devices
-    ## (e.g. /dev/zfs). Proper devfs confinement -- a dedicated jail root with
-    ## its own isolated /dev exposing only this VM's vmm/tap/nmdm devices -- is
-    ## the intended hardening and is deferred until it can be validated on real
-    ## bhyve hardware. Confinement today is allow.vmm + rctl + the jail
-    ## namespace, layered on bhyve's own Capsicum sandbox.
+    ## Confinement is allow.vmm + rctl + the jail namespace, layered on bhyve's
+    ## own Capsicum sandbox. With hardening on (the default), the jail also gets
+    ## its own root and a private restricted devfs (see vm_setup_jail_root) that
+    ## exposes only this VM's nodes; with bastille_vm_isolated_devfs=NO it uses
+    ## path=/ and shares the host's /dev.
     local vm_name="${1}"
     local supervisor_conf="${bastille_vmdir}/${vm_name}/supervisor.conf"
     local run_script="${bastille_vmdir}/${vm_name}/vm-run.sh"
@@ -520,7 +674,15 @@ vm_generate_supervisor_conf() {
     # redirections detach the daemon subtree from jail -c's stdio so
     # 'bastille start' (and the rc.d boot pipeline) return promptly instead of
     # hanging on an inherited stdout pipe; bhyve output still goes to the -o log.
+    #
+    # Hardened: the jail root is the skeleton vm_setup_jail_root builds, and the
+    # run script, args, seed, and log live inside it at jail-relative paths.
+    local jail_path="/"
     local launch="/usr/sbin/daemon -o ${bastille_logsdir}/${vm_name}_vm.log /bin/sh ${run_script} </dev/null >/dev/null 2>&1"
+    if vm_hardened; then
+        jail_path="$(vm_jail_root "${vm_name}")"
+        launch="/usr/sbin/daemon -o /vm.log /bin/sh /vm-run.sh </dev/null >/dev/null 2>&1"
+    fi
 
     if [ "${network_type}" = "vnet" ]; then
         # VNET mode: the jail owns its network stack. Move each NIC's jail-side
@@ -541,7 +703,7 @@ vm_generate_supervisor_conf() {
                 iface_lines="${iface_lines}  vnet.interface += ${epair_b};
   vnet.interface += ${tap};
 "
-                bridge_lines="${bridge_lines}  exec.start += \"ifconfig bridge${nic} create && ifconfig bridge${nic} addm ${epair_b} addm ${tap} up && ifconfig ${epair_b} up && ifconfig ${tap} up\";
+                bridge_lines="${bridge_lines}  exec.start += \"/sbin/ifconfig bridge${nic} create && /sbin/ifconfig bridge${nic} addm ${epair_b} addm ${tap} up && /sbin/ifconfig ${epair_b} up && /sbin/ifconfig ${tap} up\";
 "
                 nic=$((nic + 1))
             done < "${epairs_file}"
@@ -551,7 +713,7 @@ vm_generate_supervisor_conf() {
 ${vm_name} {
   # Bastille bhyve supervision jail (generated, VNET mode).
   # This is an implementation detail; edit vm.conf, not this file.
-  path = /;
+  path = ${jail_path};
   host.hostname = ${vm_name};
   persist;
   allow.vmm;
@@ -567,11 +729,17 @@ EOF
 ${vm_name} {
   # Bastille bhyve supervision jail (generated, shared mode).
   # This is an implementation detail; edit vm.conf, not this file.
-  path = /;
+  path = ${jail_path};
   host.hostname = ${vm_name};
   persist;
   allow.vmm;
   enforce_statfs = 1;
+  # Own (empty) network stack. The guest's tap lives on the host bridge and
+  # bhyve drives it through its /dev/tap device node, so the supervision jail
+  # needs no host network visibility: this hides every host interface (and
+  # every other VM's tap) from a device-model escape, while the guest still
+  # sits directly on the shared bridge.
+  vnet;
   exec.clean;
   exec.start = "${launch}";
   exec.stop = "";
@@ -1020,10 +1188,19 @@ vm_start() {
     fi
     vm_render_artifacts "${vm_name}"
 
+    # Hardened (default): build the skeleton root and private restricted devfs,
+    # and place the runtime files inside it, before starting the jail.
+    if vm_hardened; then
+        vm_setup_jail_root "${vm_name}"
+    fi
+
     # Start the supervision jail; its exec.start execs the bhyve loop (and, for
     # VNET, first builds the in-jail bridge).
     if ! jail -f "${bastille_vmdir}/${vm_name}/supervisor.conf" -c "${vm_name}"; then
         error_notify "[ERROR]: Failed to start supervision jail: ${vm_name}"
+        if vm_hardened; then
+            vm_teardown_jail_root "${vm_name}"
+        fi
         if [ "${network_type}" = "vnet" ]; then
             vm_destroy_vnet "${vm_name}"
         else
@@ -1087,6 +1264,11 @@ vm_stop() {
         vm_destroy_taps "${vm_name}"
     fi
 
+    # Hardened: unmount the skeleton root and drop the devfs ruleset.
+    if vm_hardened; then
+        vm_teardown_jail_root "${vm_name}"
+    fi
+
     return 0
 }
 
@@ -1117,6 +1299,11 @@ vm_destroy() {
     if check_vm_is_running "${vm_name}"; then
         vm_stop "${vm_name}" 1
     fi
+
+    # Ensure the hardened skeleton root is fully unmounted before touching the
+    # dataset or directory: leftover nullfs/devfs mounts under it would make zfs
+    # destroy fail and, worse, let rm -rf traverse into host /bin or /dev.
+    vm_teardown_jail_root "${vm_name}"
 
     # Destroy zvol-backed disks.
     if checkyesno bastille_zfs_enable && [ -n "${bastille_zfs_zpool}" ]; then

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -242,6 +242,84 @@ vm_destroy_taps() {
     rm -f "$(vm_taps_file "${vm_name}")"
 }
 
+# VNET mode: instead of a host tap on a host bridge, the supervision jail is a
+# VNET jail and the guest's networking lives inside it. For each NIC we create
+# an epair (host side onto the named bridge) plus a guest tap; both the
+# jail-side epair and the tap are moved into the jail's own vnet at jail
+# creation and bridged together inside the jail (see vm_generate_supervisor_conf).
+# The host sees only the a-side of the epair, exactly like a VNET jail.
+
+vm_epairs_file() {
+    echo "${bastille_vmdir}/${1}/epairs"
+}
+
+vm_epair_list() {
+    ## One "epair_a epair_b" pair per NIC, in declaration order.
+    local epairs_file="$(vm_epairs_file "${1}")"
+    if [ -f "${epairs_file}" ]; then
+        cat "${epairs_file}"
+    fi
+}
+
+vm_create_vnet() {
+    ## Create the host-side interfaces for every NIC of a VNET VM. Records tap
+    ## names (for the bhyve argument vector) and epair pairs (for supervisor.conf
+    ## and teardown). The jail-side epair and the tap are moved into the jail's
+    ## vnet by the generated supervisor.conf at jail creation.
+    local vm_name="${1}"
+    local nics="$(vm_get "${vm_name}" nics)"
+    local taps_file="$(vm_taps_file "${vm_name}")"
+    local epairs_file="$(vm_epairs_file "${vm_name}")"
+
+    : > "${taps_file}"
+    : > "${epairs_file}"
+    local index=0
+    for bridge in ${nics}; do
+        if ! ifconfig -g bridge | grep -owq "${bridge}"; then
+            error_exit "[ERROR]: '${bridge}' is not a bridge interface."
+        fi
+        local epair_a="$(ifconfig epair create)"
+        if [ -z "${epair_a}" ]; then
+            error_exit "[ERROR]: Failed to create epair for VM: ${vm_name}"
+        fi
+        local epair_b="${epair_a%a}b"
+        ifconfig "${epair_a}" description "vm-${vm_name}-${index}: Bastille VM ${vm_name} nic${index} uplink" >/dev/null
+        ifconfig "${epair_a}" up >/dev/null
+        ifconfig "${bridge}" addm "${epair_a}" >/dev/null
+        local tap="$(ifconfig tap create)"
+        if [ -z "${tap}" ]; then
+            error_exit "[ERROR]: Failed to create tap for VM: ${vm_name}"
+        fi
+        ifconfig "${tap}" description "vm-${vm_name}-${index}: Bastille VM ${vm_name} nic${index}" >/dev/null
+        printf '%s\n' "${tap}" >> "${taps_file}"
+        printf '%s %s\n' "${epair_a}" "${epair_b}" >> "${epairs_file}"
+        index=$((index + 1))
+    done
+}
+
+vm_destroy_vnet() {
+    ## Tear down VNET interfaces. jail -r already destroys the jail's own vnet
+    ## interfaces (jail-side epair, tap, in-jail bridge); this cleans up the
+    ## host-side epair and any stragglers idempotently, then clears the files.
+    local vm_name="${1}"
+    local epairs_file="$(vm_epairs_file "${vm_name}")"
+    if [ -f "${epairs_file}" ]; then
+        while read -r epair_a epair_b; do
+            for iface in ${epair_a} ${epair_b}; do
+                if [ -n "${iface}" ] && ifconfig "${iface}" >/dev/null 2>&1; then
+                    ifconfig "${iface}" destroy >/dev/null 2>&1
+                fi
+            done
+        done < "${epairs_file}"
+    fi
+    for tap in $(vm_tap_list "${vm_name}"); do
+        if ifconfig "${tap}" >/dev/null 2>&1; then
+            ifconfig "${tap}" destroy >/dev/null 2>&1
+        fi
+    done
+    rm -f "$(vm_epairs_file "${vm_name}")" "$(vm_taps_file "${vm_name}")"
+}
+
 # ----------------------------------------------------------------------------
 # bhyve argument generation
 # ----------------------------------------------------------------------------
@@ -372,10 +450,55 @@ vm_generate_supervisor_conf() {
     local vm_name="${1}"
     local supervisor_conf="${bastille_vmdir}/${vm_name}/supervisor.conf"
     local run_script="${bastille_vmdir}/${vm_name}/vm-run.sh"
+    local network_type="$(vm_get "${vm_name}" network_type)"
+    : "${network_type:=shared}"
 
-    cat << EOF > "${supervisor_conf}"
+    # bhyve runs a foreground loop, so daemon(8) backgrounds it -- otherwise
+    # 'jail -c' would block until the guest powers off. bhyve stays confined to
+    # this jail because daemon(8) runs inside it. The </dev/null and >/dev/null
+    # redirections detach the daemon subtree from jail -c's stdio so
+    # 'bastille start' (and the rc.d boot pipeline) return promptly instead of
+    # hanging on an inherited stdout pipe; bhyve output still goes to the -o log.
+    local launch="/usr/sbin/daemon -o ${bastille_logsdir}/${vm_name}_vm.log /bin/sh ${run_script} </dev/null >/dev/null 2>&1"
+
+    if [ "${network_type}" = "vnet" ]; then
+        # VNET mode: the jail owns its network stack. Move each NIC's jail-side
+        # epair and tap into the vnet, then bridge them together inside the jail
+        # before launching bhyve. Interface names come from the runtime files
+        # written by vm_create_vnet, so they are known at render time.
+        local iface_lines=""
+        local bridge_lines=""
+        local taps_file="$(vm_taps_file "${vm_name}")"
+        local nic=0
+        while read -r epair_a epair_b; do
+            local tap="$(sed -n "$((nic + 1))p" "${taps_file}")"
+            iface_lines="${iface_lines}  vnet.interface += ${epair_b};
+  vnet.interface += ${tap};
+"
+            bridge_lines="${bridge_lines}  exec.start += \"ifconfig bridge${nic} create && ifconfig bridge${nic} addm ${epair_b} addm ${tap} up && ifconfig ${epair_b} up && ifconfig ${tap} up\";
+"
+            nic=$((nic + 1))
+        done < "$(vm_epairs_file "${vm_name}")"
+
+        cat << EOF > "${supervisor_conf}"
 ${vm_name} {
-  # Bastille bhyve supervision jail (generated).
+  # Bastille bhyve supervision jail (generated, VNET mode).
+  # This is an implementation detail; edit vm.conf, not this file.
+  path = /;
+  host.hostname = ${vm_name};
+  persist;
+  allow.vmm;
+  enforce_statfs = 1;
+  vnet;
+${iface_lines}  exec.clean;
+${bridge_lines}  exec.start += "${launch}";
+  exec.stop = "";
+}
+EOF
+    else
+        cat << EOF > "${supervisor_conf}"
+${vm_name} {
+  # Bastille bhyve supervision jail (generated, shared mode).
   # This is an implementation detail; edit vm.conf, not this file.
   path = /;
   host.hostname = ${vm_name};
@@ -383,16 +506,11 @@ ${vm_name} {
   allow.vmm;
   enforce_statfs = 1;
   exec.clean;
-  # bhyve runs a foreground loop, so daemon(8) backgrounds it -- otherwise
-  # 'jail -c' would block until the guest powers off. bhyve stays confined to
-  # this jail because daemon(8) itself runs inside it. The </dev/null and
-  # >/dev/null redirections detach the daemon subtree from jail -c's stdio so
-  # 'bastille start' (and the rc.d boot pipeline) return promptly instead of
-  # hanging on an inherited stdout pipe; bhyve output still goes to the -o log.
-  exec.start = "/usr/sbin/daemon -o ${bastille_logsdir}/${vm_name}_vm.log /bin/sh ${run_script} </dev/null >/dev/null 2>&1";
+  exec.start = "${launch}";
   exec.stop = "";
 }
 EOF
+    fi
 }
 
 # ----------------------------------------------------------------------------
@@ -481,6 +599,7 @@ vm_create() {
     ## backing zvols. Networking taps are created lazily at start time.
     local vm_name="${1}"
     local template="${2}"
+    local network_type="${3:-shared}"
     local template_dir="${bastille_templatesdir}/${template}"
     local bastillefile="${template_dir}/Bastillefile"
     local vmdir="${bastille_vmdir}/${vm_name}"
@@ -617,6 +736,7 @@ vm_create() {
     vm_set "${vm_name}" nics "${M_NICS}"
     vm_set "${vm_name}" iso "${M_ISO}"
     vm_set "${vm_name}" address "${M_ADDRESS}"
+    vm_set "${vm_name}" network_type "${network_type}"
 
     # Boot/priority settings shared with the jail convention.
     sysrc -f "${vmdir}/settings.conf" boot="${BOOT:-on}" >/dev/null
@@ -669,16 +789,29 @@ vm_start() {
         return 1
     fi
 
-    # Create taps first so their tapN names flow into the bhyve argument
-    # vector, then regenerate artifacts (honors manifest edits). Order matters:
-    # vm_generate_args reads the taps runtime file.
-    vm_create_taps "${vm_name}"
+    local network_type="$(vm_get "${vm_name}" network_type)"
+    : "${network_type:=shared}"
+
+    # Create host-side interfaces first so their names flow into the bhyve
+    # argument vector (and, for VNET, the supervisor.conf), then regenerate
+    # artifacts (honors manifest edits). Order matters: vm_generate_args and the
+    # VNET supervisor.conf read the taps/epairs runtime files.
+    if [ "${network_type}" = "vnet" ]; then
+        vm_create_vnet "${vm_name}"
+    else
+        vm_create_taps "${vm_name}"
+    fi
     vm_render_artifacts "${vm_name}"
 
-    # Start the supervision jail; its exec.start execs the bhyve loop.
+    # Start the supervision jail; its exec.start execs the bhyve loop (and, for
+    # VNET, first builds the in-jail bridge).
     if ! jail -f "${bastille_vmdir}/${vm_name}/supervisor.conf" -c "${vm_name}"; then
         error_notify "[ERROR]: Failed to start supervision jail: ${vm_name}"
-        vm_destroy_taps "${vm_name}"
+        if [ "${network_type}" = "vnet" ]; then
+            vm_destroy_vnet "${vm_name}"
+        else
+            vm_destroy_taps "${vm_name}"
+        fi
         return 1
     fi
 
@@ -729,9 +862,13 @@ vm_stop() {
         jail -f "${bastille_vmdir}/${vm_name}/supervisor.conf" -r "${vm_name}" >/dev/null 2>&1
     fi
 
-    # Destroy the vmm instance and tear down taps.
+    # Destroy the vmm instance and tear down networking.
     bhyvectl --destroy --vm="${vm_name}" >/dev/null 2>&1
-    vm_destroy_taps "${vm_name}"
+    if [ "$(vm_get "${vm_name}" network_type)" = "vnet" ]; then
+        vm_destroy_vnet "${vm_name}"
+    else
+        vm_destroy_taps "${vm_name}"
+    fi
 
     return 0
 }

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -978,3 +978,102 @@ vm_destroy() {
 
     return 0
 }
+
+vm_clone() {
+    ## Clone a VM. Per the design, this is a `zfs clone` of the source's zvols
+    ## (near-instant, copy-on-write) plus a manifest rewrite, which is the
+    ## golden-image workflow the whole storage model exists for. The clone's
+    ## disks share unwritten blocks with the source until either diverges, so a
+    ## clone depends on a snapshot of the source (standard ZFS COW, the same as
+    ## `bastille create -C` clone jails): the source cannot be destroyed while
+    ## clones of it exist, which is the correct golden-image semantics.
+    local target="${1}"
+    local newname="${2}"
+    local new_address="${3}"
+    local auto="${4}"
+    local live="${5}"
+    local src_dir="${bastille_vmdir}/${target}"
+    local dst_dir="${bastille_vmdir}/${newname}"
+    local src_ds="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${target}"
+    local dst_ds="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${newname}"
+
+    # Validate the new name.
+    if check_vm_exists "${newname}"; then
+        error_exit "[ERROR]: VM already exists: ${newname}"
+    elif check_target_exists "${newname}"; then
+        error_exit "[ERROR]: A jail already exists with that name: ${newname}"
+    elif [ "$(echo "${newname}" | tr -c -d 'a-zA-Z0-9-_')" != "${newname}" ]; then
+        error_exit "[ERROR]: VM names may not contain special characters!"
+    elif echo "${newname}" | grep -qE '^[0-9]+$'; then
+        error_exit "[ERROR]: VM names may not contain only digits."
+    fi
+
+    if ! checkyesno bastille_zfs_enable || [ -z "${bastille_zfs_zpool}" ]; then
+        error_exit "[ERROR]: VM clone requires ZFS."
+    fi
+
+    # State: stopped (or -a to auto-stop, or -l to clone a running VM).
+    if [ "${live}" = "1" ]; then
+        if ! check_vm_is_running "${target}"; then
+            error_exit "[ERROR]: [-l|--live] can only be used with a running VM."
+        fi
+    elif check_vm_is_running "${target}"; then
+        if [ "${auto}" = "1" ]; then
+            bastille stop "${target}"
+        else
+            error_notify "VM is running."
+            error_exit "Use [-a|--auto] to auto-stop, or [-l|--live] (crash-consistent) to clone a running VM."
+        fi
+    fi
+
+    info 1 "\nCloning VM '${target}' to '${newname}'..."
+
+    # New instance dataset to hold the cloned manifest and config.
+    if ! zfs create "${dst_ds}"; then
+        error_exit "[ERROR]: Failed to create clone dataset: ${dst_ds}"
+    fi
+    mkdir -p "${dst_dir}"
+    chmod 0700 "${dst_dir}"
+
+    # Manifest rewrite: copy vm.conf and boot/priority settings.
+    cp "${src_dir}/vm.conf" "${dst_dir}/vm.conf"
+    if [ -f "${src_dir}/settings.conf" ]; then
+        cp "${src_dir}/settings.conf" "${dst_dir}/settings.conf"
+    fi
+
+    # Copy-on-write clone of each disk.
+    local snap="bastille_clone_${newname}_$(date +%F-%H%M%S)"
+    local disks="$(vm_get "${target}" disks)"
+    for spec in ${disks}; do
+        local disk="$(echo "${spec}" | awk -F: '{print $1}')"
+        if ! zfs snapshot "${src_ds}/${disk}@${snap}" || \
+           ! zfs clone "${src_ds}/${disk}@${snap}" "${dst_ds}/${disk}"; then
+            error_notify "[ERROR]: Failed to clone disk: ${disk}"
+            zfs destroy -rf "${dst_ds}" >/dev/null 2>&1
+            zfs destroy "${src_ds}/${disk}@${snap}" >/dev/null 2>&1
+            return 1
+        fi
+    done
+
+    # Optional new address for the clone (the ADDRESS field is RDR metadata).
+    if [ -n "${new_address}" ]; then
+        vm_set "${newname}" address "${new_address}"
+    fi
+
+    # Regenerate name-specific artifacts and the console symlink for the clone.
+    ln -sf "$(vm_nmdm_client "${newname}")" "${dst_dir}/console"
+    vm_render_artifacts "${newname}"
+
+    info 1 "Cloned '${target}' to '${newname}' successfully."
+    info 1 "Note: the guest's in-VM network config is copied as-is; reconfigure"
+    info 1 "it inside the clone to avoid an address conflict with '${target}'."
+
+    if [ "${auto}" = "1" ]; then
+        bastille start "${target}"
+        bastille start "${newname}"
+    elif [ "${live}" = "1" ]; then
+        bastille start "${newname}"
+    fi
+
+    return 0
+}

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -164,6 +164,11 @@ vm_create_disk() {
 
     if zfs list "${dataset}" >/dev/null 2>&1; then
         info 2 "Disk already exists: ${dataset}"
+        # Enforce volmode=dev even on a pre-existing disk. A VM zvol left at the
+        # system default (commonly geom) is exposed to GEOM, and GEOM tasting a
+        # guest GPT can panic the host kernel (g_label_taste). VM disks must
+        # never appear as GEOM providers.
+        zfs set volmode=dev "${dataset}" >/dev/null 2>&1
         return 0
     fi
 

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -876,6 +876,15 @@ vm_guess_os_from_iso() {
     fi
 }
 
+vm_netconfig_address() {
+    ## First IPv4 address (bare, no /prefix) declared in a cloud-init
+    ## network-config (v1 'address:' or v2 'addresses:'). Used to derive the
+    ## ADDRESS metadata so the guest's address lives in exactly one place.
+    local file="${1}"
+    grep -E '^[[:space:]]*(addresses|address):' "${file}" 2>/dev/null \
+        | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -1
+}
+
 vm_build_cloudinit_seed() {
     ## Build a NoCloud "cidata" seed ISO using base makefs(8) (no ports
     ## dependency). It always carries an auto-generated meta-data, plus the
@@ -1096,6 +1105,32 @@ vm_create() {
     mkdir -p "${vmdir}"
     chmod 0700 "${vmdir}"
 
+    # Resolve cloud-init file paths (relative to the template dir unless
+    # absolute) up front: the ADDRESS metadata is derived from the
+    # network-config below.
+    case "${M_CLOUDINIT}" in
+        ""|/*) : ;;
+        *) M_CLOUDINIT="${template_dir}/${M_CLOUDINIT}" ;;
+    esac
+    case "${M_NETCONFIG}" in
+        ""|/*) : ;;
+        *) M_NETCONFIG="${template_dir}/${M_NETCONFIG}" ;;
+    esac
+
+    # The guest address lives in one place. A network-config, when present, is
+    # authoritative (it is what actually configures the guest), so derive the
+    # ADDRESS metadata from it rather than repeating the IP in an ADDRESS verb.
+    # Warn if both were given and disagree.
+    if [ -n "${M_NETCONFIG}" ] && [ -f "${M_NETCONFIG}" ]; then
+        local nc_addr="$(vm_netconfig_address "${M_NETCONFIG}")"
+        if [ -n "${nc_addr}" ]; then
+            if [ -n "${M_ADDRESS}" ] && [ "${M_ADDRESS}" != "${nc_addr}" ]; then
+                warn 1 "[WARNING]: ADDRESS (${M_ADDRESS}) differs from the network-config address (${nc_addr}); using the network-config."
+            fi
+            M_ADDRESS="${nc_addr}"
+        fi
+    fi
+
     vm_set "${vm_name}" version "1"
     vm_set "${vm_name}" cpu "${M_CPU}"
     vm_set "${vm_name}" memory "${M_MEM}"
@@ -1141,17 +1176,8 @@ vm_create() {
     fi
 
     # Build the cloud-init NoCloud seed if the template declared user-data
-    # and/or network-config. Resolve paths relative to the template directory
-    # unless absolute.
+    # and/or network-config (paths were resolved above).
     if [ -n "${M_CLOUDINIT}" ] || [ -n "${M_NETCONFIG}" ]; then
-        case "${M_CLOUDINIT}" in
-            ""|/*) : ;;
-            *) M_CLOUDINIT="${template_dir}/${M_CLOUDINIT}" ;;
-        esac
-        case "${M_NETCONFIG}" in
-            ""|/*) : ;;
-            *) M_NETCONFIG="${template_dir}/${M_NETCONFIG}" ;;
-        esac
         vm_build_cloudinit_seed "${vm_name}" "${M_CLOUDINIT}" "${M_NETCONFIG}"
     fi
 

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -101,11 +101,10 @@ vm_nmdm_client() {
     echo "/dev/nmdm-${1}.1B"
 }
 
-# NOTE: A restrictive devfs ruleset for the supervision jail is deliberately
-# NOT applied in v1. With path=/ (see vm_generate_supervisor_conf) a
-# mount.devfs would stack over the host's own /dev and hide host devices such
-# as /dev/zfs. Isolating the VM's /dev requires a dedicated jail root, which is
-# deferred; the config key bastille_vm_devfs_ruleset is reserved for that work.
+# NOTE: the supervision jail's /dev is confined by default (its own root plus a
+# private per-VM devfs; see the hardening section below and the config key
+# bastille_vm_isolated_devfs). Setting that to NO falls back to a path=/ jail
+# sharing the host /dev.
 
 # ----------------------------------------------------------------------------
 # Disk (zvol) lifecycle
@@ -372,16 +371,19 @@ vm_destroy_vnet() {
 }
 
 # ----------------------------------------------------------------------------
-# Supervision-jail hardening: skeleton root + restricted devfs (opt-in)
+# Supervision-jail hardening: skeleton root + restricted devfs (default on)
 #
-# Default (v1): the supervision jail uses path=/ and shares the host /dev.
-# With bastille_vm_isolated_devfs=YES the jail instead gets its own root -- a
-# read-only nullfs skeleton of just the host userland bhyve needs, plus a
-# private devfs whose per-VM ruleset exposes only this VM's nodes (its vmm
-# instance, console, disks, tap, and null/zero/random) and hides /dev/mem,
-# /dev/kmem, and raw host disks. A device-model escape then lands in a jail
-# that can reach one VM and nothing else. A dedicated root is required because
-# a restrictive devfs over path=/ would mask the host's own /dev (Phase 0).
+# By default (bastille_vm_isolated_devfs=YES) the supervision jail gets its own
+# root -- a read-only nullfs skeleton of just the host userland bhyve needs, a
+# minimal generated /etc, and a writable /tmp -- plus a private devfs whose
+# per-VM ruleset exposes only this VM's nodes (its vmm/vmm.io instance, nmdm
+# console, disks, tap, and null/zero/random/urandom + pci for ACPI) and hides
+# /dev/mem, /dev/kmem, raw host disks, and every other VM. The jail also gets
+# its own vnet (empty in shared mode, full in VNET mode), so it sees no host
+# interfaces. A device-model escape then lands in a jail that can reach one VM
+# and nothing else. Set bastille_vm_isolated_devfs=NO to fall back to a path=/
+# jail sharing the host /dev; a dedicated root is required because a restrictive
+# devfs over path=/ would mask the host's own /dev (Phase 0).
 # ----------------------------------------------------------------------------
 
 # Read-only host dirs nullfs-mounted into the skeleton: rtld + libs + the

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -594,6 +594,41 @@ vm_fetch_iso() {
     esac
 }
 
+vm_guess_os_from_iso() {
+    ## Best-effort guest OS label from an install ISO's name, shown in
+    ## 'bastille list' instead of a generic "uefi-guest". The result is a
+    ## single whitespace-free token (like "15.0-RELEASE" for jails) so it does
+    ## not break the JSON/columnar output. Returns empty if nothing recognized.
+    local iso="${1}"
+    [ -n "${iso}" ] || return 0
+    local base="$(basename "${iso}" | tr '[:upper:]' '[:lower:]')"
+    local name=""
+    case "${base}" in
+        *alpine*)   name="Alpine" ;;
+        *ubuntu*)   name="Ubuntu" ;;
+        *debian*)   name="Debian" ;;
+        *rocky*)    name="Rocky" ;;
+        *alma*)     name="AlmaLinux" ;;
+        *fedora*)   name="Fedora" ;;
+        *centos*)   name="CentOS" ;;
+        *freebsd*)  name="FreeBSD" ;;
+        *arch*)     name="Arch" ;;
+        *opensuse*|*suse*) name="openSUSE" ;;
+        *) return 0 ;;
+    esac
+    # Arch is rolling; its "version" is a date, so leave it unversioned.
+    if [ "${name}" = "Arch" ]; then
+        echo "${name}"
+        return 0
+    fi
+    local ver="$(echo "${base}" | grep -Eo '[0-9]+(\.[0-9]+)?' | head -1)"
+    if [ -n "${ver}" ]; then
+        echo "${name}-${ver}"
+    else
+        echo "${name}"
+    fi
+}
+
 vm_create() {
     ## Render a VM template into an authoritative manifest, then create the
     ## backing zvols. Networking taps are created lazily at start time.
@@ -616,6 +651,7 @@ vm_create() {
     local M_NICS=""
     local M_ISO=""
     local M_ADDRESS=""
+    local M_OS=""
     local RDR_RULES=""
     local seen_vm=0
 
@@ -680,6 +716,11 @@ vm_create() {
             ADDRESS)
                 M_ADDRESS="$(echo "${args}" | awk '{print $1}')"
                 ;;
+            OS)
+                # Human label for the guest OS shown in 'bastille list'
+                # (e.g. "Ubuntu 24.04"). Overrides the guess from the ISO name.
+                M_OS="${args}"
+                ;;
             RDR)
                 RDR_RULES="${RDR_RULES}${args}
 "
@@ -737,6 +778,15 @@ vm_create() {
     vm_set "${vm_name}" iso "${M_ISO}"
     vm_set "${vm_name}" address "${M_ADDRESS}"
     vm_set "${vm_name}" network_type "${network_type}"
+
+    # Guest OS label for 'bastille list' (Release column). Prefer an explicit
+    # OS verb, else guess from the ISO name. Collapse whitespace to a single
+    # token so it never breaks the columnar/JSON output.
+    if [ -z "${M_OS}" ]; then
+        M_OS="$(vm_guess_os_from_iso "${M_ISO}")"
+    fi
+    M_OS="$(echo "${M_OS}" | tr -s ' ' '-' | sed 's/^-//;s/-$//')"
+    vm_set "${vm_name}" os "${M_OS}"
 
     # Boot/priority settings shared with the jail convention.
     sysrc -f "${vmdir}/settings.conf" boot="${BOOT:-on}" >/dev/null

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -1317,6 +1317,23 @@ vm_destroy() {
     # destroy fail and, worse, let rm -rf traverse into host /bin or /dev.
     vm_teardown_jail_root "${vm_name}"
 
+    # Wait out the teardown race. jail -r signals the supervisor's bhyve/sh
+    # processes but returns before they exit, and for a hardened VM their cwd is
+    # on this instance dataset, so an immediate zfs destroy fails "busy". Wait
+    # for the dataset to be released, then force any straggler.
+    local vmdir="${bastille_vmdir}/${vm_name}"
+    local waited=0
+    while [ "${waited}" -lt 10 ] && [ -n "$(fuser -c "${vmdir}" 2>/dev/null)" ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    local holders="$(fuser -c "${vmdir}" 2>/dev/null | tr -cs '0-9' ' ')"
+    if [ -n "${holders}" ]; then
+        # shellcheck disable=SC2086
+        kill -9 ${holders} >/dev/null 2>&1
+        sleep 1
+    fi
+
     # Destroy zvol-backed disks.
     if checkyesno bastille_zfs_enable && [ -n "${bastille_zfs_zpool}" ]; then
         local dataset="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}"

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -174,6 +174,52 @@ vm_create_disk() {
     fi
 }
 
+vm_write_disk_image() {
+    ## Populate a VM disk from a cloud/disk image (the DISK 'source=' option).
+    ## This is what makes cloud-init useful: you boot a pre-built cloud image and
+    ## cloud-init provisions it, rather than installing from an ISO. Raw images
+    ## are written with dd (no dependency); qcow2 images are converted straight
+    ## onto the zvol with qemu-img (sysutils/qemu-tools) when available.
+    local vm_name="${1}"
+    local disk="${2}"
+    local source="${3}"
+    local device="$(vm_disk_device "${vm_name}" "${disk}")"
+
+    # Fetch remote images into the cache (mirrors the ISO caching posture).
+    case "${source}" in
+        http://*|https://*|ftp://*)
+            local img_cache="${bastille_cachedir}/img"
+            local img_path="${img_cache}/$(basename "${source}")"
+            if [ ! -f "${img_path}" ]; then
+                mkdir -p "${img_cache}"
+                info 1 "Fetching disk image: ${source}"
+                if ! fetch -o "${img_path}" "${source}"; then
+                    error_exit "[ERROR]: Failed to fetch disk image: ${source}"
+                fi
+            fi
+            source="${img_path}"
+            ;;
+    esac
+    if [ ! -f "${source}" ]; then
+        error_exit "[ERROR]: Disk image not found: ${source}"
+    fi
+
+    info 1 "Writing image to ${disk}: $(basename "${source}")"
+    # qcow2 magic is "QFI\xfb" (51 46 49 fb); anything else is treated as raw.
+    if [ "$(head -c 4 "${source}" 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "514649fb" ]; then
+        if ! command -v qemu-img >/dev/null 2>&1; then
+            error_exit "[ERROR]: qcow2 image needs sysutils/qemu-tools (qemu-img); use a raw image or install it."
+        fi
+        if ! qemu-img convert -O raw "${source}" "${device}"; then
+            error_exit "[ERROR]: Failed to write qcow2 image to ${disk}."
+        fi
+    else
+        if ! dd if="${source}" of="${device}" bs=1m conv=sync status=none 2>/dev/null; then
+            error_exit "[ERROR]: Failed to write raw image to ${disk}."
+        fi
+    fi
+}
+
 # ----------------------------------------------------------------------------
 # tap / bridge lifecycle
 #
@@ -389,10 +435,13 @@ vm_generate_args() {
             slot=$((slot + 1))
         fi
 
-        # cloud-init NoCloud seed (a CIDATA CD the guest reads at first boot).
+        # cloud-init NoCloud seed, presented as a virtio-blk disk labeled
+        # CIDATA. virtio-blk is in the guest initramfs (same as the boot disk),
+        # so cloud-init's ds-identify sees the seed early enough; an AHCI/optical
+        # device can be probed too late in boot to be detected.
         local seed="${bastille_vmdir}/${vm_name}/seed.iso"
         if [ -f "${seed}" ]; then
-            printf '%s\n' "-s ${slot},ahci-cd,${seed}"
+            printf '%s\n' "-s ${slot},virtio-blk,${seed}"
             slot=$((slot + 1))
         fi
 
@@ -643,27 +692,45 @@ vm_guess_os_from_iso() {
 }
 
 vm_build_cloudinit_seed() {
-    ## Build a NoCloud "cidata" seed ISO from a user-data file plus an
-    ## auto-generated meta-data, using base makefs(8) (no ports dependency). A
-    ## cloud-init-enabled guest reads it from the attached CD at first boot and
-    ## applies it (users, SSH keys, packages, runcmd, network, and so on).
+    ## Build a NoCloud "cidata" seed ISO using base makefs(8) (no ports
+    ## dependency). It always carries an auto-generated meta-data, plus the
+    ## user-data and/or network-config the template declared. A cloud-init guest
+    ## reads it from the attached CD at first boot and applies it: users, SSH
+    ## keys, packages, runcmd, and (renderer-agnostic) network configuration.
     local vm_name="${1}"
     local userdata="${2}"
+    local netconfig="${3}"
     local vmdir="${bastille_vmdir}/${vm_name}"
 
-    if [ ! -f "${userdata}" ]; then
-        error_exit "[ERROR]: cloud-init user-data not found: ${userdata}"
-    fi
-
     local seed_dir="$(mktemp -d "/tmp/bastille-cidata-${vm_name}.XXXXXX")"
-    # Keep an inspectable copy of the user-data with the VM (a debuggable
-    # boundary, like bhyve.args).
-    cp "${userdata}" "${vmdir}/cloud-init.yaml"
-    cp "${userdata}" "${seed_dir}/user-data"
     cat > "${seed_dir}/meta-data" <<EOF
 instance-id: ${vm_name}
 local-hostname: ${vm_name}
 EOF
+
+    # user-data (cloud-init requires the file to exist; default to an empty one).
+    if [ -n "${userdata}" ]; then
+        if [ ! -f "${userdata}" ]; then
+            rm -rf "${seed_dir}"
+            error_exit "[ERROR]: cloud-init user-data not found: ${userdata}"
+        fi
+        cp "${userdata}" "${vmdir}/cloud-init.yaml"
+        cp "${userdata}" "${seed_dir}/user-data"
+    else
+        printf '#cloud-config\n' > "${seed_dir}/user-data"
+    fi
+
+    # network-config (optional). cloud-init renders it to whatever the guest
+    # uses (netplan on Ubuntu, systemd-networkd/ifupdown on Debian), so it works
+    # across distros unlike a hand-written netplan file.
+    if [ -n "${netconfig}" ]; then
+        if [ ! -f "${netconfig}" ]; then
+            rm -rf "${seed_dir}"
+            error_exit "[ERROR]: cloud-init network-config not found: ${netconfig}"
+        fi
+        cp "${netconfig}" "${vmdir}/network-config.yaml"
+        cp "${netconfig}" "${seed_dir}/network-config"
+    fi
 
     # Label CIDATA is what cloud-init's NoCloud datasource looks for.
     if ! makefs -t cd9660 -o rockridge -o label=CIDATA "${vmdir}/seed.iso" "${seed_dir}" >/dev/null 2>&1; then
@@ -693,11 +760,13 @@ vm_create() {
     local M_MEM="512M"
     local M_BOOTROM="${bastille_vm_bootrom}"
     local M_DISKS=""
+    local M_DISK_SOURCES=""
     local M_NICS=""
     local M_ISO=""
     local M_ADDRESS=""
     local M_OS=""
     local M_CLOUDINIT=""
+    local M_NETCONFIG=""
     local RDR_RULES=""
     local seen_vm=0
 
@@ -737,19 +806,31 @@ vm_create() {
                 M_BOOTROM="$(vm_resolve_bootrom "${args}")"
                 ;;
             DISK)
-                # "DISK disk0 40G [prop=val ...]" -> "disk0:40G[,prop=val,...]"
+                # "DISK disk0 40G [source=<image>] [prop=val ...]". source=<url
+                # or path> populates the disk from a cloud/disk image; other
+                # tokens are zfs properties.
                 local d_name="$(echo "${args}" | awk '{print $1}')"
                 local d_size="$(echo "${args}" | awk '{print $2}')"
-                local d_props="$(echo "${args}" | awk '{$1="";$2="";sub(/^ */,"");print}' | tr ' ' ',')"
                 if [ -z "${d_name}" ] || [ -z "${d_size}" ]; then
                     set +f; unset IFS
                     error_exit "[ERROR]: DISK requires a name and size: ${args}"
                 fi
+                local d_source=""
+                local d_props=""
+                for d_tok in $(echo "${args}" | awk '{for (i=3; i<=NF; i++) print $i}'); do
+                    case "${d_tok}" in
+                        source=*) d_source="${d_tok#source=}" ;;
+                        *) d_props="${d_props}${d_props:+,}${d_tok}" ;;
+                    esac
+                done
                 local d_spec="${d_name}:${d_size}"
                 if [ -n "${d_props}" ]; then
                     d_spec="${d_spec},${d_props}"
                 fi
                 M_DISKS="${M_DISKS} ${d_spec}"
+                if [ -n "${d_source}" ]; then
+                    M_DISK_SOURCES="${M_DISK_SOURCES} ${d_name}=${d_source}"
+                fi
                 ;;
             NIC)
                 local n_bridge="$(echo "${args}" | awk '{print $1}')"
@@ -771,6 +852,11 @@ vm_create() {
                 # Path to a cloud-init user-data file (relative to the template
                 # directory, or absolute). Built into a NoCloud seed ISO.
                 M_CLOUDINIT="$(echo "${args}" | awk '{print $1}')"
+                ;;
+            NETWORK_CONFIG|NETCONFIG)
+                # Path to a cloud-init network-config file, added to the seed so
+                # the guest gets a deterministic (e.g. static) IP at first boot.
+                M_NETCONFIG="$(echo "${args}" | awk '{print $1}')"
                 ;;
             RDR)
                 RDR_RULES="${RDR_RULES}${args}
@@ -849,6 +935,11 @@ vm_create() {
         vm_create_disk "${vm_name}" "${spec}"
     done
 
+    # Populate any disk that declared a source image (cloud image boot disk).
+    for src_entry in ${M_DISK_SOURCES}; do
+        vm_write_disk_image "${vm_name}" "${src_entry%%=*}" "${src_entry#*=}"
+    done
+
     # Persist RDR rules for later application (needs ADDRESS).
     if [ -n "${RDR_RULES}" ]; then
         if [ -z "${M_ADDRESS}" ]; then
@@ -859,14 +950,19 @@ vm_create() {
         fi
     fi
 
-    # Build the cloud-init NoCloud seed, if the template declared one. Resolve
-    # the path relative to the template directory unless it is absolute.
-    if [ -n "${M_CLOUDINIT}" ]; then
+    # Build the cloud-init NoCloud seed if the template declared user-data
+    # and/or network-config. Resolve paths relative to the template directory
+    # unless absolute.
+    if [ -n "${M_CLOUDINIT}" ] || [ -n "${M_NETCONFIG}" ]; then
         case "${M_CLOUDINIT}" in
-            /*) : ;;
+            ""|/*) : ;;
             *) M_CLOUDINIT="${template_dir}/${M_CLOUDINIT}" ;;
         esac
-        vm_build_cloudinit_seed "${vm_name}" "${M_CLOUDINIT}"
+        case "${M_NETCONFIG}" in
+            ""|/*) : ;;
+            *) M_NETCONFIG="${template_dir}/${M_NETCONFIG}" ;;
+        esac
+        vm_build_cloudinit_seed "${vm_name}" "${M_CLOUDINIT}" "${M_NETCONFIG}"
     fi
 
     # Materialize derived artifacts (bhyve.args, supervisor.conf, vm-run.sh).
@@ -1107,6 +1203,7 @@ vm_clone() {
     if [ -f "${src_dir}/seed.iso" ]; then
         cp "${src_dir}/seed.iso" "${dst_dir}/seed.iso"
         [ -f "${src_dir}/cloud-init.yaml" ] && cp "${src_dir}/cloud-init.yaml" "${dst_dir}/cloud-init.yaml"
+        [ -f "${src_dir}/network-config.yaml" ] && cp "${src_dir}/network-config.yaml" "${dst_dir}/network-config.yaml"
     fi
 
     # Copy-on-write clone of each disk.

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -476,16 +476,22 @@ vm_generate_supervisor_conf() {
         local iface_lines=""
         local bridge_lines=""
         local taps_file="$(vm_taps_file "${vm_name}")"
+        local epairs_file="$(vm_epairs_file "${vm_name}")"
         local nic=0
-        while read -r epair_a epair_b; do
-            local tap="$(sed -n "$((nic + 1))p" "${taps_file}")"
-            iface_lines="${iface_lines}  vnet.interface += ${epair_b};
+        # The epairs/taps files are written by vm_create_vnet at start time, so
+        # they are absent during the create-time render. Skip the per-NIC lines
+        # when they are missing; vm_start re-renders once the files exist.
+        if [ -f "${epairs_file}" ]; then
+            while read -r epair_a epair_b; do
+                local tap="$(sed -n "$((nic + 1))p" "${taps_file}")"
+                iface_lines="${iface_lines}  vnet.interface += ${epair_b};
   vnet.interface += ${tap};
 "
-            bridge_lines="${bridge_lines}  exec.start += \"ifconfig bridge${nic} create && ifconfig bridge${nic} addm ${epair_b} addm ${tap} up && ifconfig ${epair_b} up && ifconfig ${tap} up\";
+                bridge_lines="${bridge_lines}  exec.start += \"ifconfig bridge${nic} create && ifconfig bridge${nic} addm ${epair_b} addm ${tap} up && ifconfig ${epair_b} up && ifconfig ${tap} up\";
 "
-            nic=$((nic + 1))
-        done < "$(vm_epairs_file "${vm_name}")"
+                nic=$((nic + 1))
+            done < "${epairs_file}"
+        fi
 
         cat << EOF > "${supervisor_conf}"
 ${vm_name} {

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -700,12 +700,17 @@ vm_build_cloudinit_seed() {
     local vm_name="${1}"
     local userdata="${2}"
     local netconfig="${3}"
+    # instance-id drives cloud-init's "new instance" detection; a fresh value
+    # (used by clone --reseed) makes a cloned guest re-run its per-instance
+    # provisioning. Both default to the VM name for a normal create.
+    local instance_id="${4:-${vm_name}}"
+    local hostname="${5:-${vm_name}}"
     local vmdir="${bastille_vmdir}/${vm_name}"
 
     local seed_dir="$(mktemp -d "/tmp/bastille-cidata-${vm_name}.XXXXXX")"
     cat > "${seed_dir}/meta-data" <<EOF
-instance-id: ${vm_name}
-local-hostname: ${vm_name}
+instance-id: ${instance_id}
+local-hostname: ${hostname}
 EOF
 
     # user-data (cloud-init requires the file to exist; default to an empty one).
@@ -1149,6 +1154,8 @@ vm_clone() {
     local new_address="${3}"
     local auto="${4}"
     local live="${5}"
+    local reseed="${6:-0}"
+    local reseed_hostname="${7}"
     local src_dir="${bastille_vmdir}/${target}"
     local dst_dir="${bastille_vmdir}/${newname}"
     local src_ds="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${target}"
@@ -1167,6 +1174,15 @@ vm_clone() {
 
     if ! checkyesno bastille_zfs_enable || [ -z "${bastille_zfs_zpool}" ]; then
         error_exit "[ERROR]: VM clone requires ZFS."
+    fi
+
+    # For a reseed with a new address, refuse a collision up front (before any
+    # dataset is created), reusing the create-time guard.
+    if [ "${reseed}" = "1" ] && [ -n "${new_address}" ]; then
+        local addr_owner="$(check_address_in_use "${new_address%%/*}")"
+        if [ -n "${addr_owner}" ]; then
+            error_exit "[ERROR]: IP address already in use by ${addr_owner}: ${new_address}"
+        fi
     fi
 
     # State: stopped (or -a to auto-stop, or -l to clone a running VM).
@@ -1197,10 +1213,42 @@ vm_clone() {
     if [ -f "${src_dir}/settings.conf" ]; then
         cp "${src_dir}/settings.conf" "${dst_dir}/settings.conf"
     fi
-    # Carry the cloud-init seed if the source has one. cloud-init keys off the
-    # instance-id (the source's name), so the clone will not re-run the source's
-    # provisioning, which is the right default for a golden image.
-    if [ -f "${src_dir}/seed.iso" ]; then
+    # cloud-init seed. Two modes:
+    #  - default (golden image): copy the source seed verbatim. cloud-init keys
+    #    off the instance-id (the source's name) and so does not re-run, giving
+    #    an identical twin the operator reconfigures by hand.
+    #  - reseed: rebuild the seed with a fresh instance-id (and optional new
+    #    address/hostname) so cloud-init treats the clone as a new instance and
+    #    re-runs its per-instance provisioning: network, hostname, users/keys,
+    #    and SSH host-key regeneration. That stamps a distinct instance.
+    if [ "${reseed}" = "1" ]; then
+        local rs_host="${reseed_hostname:-${newname}}"
+        local rs_ud="" rs_nc=""
+        if [ -f "${src_dir}/cloud-init.yaml" ]; then
+            rs_ud="$(mktemp -t bastille-reseed-ud)"
+            # Give the clone its own hostname: rewrite a hardcoded user-data
+            # hostname (meta-data local-hostname covers the case with none).
+            sed -E "s/^([[:space:]]*hostname:).*/\1 ${rs_host}/" "${src_dir}/cloud-init.yaml" > "${rs_ud}"
+        fi
+        if [ -f "${src_dir}/network-config.yaml" ]; then
+            rs_nc="$(mktemp -t bastille-reseed-nc)"
+            if [ -n "${new_address}" ]; then
+                # Rewrite the address on the network-config's addresses line,
+                # preserving the original prefix length.
+                sed -E "/addresses:/ s#([0-9]{1,3}\.){3}[0-9]{1,3}#${new_address%%/*}#" \
+                    "${src_dir}/network-config.yaml" > "${rs_nc}"
+            else
+                cp "${src_dir}/network-config.yaml" "${rs_nc}"
+            fi
+        fi
+        if [ -z "${rs_ud}" ] && [ -z "${rs_nc}" ]; then
+            warn 1 "[WARNING]: --reseed on a VM with no cloud-init; the clone gets only a fresh instance-id and hostname."
+        elif [ -n "${rs_nc}" ] && [ -z "${new_address}" ]; then
+            warn 1 "[WARNING]: --reseed without an address: the clone requests the same address as '${target}'. Pass an address to avoid a conflict."
+        fi
+        vm_build_cloudinit_seed "${newname}" "${rs_ud}" "${rs_nc}" "${newname}" "${rs_host}"
+        rm -f "${rs_ud}" "${rs_nc}"
+    elif [ -f "${src_dir}/seed.iso" ]; then
         cp "${src_dir}/seed.iso" "${dst_dir}/seed.iso"
         [ -f "${src_dir}/cloud-init.yaml" ] && cp "${src_dir}/cloud-init.yaml" "${dst_dir}/cloud-init.yaml"
         [ -f "${src_dir}/network-config.yaml" ] && cp "${src_dir}/network-config.yaml" "${dst_dir}/network-config.yaml"
@@ -1230,8 +1278,13 @@ vm_clone() {
     vm_render_artifacts "${newname}"
 
     info 1 "Cloned '${target}' to '${newname}' successfully."
-    info 1 "Note: the guest's in-VM network config is copied as-is; reconfigure"
-    info 1 "it inside the clone to avoid an address conflict with '${target}'."
+    if [ "${reseed}" = "1" ]; then
+        info 1 "Reseeded: cloud-init re-provisions the clone at first boot (fresh"
+        info 1 "instance-id, hostname '${reseed_hostname:-${newname}}'${new_address:+, address ${new_address}})."
+    else
+        info 1 "Note: the guest's in-VM network config is copied as-is; reconfigure"
+        info 1 "it inside the clone to avoid an address conflict with '${target}'."
+    fi
 
     if [ "${auto}" = "1" ]; then
         bastille start "${target}"

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -1,0 +1,793 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2026, Sasha Karcz <sasha@starnix.net>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# bhyve.sh -- shared library for Bastille bhyve VM support.
+#
+# A Bastille VM is a peer instance type to a jail. Every VM is described by a
+# generated-but-authoritative manifest (vm.conf) and runs its bhyve(8) device
+# model inside a minimal, auto-generated "supervision jail" with allow.vmm.
+# The supervision jail is what makes a Bastille VM *a kind of jail* rather than
+# a process standing beside jails: it gets a real JID, is visible to jls(8),
+# and is constrained by rctl(8) like any other jail.
+#
+# This file is sourced by the VM-aware branches of create/start/stop/console/
+# destroy/list. It never touches the jail code path.
+
+# The VM's on-disk layout mirrors the per-jail directory:
+#
+#   ${bastille_vmdir}/<name>/
+#     vm.conf          # canonical VM definition (rc.conf-style key=value)
+#     supervisor.conf  # generated jail.conf for the supervision jail
+#     bhyve.args       # materialized bhyve(8) argument vector (debuggable)
+#     vm-run.sh        # generated supervisor entry point (loops bhyve)
+#     settings.conf    # boot/priority/depend (shared convention with jails)
+#     rdr.conf         # pf redirect rules (shared convention with jails)
+#     console          # symlink to the nmdm console (client) side
+#
+# Disk images are zvols, not files, so `zfs snapshot -r` of the Bastille tree
+# stays meaningful and VMs inherit the clone/rollback story jails already have:
+#
+#   ${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/<name>/disk0
+
+# The supervision jail is named "<name>" so it is a first-class peer of jails
+# in jls/rctl. The bhyve vmm(4) instance shares the same name, exposed at
+# /dev/vmm/<name>.
+
+# ----------------------------------------------------------------------------
+# Manifest (vm.conf) accessors
+# ----------------------------------------------------------------------------
+
+vm_config() {
+    ## Path to a VM's manifest.
+    local vm_name="${1}"
+    echo "${bastille_vmdir}/${vm_name}/vm.conf"
+}
+
+vm_get() {
+    ## Read a single value from a VM manifest.
+    local vm_name="${1}"
+    local key="${2}"
+    sysrc -f "$(vm_config "${vm_name}")" -n "${key}" 2>/dev/null
+}
+
+vm_set() {
+    ## Write a single value to a VM manifest.
+    local vm_name="${1}"
+    local key="${2}"
+    local value="${3}"
+    sysrc -f "$(vm_config "${vm_name}")" "${key}=${value}" >/dev/null
+}
+
+# ----------------------------------------------------------------------------
+# nmdm / console helpers
+# ----------------------------------------------------------------------------
+
+vm_nmdm_host() {
+    ## The host (bhyve) side of the null-modem console pair.
+    echo "/dev/nmdm-${1}.1A"
+}
+
+vm_nmdm_client() {
+    ## The client (operator) side, attached with cu(1) by `bastille console`.
+    echo "/dev/nmdm-${1}.1B"
+}
+
+# NOTE: A restrictive devfs ruleset for the supervision jail is deliberately
+# NOT applied in v1. With path=/ (see vm_generate_supervisor_conf) a
+# mount.devfs would stack over the host's own /dev and hide host devices such
+# as /dev/zfs. Isolating the VM's /dev requires a dedicated jail root, which is
+# deferred; the config key bastille_vm_devfs_ruleset is reserved for that work.
+
+# ----------------------------------------------------------------------------
+# Disk (zvol) lifecycle
+# ----------------------------------------------------------------------------
+
+vm_disk_dataset() {
+    ## Dataset path for a VM disk.
+    local vm_name="${1}"
+    local disk="${2}"
+    echo "${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}/${disk}"
+}
+
+vm_disk_device() {
+    ## /dev path bhyve attaches for a VM disk.
+    local vm_name="${1}"
+    local disk="${2}"
+    echo "/dev/zvol/$(vm_disk_dataset "${vm_name}" "${disk}")"
+}
+
+vm_create_disk() {
+    ## Create a single zvol-backed disk. 'spec' is "name:size[,zfsprop=val,...]".
+    local vm_name="${1}"
+    local spec="${2}"
+    local disk="$(echo "${spec}" | awk -F: '{print $1}')"
+    local rest="$(echo "${spec}" | cut -s -d: -f2-)"
+    local size="$(echo "${rest}" | awk -F, '{print $1}')"
+    local props="$(echo "${rest}" | cut -s -d, -f2-)"
+    local dataset="$(vm_disk_dataset "${vm_name}" "${disk}")"
+
+    if [ -z "${disk}" ] || [ -z "${size}" ]; then
+        error_exit "[ERROR]: Malformed DISK spec: ${spec}"
+    fi
+
+    # Assemble any per-disk zfs properties (comma-separated) into -o flags.
+    # bhyve needs volmode=dev; add it as a default only if the user did not
+    # already set volmode (otherwise zfs rejects the duplicate property).
+    local zfs_props=""
+    local has_volmode=0
+    if [ -n "${props}" ]; then
+        local IFS=','
+        for prop in ${props}; do
+            zfs_props="${zfs_props} ${prop}"
+            case "${prop}" in
+                volmode=*) has_volmode=1 ;;
+            esac
+        done
+        unset IFS
+    fi
+    if [ "${has_volmode}" -eq 0 ]; then
+        zfs_props="volmode=dev ${zfs_props}"
+    fi
+    local zfs_opts=""
+    for prop in ${zfs_props}; do
+        zfs_opts="${zfs_opts} -o ${prop}"
+    done
+
+    if zfs list "${dataset}" >/dev/null 2>&1; then
+        info 2 "Disk already exists: ${dataset}"
+        return 0
+    fi
+
+    info 1 "Creating disk ${disk} (${size}): ${dataset}"
+    # shellcheck disable=SC2086
+    if ! zfs create -V "${size}" ${zfs_opts} "${dataset}"; then
+        error_exit "[ERROR]: Failed to create disk: ${dataset}"
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# tap / bridge lifecycle
+#
+# bhyve's virtio-net backend opens /dev/<tap>, and renaming a tap interface
+# does NOT rename its device node -- so we keep the kernel-assigned tapN name
+# for bhyve and use the interface description for human legibility. The tapN
+# names allocated for a running VM (one per NIC, in declaration order) are
+# tracked in a runtime file so stop/destroy and the devfs ruleset can find them.
+# ----------------------------------------------------------------------------
+
+vm_taps_file() {
+    echo "${bastille_vmdir}/${1}/taps"
+}
+
+vm_tap_list() {
+    ## Ordered list of tap devices currently backing a VM's NICs.
+    local taps_file="$(vm_taps_file "${1}")"
+    if [ -f "${taps_file}" ]; then
+        cat "${taps_file}"
+    fi
+}
+
+vm_create_tap() {
+    ## Create a tap, attach it to the named bridge, and echo its tapN name.
+    ## Mirrors network.sh's `ifconfig <bridge> addm` model for jail epairs.
+    local vm_name="${1}"
+    local index="${2}"
+    local bridge="${3}"
+
+    if ! ifconfig -g bridge | grep -owq "${bridge}"; then
+        error_exit "[ERROR]: '${bridge}' is not a bridge interface."
+    fi
+
+    local tap="$(ifconfig tap create)"
+    if [ -z "${tap}" ]; then
+        error_exit "[ERROR]: Failed to create tap interface for VM: ${vm_name}"
+    fi
+    ifconfig "${tap}" description "vm-${vm_name}-${index}: Bastille VM ${vm_name} nic${index}" >/dev/null
+    ifconfig "${tap}" up >/dev/null
+    ifconfig "${bridge}" addm "${tap}" >/dev/null
+    echo "${tap}"
+}
+
+vm_create_taps() {
+    ## Create every tap for a VM (one per NIC), recording the tapN names.
+    local vm_name="${1}"
+    local nics="$(vm_get "${vm_name}" nics)"
+    local taps_file="$(vm_taps_file "${vm_name}")"
+
+    : > "${taps_file}"
+    local index=0
+    for bridge in ${nics}; do
+        vm_create_tap "${vm_name}" "${index}" "${bridge}" >> "${taps_file}"
+        index=$((index + 1))
+    done
+}
+
+vm_destroy_taps() {
+    ## Tear down every tap recorded for a VM and clear the runtime file.
+    local vm_name="${1}"
+    for tap in $(vm_tap_list "${vm_name}"); do
+        if ifconfig "${tap}" >/dev/null 2>&1; then
+            ifconfig "${tap}" destroy >/dev/null 2>&1
+        fi
+    done
+    rm -f "$(vm_taps_file "${vm_name}")"
+}
+
+# ----------------------------------------------------------------------------
+# bhyve argument generation
+# ----------------------------------------------------------------------------
+
+vm_generate_args() {
+    ## Materialize the bhyve(8) argument vector into bhyve.args. This file is
+    ## the debuggable boundary between manifest and hypervisor: users read and
+    ## diff it, and the supervisor runs exactly what it contains.
+    local vm_name="${1}"
+    local vmdir="${bastille_vmdir}/${vm_name}"
+    local args_file="${vmdir}/bhyve.args"
+
+    local cpu="$(vm_get "${vm_name}" cpu)"
+    local memory="$(vm_get "${vm_name}" memory)"
+    local bootrom="$(vm_get "${vm_name}" bootrom)"
+    local disks="$(vm_get "${vm_name}" disks)"
+    local nics="$(vm_get "${vm_name}" nics)"
+    local iso="$(vm_get "${vm_name}" iso)"
+
+    : "${cpu:=1}"
+    : "${memory:=512M}"
+    : "${bootrom:=${bastille_vm_bootrom}}"
+
+    if [ ! -r "${bootrom}" ]; then
+        warn 1 "[WARNING]: UEFI firmware not found: ${bootrom}"
+        warn 1 "Install sysutils/edk2-bhyve or set 'bastille_vm_bootrom'."
+    fi
+
+    # PCI slot layout: 0 hostbridge, 31 lpc (fixed), devices from slot 3 up.
+    local slot=3
+
+    {
+        printf '%s\n' "-c ${cpu}"
+        printf '%s\n' "-m ${memory}"
+        # -A ACPI tables, -H yield on HLT, -P exit on PAUSE, -w ignore bad MSR.
+        printf '%s\n' "-AHPw"
+        printf '%s\n' "-s 0,hostbridge"
+        printf '%s\n' "-s 31,lpc"
+        printf '%s\n' "-l bootrom,${bootrom}"
+        printf '%s\n' "-l com1,$(vm_nmdm_host "${vm_name}")"
+
+        # Disks in declaration order.
+        local disk_type="${bastille_vm_disk_type:-virtio-blk}"
+        for spec in ${disks}; do
+            local disk="$(echo "${spec}" | awk -F: '{print $1}')"
+            printf '%s\n' "-s ${slot},${disk_type},$(vm_disk_device "${vm_name}" "${disk}")"
+            slot=$((slot + 1))
+        done
+
+        # NICs in declaration order, backed by the tap devices allocated at
+        # start. Before the taps exist (e.g. bhyve.args written at create time)
+        # a placeholder is emitted; the file is regenerated at start.
+        local nic_type="${bastille_vm_nic_type:-virtio-net}"
+        local nic_index=0
+        local taps="$(vm_tap_list "${vm_name}")"
+        for _bridge in ${nics}; do
+            local backend="$(echo "${taps}" | sed -n "$((nic_index + 1))p")"
+            : "${backend:=tap-pending${nic_index}}"
+            printf '%s\n' "-s ${slot},${nic_type},${backend}"
+            slot=$((slot + 1))
+            nic_index=$((nic_index + 1))
+        done
+
+        # Installation media (first boot).
+        if [ -n "${iso}" ]; then
+            printf '%s\n' "-s ${slot},ahci-cd,${iso}"
+            slot=$((slot + 1))
+        fi
+
+        # The vmm(4) instance name is the VM name, matching the jail name.
+        printf '%s\n' "${vm_name}"
+    } > "${args_file}"
+
+    info 2 "Wrote bhyve arguments: ${args_file}"
+}
+
+# ----------------------------------------------------------------------------
+# supervisor entry point + jail.conf generation
+# ----------------------------------------------------------------------------
+
+vm_generate_run_script() {
+    ## Generate the supervisor entry point. bhyve(8) exits 0 to request a
+    ## reboot and non-zero to power off; the loop mirrors what every hypervisor
+    ## supervisor does. On final exit the vmm device is destroyed so the VM can
+    ## cleanly restart later.
+    local vm_name="${1}"
+    local run_script="${bastille_vmdir}/${vm_name}/vm-run.sh"
+
+    cat << EOF > "${run_script}"
+#!/bin/sh
+# Generated by Bastille -- do not edit. Regenerated on every 'bastille start'.
+vm_name="${vm_name}"
+args_file="${bastille_vmdir}/${vm_name}/bhyve.args"
+
+while :; do
+    # Destroy any prior vmm instance first. bhyve does not tear down
+    # /dev/vmm/<name> on exit, so this must run before every boot -- including
+    # a guest-requested reboot -- or the next bhyve would fail "already in use".
+    bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
+    # shellcheck disable=SC2046
+    bhyve \$(cat "\${args_file}")
+    rc=\$?
+    # 0 = guest requested reboot; anything else = power off / halt / error.
+    if [ "\${rc}" -ne 0 ]; then
+        break
+    fi
+done
+
+bhyvectl --destroy --vm="\${vm_name}" >/dev/null 2>&1
+EOF
+    chmod 0700 "${run_script}"
+}
+
+vm_generate_supervisor_conf() {
+    ## Generate the supervision jail.conf. The jail carries allow.vmm and an
+    ## rctl memory cap derived from MEM (applied separately) so bhyve's wired
+    ## guest RAM is accounted for, giving the VM a real JID that jls and rctl
+    ## treat as a peer of jails.
+    ##
+    ## NOTE: this v1 jail uses path=/ and shares the host's /dev. It does NOT
+    ## use mount.devfs + a restrictive devfs_ruleset: with path=/ that would
+    ## stack a locked-down devfs over the host's own /dev and hide host devices
+    ## (e.g. /dev/zfs). Proper devfs confinement -- a dedicated jail root with
+    ## its own isolated /dev exposing only this VM's vmm/tap/nmdm devices -- is
+    ## the intended hardening and is deferred until it can be validated on real
+    ## bhyve hardware. Confinement today is allow.vmm + rctl + the jail
+    ## namespace, layered on bhyve's own Capsicum sandbox.
+    local vm_name="${1}"
+    local supervisor_conf="${bastille_vmdir}/${vm_name}/supervisor.conf"
+    local run_script="${bastille_vmdir}/${vm_name}/vm-run.sh"
+
+    cat << EOF > "${supervisor_conf}"
+${vm_name} {
+  # Bastille bhyve supervision jail (generated).
+  # This is an implementation detail; edit vm.conf, not this file.
+  path = /;
+  host.hostname = ${vm_name};
+  persist;
+  allow.vmm;
+  enforce_statfs = 1;
+  exec.clean;
+  # bhyve runs a foreground loop, so daemon(8) backgrounds it -- otherwise
+  # 'jail -c' would block until the guest powers off. bhyve stays confined to
+  # this jail because daemon(8) itself runs inside it. The </dev/null and
+  # >/dev/null redirections detach the daemon subtree from jail -c's stdio so
+  # 'bastille start' (and the rc.d boot pipeline) return promptly instead of
+  # hanging on an inherited stdout pipe; bhyve output still goes to the -o log.
+  exec.start = "/usr/sbin/daemon -o ${bastille_logsdir}/${vm_name}_vm.log /bin/sh ${run_script} </dev/null >/dev/null 2>&1";
+  exec.stop = "";
+}
+EOF
+}
+
+# ----------------------------------------------------------------------------
+# rctl memory accounting
+# ----------------------------------------------------------------------------
+
+vm_memory_bytes() {
+    ## Convert a bhyve memory string (e.g. 8G, 512M) to bytes for rctl.
+    local mem="${1}"
+    local num="$(echo "${mem}" | sed -E 's/[^0-9]//g')"
+    local unit="$(echo "${mem}" | sed -E 's/[0-9]//g' | tr '[:lower:]' '[:upper:]')"
+    case "${unit}" in
+        T) echo $((num * 1024 * 1024 * 1024 * 1024)) ;;
+        G) echo $((num * 1024 * 1024 * 1024)) ;;
+        # A bare number is megabytes, matching bhyve's own -m interpretation.
+        M|"") echo $((num * 1024 * 1024)) ;;
+        K) echo $((num * 1024)) ;;
+        *) echo "" ;;
+    esac
+}
+
+vm_apply_rctl() {
+    ## Cap the supervision jail's memory at guest RAM + overhead. bhyve wires
+    ## the full guest memory, so this bounds the VM's host-side footprint.
+    local vm_name="${1}"
+    local memory="$(vm_get "${vm_name}" memory)"
+    local bytes="$(vm_memory_bytes "${memory}")"
+    if [ -z "${bytes}" ]; then
+        return 0
+    fi
+    # Add ~256MB overhead for the device model process itself.
+    local cap=$((bytes + 268435456))
+    rctl -a "jail:${vm_name}:memoryuse:deny=${cap}" >/dev/null 2>&1
+}
+
+# ----------------------------------------------------------------------------
+# Manifest rendering from a VM template
+# ----------------------------------------------------------------------------
+
+vm_resolve_bootrom() {
+    ## Map a BOOTROM verb value to a firmware path.
+    ##   uefi      -> edk2-bhyve UEFI firmware (default)
+    ##   uefi-csm  -> UEFI + legacy CSM
+    ##   <path>    -> used as-is
+    local spec="${1}"
+    local firmware_dir="$(dirname "${bastille_vm_bootrom}")"
+    case "${spec}" in
+        uefi|UEFI|"")
+            echo "${bastille_vm_bootrom}"
+            ;;
+        uefi-csm|UEFI-CSM)
+            echo "${firmware_dir}/BHYVE_UEFI_CSM.fd"
+            ;;
+        *)
+            echo "${spec}"
+            ;;
+    esac
+}
+
+vm_fetch_iso() {
+    ## Resolve an ISO verb value to a local path, fetching remote media into
+    ## the Bastille cache (mirrors bootstrap's caching posture).
+    local spec="${1}"
+    case "${spec}" in
+        http://*|https://*|ftp://*)
+            local iso_cache="${bastille_cachedir}/iso"
+            local iso_name="$(basename "${spec}")"
+            local iso_path="${iso_cache}/${iso_name}"
+            if [ ! -f "${iso_path}" ]; then
+                mkdir -p "${iso_cache}"
+                info 1 "Fetching ISO: ${spec}"
+                if ! fetch -o "${iso_path}" "${spec}"; then
+                    error_exit "[ERROR]: Failed to fetch ISO: ${spec}"
+                fi
+            fi
+            echo "${iso_path}"
+            ;;
+        *)
+            echo "${spec}"
+            ;;
+    esac
+}
+
+vm_create() {
+    ## Render a VM template into an authoritative manifest, then create the
+    ## backing zvols. Networking taps are created lazily at start time.
+    local vm_name="${1}"
+    local template="${2}"
+    local template_dir="${bastille_templatesdir}/${template}"
+    local bastillefile="${template_dir}/Bastillefile"
+    local vmdir="${bastille_vmdir}/${vm_name}"
+
+    if [ ! -s "${bastillefile}" ]; then
+        error_exit "[ERROR]: Template not found: ${template}"
+    fi
+
+    # Parsed manifest fields.
+    local M_CPU="1"
+    local M_MEM="512M"
+    local M_BOOTROM="${bastille_vm_bootrom}"
+    local M_DISKS=""
+    local M_NICS=""
+    local M_ISO=""
+    local M_ADDRESS=""
+    local RDR_RULES=""
+    local seen_vm=0
+
+    # Join line continuations, drop blank/comment lines (template.sh idiom).
+    local SCRIPT
+    SCRIPT=$(awk '{ if (substr($0, length, 1) == "\\") { printf "%s", substr($0, 1, length-1); } else { print $0; } }' "${bastillefile}" | grep -v '^[[:blank:]]*$' | grep -v '^[[:blank:]]*#')
+
+    local IFS='
+'
+    set -f
+    for line in ${SCRIPT}; do
+        local verb="$(echo "${line}" | awk '{print toupper($1)}')"
+        local args="$(echo "${line}" | awk '{$1=""; sub(/^ */, ""); print}')"
+
+        # The VM verb must open the file; it declares the template's brand.
+        if [ "${seen_vm}" -eq 0 ] && [ "${verb}" != "VM" ]; then
+            set +f
+            unset IFS
+            error_exit "[ERROR]: VM templates must begin with the 'VM' verb."
+        fi
+
+        case "${verb}" in
+            VM)
+                seen_vm=1
+                ;;
+            CPU)
+                if ! echo "${args}" | grep -Eq '^[0-9]+$'; then
+                    set +f; unset IFS
+                    error_exit "[ERROR]: CPU must be an integer: ${args}"
+                fi
+                M_CPU="${args}"
+                ;;
+            MEM|MEMORY)
+                M_MEM="${args}"
+                ;;
+            BOOTROM)
+                M_BOOTROM="$(vm_resolve_bootrom "${args}")"
+                ;;
+            DISK)
+                # "DISK disk0 40G [prop=val ...]" -> "disk0:40G[,prop=val,...]"
+                local d_name="$(echo "${args}" | awk '{print $1}')"
+                local d_size="$(echo "${args}" | awk '{print $2}')"
+                local d_props="$(echo "${args}" | awk '{$1="";$2="";sub(/^ */,"");print}' | tr ' ' ',')"
+                if [ -z "${d_name}" ] || [ -z "${d_size}" ]; then
+                    set +f; unset IFS
+                    error_exit "[ERROR]: DISK requires a name and size: ${args}"
+                fi
+                local d_spec="${d_name}:${d_size}"
+                if [ -n "${d_props}" ]; then
+                    d_spec="${d_spec},${d_props}"
+                fi
+                M_DISKS="${M_DISKS} ${d_spec}"
+                ;;
+            NIC)
+                local n_bridge="$(echo "${args}" | awk '{print $1}')"
+                : "${n_bridge:=${bastille_vm_bridge}}"
+                M_NICS="${M_NICS} ${n_bridge}"
+                ;;
+            ISO)
+                M_ISO="$(vm_fetch_iso "${args}")"
+                ;;
+            ADDRESS)
+                M_ADDRESS="$(echo "${args}" | awk '{print $1}')"
+                ;;
+            RDR)
+                RDR_RULES="${RDR_RULES}${args}
+"
+                ;;
+            PKG|HPKG|SYSRC|CP|COPY|CMD|SERVICE|OVERLAY|MOUNT|FSTAB|RENDER)
+                set +f; unset IFS
+                error_exit "[ERROR]: '${verb}' is a jail verb and is not valid in a VM template."
+                ;;
+            *)
+                set +f; unset IFS
+                error_exit "[ERROR]: Unknown VM verb: ${verb}"
+                ;;
+        esac
+    done
+    set +f
+    unset IFS
+
+    # Trim leading spaces on accumulated lists.
+    M_DISKS="$(echo "${M_DISKS}" | sed 's/^ *//')"
+    M_NICS="$(echo "${M_NICS}" | sed 's/^ *//')"
+
+    if [ -z "${M_DISKS}" ]; then
+        error_exit "[ERROR]: A VM template must declare at least one DISK."
+    fi
+
+    # VM support requires ZFS in v1 (halves the storage code, matches where
+    # serious deployments already are -- see the design doc's Open Questions).
+    if ! checkyesno bastille_zfs_enable || [ -z "${bastille_zfs_zpool}" ]; then
+        error_exit "[ERROR]: VM support requires ZFS (set bastille_zfs_enable=YES)."
+    fi
+
+    # Create the VM datasets first; their mountpoints materialize the instance
+    # directory. Pin the parent mountpoint to bastille_vmdir (mirrors bootstrap).
+    if ! zfs list "${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms" >/dev/null 2>&1; then
+        if ! zfs create -o mountpoint="${bastille_vmdir}" "${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms"; then
+            error_exit "[ERROR]: Failed to create VM parent dataset."
+        fi
+    fi
+    if ! zfs list "${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}" >/dev/null 2>&1; then
+        if ! zfs create "${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}"; then
+            error_exit "[ERROR]: Failed to create VM dataset: ${vm_name}"
+        fi
+    fi
+
+    # Lock down the instance directory (root-only), matching bastille_prefix.
+    mkdir -p "${vmdir}"
+    chmod 0700 "${vmdir}"
+
+    vm_set "${vm_name}" version "1"
+    vm_set "${vm_name}" cpu "${M_CPU}"
+    vm_set "${vm_name}" memory "${M_MEM}"
+    vm_set "${vm_name}" bootrom "${M_BOOTROM}"
+    vm_set "${vm_name}" disks "${M_DISKS}"
+    vm_set "${vm_name}" nics "${M_NICS}"
+    vm_set "${vm_name}" iso "${M_ISO}"
+    vm_set "${vm_name}" address "${M_ADDRESS}"
+
+    # Boot/priority settings shared with the jail convention.
+    sysrc -f "${vmdir}/settings.conf" boot="${BOOT:-on}" >/dev/null
+    sysrc -f "${vmdir}/settings.conf" depend="" >/dev/null
+    sysrc -f "${vmdir}/settings.conf" priority="${PRIORITY:-99}" >/dev/null
+
+    # Create backing disks.
+    for spec in ${M_DISKS}; do
+        vm_create_disk "${vm_name}" "${spec}"
+    done
+
+    # Persist RDR rules for later application (needs ADDRESS).
+    if [ -n "${RDR_RULES}" ]; then
+        if [ -z "${M_ADDRESS}" ]; then
+            warn 1 "[WARNING]: RDR declared without ADDRESS; skipping redirect rules."
+        else
+            printf '%s' "${RDR_RULES}" > "${vmdir}/rdr.conf.pending"
+            info 2 "Recorded pending RDR rules: ${vmdir}/rdr.conf.pending"
+        fi
+    fi
+
+    # Materialize derived artifacts (bhyve.args, supervisor.conf, vm-run.sh).
+    vm_render_artifacts "${vm_name}"
+
+    # Console convenience symlink.
+    ln -sf "$(vm_nmdm_client "${vm_name}")" "${vmdir}/console"
+
+    info 1 "\nVM created: ${vm_name}"
+    info 1 "Review the invocation at: ${vmdir}/bhyve.args"
+}
+
+# ----------------------------------------------------------------------------
+# High-level lifecycle actions
+# ----------------------------------------------------------------------------
+
+vm_render_artifacts() {
+    ## (Re)generate every derived artifact from the manifest. Called by create
+    ## and again by start so a hand-edited vm.conf is always honored.
+    local vm_name="${1}"
+    vm_generate_args "${vm_name}"
+    vm_generate_run_script "${vm_name}"
+    vm_generate_supervisor_conf "${vm_name}"
+}
+
+vm_start() {
+    local vm_name="${1}"
+
+    if check_vm_is_running "${vm_name}"; then
+        error_notify "VM is already running."
+        return 1
+    fi
+
+    # Create taps first so their tapN names flow into the bhyve argument
+    # vector, then regenerate artifacts (honors manifest edits). Order matters:
+    # vm_generate_args reads the taps runtime file.
+    vm_create_taps "${vm_name}"
+    vm_render_artifacts "${vm_name}"
+
+    # Start the supervision jail; its exec.start execs the bhyve loop.
+    if ! jail -f "${bastille_vmdir}/${vm_name}/supervisor.conf" -c "${vm_name}"; then
+        error_notify "[ERROR]: Failed to start supervision jail: ${vm_name}"
+        vm_destroy_taps "${vm_name}"
+        return 1
+    fi
+
+    vm_apply_rctl "${vm_name}"
+
+    # NOTE: pf redirect (RDR) application for VMs is Phase 2. Rules declared in
+    # the template are recorded to rdr.conf.pending at create time; wiring them
+    # to pf (via an ADDRESS-aware rdr.sh branch) lands with the Phase 2 work.
+
+    return 0
+}
+
+vm_stop() {
+    local vm_name="${1}"
+    local force="${2}"
+    local timeout="${bastille_vm_shutdown_timeout:-30}"
+
+    if check_vm_is_stopped "${vm_name}"; then
+        error_notify "VM is already stopped."
+        return 1
+    fi
+
+    if [ "${force}" != "1" ] && check_vm_guest_is_running "${vm_name}"; then
+        # Graceful ACPI poweroff: bhyve raises a virtual power button on TERM.
+        # FreeBSD signal names have no SIG prefix (pkill -TERM, not -SIGTERM).
+        # Poll the guest (vmm instance), not the jail: the persistent jail
+        # lingers until we remove it below, so it is not the shutdown signal.
+        info 1 "Requesting graceful shutdown (timeout ${timeout}s)..."
+        pkill -TERM -f "bhyve.*[ ]${vm_name}\$" >/dev/null 2>&1
+        local waited=0
+        while [ "${waited}" -lt "${timeout}" ]; do
+            if ! check_vm_guest_is_running "${vm_name}"; then
+                break
+            fi
+            sleep 1
+            waited=$((waited + 1))
+        done
+    fi
+
+    # Force poweroff if the guest is still live (or if forced up front).
+    if check_vm_guest_is_running "${vm_name}"; then
+        warn 1 "Forcing power off: ${vm_name}"
+        bhyvectl --force-poweroff --vm="${vm_name}" >/dev/null 2>&1
+    fi
+
+    # Remove the supervision jail.
+    if jls name | grep -Eq "^${vm_name}\$"; then
+        jail -f "${bastille_vmdir}/${vm_name}/supervisor.conf" -r "${vm_name}" >/dev/null 2>&1
+    fi
+
+    # Destroy the vmm instance and tear down taps.
+    bhyvectl --destroy --vm="${vm_name}" >/dev/null 2>&1
+    vm_destroy_taps "${vm_name}"
+
+    return 0
+}
+
+vm_console() {
+    ## Attach to the VM serial console over nmdm(4) with cu(1). The exact
+    ## analogue of `zlogin -C` for an illumos bhyve zone. Detach with ~. .
+    local vm_name="${1}"
+    local client="$(vm_nmdm_client "${vm_name}")"
+
+    if ! check_vm_guest_is_running "${vm_name}"; then
+        error_notify "VM guest is not running (no bhyve instance)."
+        return 1
+    fi
+    if [ ! -e "${client}" ]; then
+        error_notify "[ERROR]: Console device not found: ${client}"
+        return 1
+    fi
+    info 1 "Attaching to ${vm_name} console (detach with ~.)"
+    cu -l "${client}" -s 115200
+}
+
+vm_destroy() {
+    ## Tear down the VM: stop it, destroy its disks (with force semantics
+    ## matching jails) and remove its instance directory.
+    local vm_name="${1}"
+    local force="${2}"
+
+    if check_vm_is_running "${vm_name}"; then
+        vm_stop "${vm_name}" 1
+    fi
+
+    # Destroy zvol-backed disks.
+    if checkyesno bastille_zfs_enable && [ -n "${bastille_zfs_zpool}" ]; then
+        local dataset="${bastille_zfs_zpool}/${bastille_zfs_prefix}/vms/${vm_name}"
+        if zfs list "${dataset}" >/dev/null 2>&1; then
+            local opts="-r"
+            if [ "${force}" = "1" ]; then
+                opts="-rf"
+            fi
+            if ! zfs destroy "${opts}" "${dataset}"; then
+                error_notify "[ERROR]: VM dataset appears busy: ${dataset}"
+                return 1
+            fi
+        fi
+    fi
+
+    # Clear pf redirect anchors, mirroring destroy.sh for jails.
+    pfctl -a "rdr/${vm_name}" -Fn >/dev/null 2>&1
+    pfctl -a "bastille/${vm_name}" -Fr >/dev/null 2>&1
+
+    # Remove the instance directory. The :? guards ensure this can never
+    # expand to '/' should either variable somehow be empty.
+    if [ -d "${bastille_vmdir}/${vm_name}" ]; then
+        rm -rf "${bastille_vmdir:?}/${vm_name:?}"
+    fi
+
+    return 0
+}

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -510,6 +510,16 @@ vm_setup_jail_root() {
     if [ -f "${vmdir}/seed.iso" ]; then
         cp "${vmdir}/seed.iso" "${root}/seed.iso"
     fi
+
+    # Make an install ISO (if any) reachable in the jail root. bhyve.args
+    # references it by absolute path, so nullfs-mount its directory read-only at
+    # the same path inside the root. ISOs can be large; mount rather than copy.
+    local iso="$(vm_get "${vm_name}" iso)"
+    if [ -n "${iso}" ] && [ -f "${iso}" ]; then
+        local iso_dir="$(dirname "${iso}")"
+        mkdir -p "${root}${iso_dir}"
+        mount -t nullfs -o ro "${iso_dir}" "${root}${iso_dir}"
+    fi
 }
 
 vm_teardown_jail_root() {

--- a/usr/local/share/bastille/bhyve.sh
+++ b/usr/local/share/bastille/bhyve.sh
@@ -389,6 +389,13 @@ vm_generate_args() {
             slot=$((slot + 1))
         fi
 
+        # cloud-init NoCloud seed (a CIDATA CD the guest reads at first boot).
+        local seed="${bastille_vmdir}/${vm_name}/seed.iso"
+        if [ -f "${seed}" ]; then
+            printf '%s\n' "-s ${slot},ahci-cd,${seed}"
+            slot=$((slot + 1))
+        fi
+
         # The vmm(4) instance name is the VM name, matching the jail name.
         printf '%s\n' "${vm_name}"
     } > "${args_file}"
@@ -629,6 +636,38 @@ vm_guess_os_from_iso() {
     fi
 }
 
+vm_build_cloudinit_seed() {
+    ## Build a NoCloud "cidata" seed ISO from a user-data file plus an
+    ## auto-generated meta-data, using base makefs(8) (no ports dependency). A
+    ## cloud-init-enabled guest reads it from the attached CD at first boot and
+    ## applies it (users, SSH keys, packages, runcmd, network, and so on).
+    local vm_name="${1}"
+    local userdata="${2}"
+    local vmdir="${bastille_vmdir}/${vm_name}"
+
+    if [ ! -f "${userdata}" ]; then
+        error_exit "[ERROR]: cloud-init user-data not found: ${userdata}"
+    fi
+
+    local seed_dir="$(mktemp -d "/tmp/bastille-cidata-${vm_name}.XXXXXX")"
+    # Keep an inspectable copy of the user-data with the VM (a debuggable
+    # boundary, like bhyve.args).
+    cp "${userdata}" "${vmdir}/cloud-init.yaml"
+    cp "${userdata}" "${seed_dir}/user-data"
+    cat > "${seed_dir}/meta-data" <<EOF
+instance-id: ${vm_name}
+local-hostname: ${vm_name}
+EOF
+
+    # Label CIDATA is what cloud-init's NoCloud datasource looks for.
+    if ! makefs -t cd9660 -o rockridge -o label=CIDATA "${vmdir}/seed.iso" "${seed_dir}" >/dev/null 2>&1; then
+        rm -rf "${seed_dir}"
+        error_exit "[ERROR]: Failed to build cloud-init seed ISO."
+    fi
+    rm -rf "${seed_dir}"
+    info 2 "Wrote cloud-init seed: ${vmdir}/seed.iso"
+}
+
 vm_create() {
     ## Render a VM template into an authoritative manifest, then create the
     ## backing zvols. Networking taps are created lazily at start time.
@@ -652,6 +691,7 @@ vm_create() {
     local M_ISO=""
     local M_ADDRESS=""
     local M_OS=""
+    local M_CLOUDINIT=""
     local RDR_RULES=""
     local seen_vm=0
 
@@ -720,6 +760,11 @@ vm_create() {
                 # Human label for the guest OS shown in 'bastille list'
                 # (e.g. "Ubuntu 24.04"). Overrides the guess from the ISO name.
                 M_OS="${args}"
+                ;;
+            CLOUDINIT|CLOUD_INIT)
+                # Path to a cloud-init user-data file (relative to the template
+                # directory, or absolute). Built into a NoCloud seed ISO.
+                M_CLOUDINIT="$(echo "${args}" | awk '{print $1}')"
                 ;;
             RDR)
                 RDR_RULES="${RDR_RULES}${args}
@@ -806,6 +851,16 @@ vm_create() {
             printf '%s' "${RDR_RULES}" > "${vmdir}/rdr.conf.pending"
             info 2 "Recorded pending RDR rules: ${vmdir}/rdr.conf.pending"
         fi
+    fi
+
+    # Build the cloud-init NoCloud seed, if the template declared one. Resolve
+    # the path relative to the template directory unless it is absolute.
+    if [ -n "${M_CLOUDINIT}" ]; then
+        case "${M_CLOUDINIT}" in
+            /*) : ;;
+            *) M_CLOUDINIT="${template_dir}/${M_CLOUDINIT}" ;;
+        esac
+        vm_build_cloudinit_seed "${vm_name}" "${M_CLOUDINIT}"
     fi
 
     # Materialize derived artifacts (bhyve.args, supervisor.conf, vm-run.sh).
@@ -1039,6 +1094,13 @@ vm_clone() {
     cp "${src_dir}/vm.conf" "${dst_dir}/vm.conf"
     if [ -f "${src_dir}/settings.conf" ]; then
         cp "${src_dir}/settings.conf" "${dst_dir}/settings.conf"
+    fi
+    # Carry the cloud-init seed if the source has one. cloud-init keys off the
+    # instance-id (the source's name), so the clone will not re-run the source's
+    # provisioning, which is the right default for a golden image.
+    if [ -f "${src_dir}/seed.iso" ]; then
+        cp "${src_dir}/seed.iso" "${dst_dir}/seed.iso"
+        [ -f "${src_dir}/cloud-init.yaml" ] && cp "${src_dir}/cloud-init.yaml" "${dst_dir}/cloud-init.yaml"
     fi
 
     # Copy-on-write clone of each disk.

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -42,6 +42,10 @@ usage() {
 
     -a | --auto      Auto mode. Start/stop jail(s) if required. Cannot be used with [-l|--live].
     -l | --live      Clone a running jail (ZFS only). Cannot be used with [-a|--auto].
+    --reseed         (VM only) Rebuild the cloud-init seed with a fresh instance-id so the
+                     clone re-provisions at first boot (its own IP/hostname/keys) instead
+                     of being an identical twin. Pass ADDRESS to give it a new address.
+    --hostname NAME  (VM only, with --reseed) Hostname for the reseeded clone (default: NEW_NAME).
 
 EOF
     exit 1
@@ -50,6 +54,8 @@ EOF
 # Handle options
 AUTO=0
 LIVE=0
+RESEED=0
+RESEED_HOSTNAME=""
 while [ "$#" -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
@@ -66,6 +72,17 @@ while [ "$#" -gt 0 ]; do
                 LIVE=1
                 shift
             fi
+            ;;
+        --reseed)
+            RESEED=1
+            shift
+            ;;
+        --hostname)
+            if [ -z "${2}" ]; then
+                error_exit "[ERROR]: [--hostname] requires a name."
+            fi
+            RESEED_HOSTNAME="${2}"
+            shift 2
             ;;
         -*)
             for opt in $(echo ${1} | sed 's/-//g' | fold -w1); do
@@ -93,8 +110,13 @@ bastille_root_check
 # Brand dispatch: clone a VM. Address is optional (it is RDR metadata; the
 # guest's real network config lives inside the guest and is cloned as-is).
 if [ "$#" -ge 2 ] && check_vm_exists "${1}"; then
-    vm_clone "${1}" "${2}" "${3}" "${AUTO}" "${LIVE}"
+    vm_clone "${1}" "${2}" "${3}" "${AUTO}" "${LIVE}" "${RESEED}" "${RESEED_HOSTNAME}"
     exit $?
+fi
+
+# --reseed / --hostname are VM-only.
+if [ "${RESEED}" -eq 1 ] || [ -n "${RESEED_HOSTNAME}" ]; then
+    error_exit "[ERROR]: [--reseed] and [--hostname] apply only to VM clones."
 fi
 
 # Verify parameter count

--- a/usr/local/share/bastille/clone.sh
+++ b/usr/local/share/bastille/clone.sh
@@ -31,9 +31,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille clone [option(s)] TARGET NEW_NAME IP"
+    error_notify "       bastille clone [option(s)] VM_TARGET NEW_NAME [ADDRESS]"
     cat << EOF
 
     Options:
@@ -84,6 +86,15 @@ done
 # Verify options
 if [ "${AUTO}" -eq 1 ] && [ "${LIVE}" -eq 1 ]; then
     error_exit "[-a|--auto] cannot be used with [-l|--live]"
+fi
+
+bastille_root_check
+
+# Brand dispatch: clone a VM. Address is optional (it is RDR metadata; the
+# guest's real network config lives inside the guest and is cloned as-is).
+if [ "$#" -ge 2 ] && check_vm_exists "${1}"; then
+    vm_clone "${1}" "${2}" "${3}" "${AUTO}" "${LIVE}"
+    exit $?
 fi
 
 # Verify parameter count

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -613,6 +613,67 @@ validate_ip() {
     fi
 }
 
+check_address_in_use() {
+    ## Echo a short description of what already holds an IPv4/IPv6 address (a
+    ## host interface, another jail, or a VM), or nothing if it is free. Used by
+    ## create/clone to refuse a duplicate address. Matches the bare address,
+    ## ignoring any "interface|" prefix or "/subnet" suffix.
+    local addr="${1}"
+    if [ -z "${addr}" ]; then
+        return 1
+    fi
+    # Normalize: drop "interface|" prefix and "/subnet" suffix.
+    local want="${addr##*|}"
+    want="${want%%/*}"
+    if [ -z "${want}" ]; then
+        return 1
+    fi
+
+    # Host interfaces (exact inet/inet6 match; escape dots so they are literal).
+    local want_re="$(printf '%s' "${want}" | sed 's/[.]/\\./g')"
+    if ifconfig 2>/dev/null | grep -Eq "^[[:space:]]*inet6?[[:space:]]+${want_re}([[:space:]]|%|\$)"; then
+        echo "a host interface"
+        return 0
+    fi
+
+    # Other jails: shared-IP jails record the address in jail.conf (ip4.addr /
+    # ip6.addr); VNET jails record it inside the jail's rc.conf (ifconfig_vnet*),
+    # the same two sources bastille list reads.
+    if [ -d "${bastille_jailsdir}" ]; then
+        local jd jail_ips
+        for jd in "${bastille_jailsdir}"/*/; do
+            [ -d "${jd}" ] || continue
+            jail_ips="$(
+                sed -n 's/^[[:space:]]*ip[46]\.addr[[:space:]]*[+]*=[[:space:]]*\(.*\);.*$/\1/p' "${jd}jail.conf" 2>/dev/null \
+                    | sed -e 's#/# #g' -e 's/.*|//g' | awk '{print $1}'
+                grep -E '^ifconfig_vnet.*inet ' "${jd}root/etc/rc.conf" 2>/dev/null \
+                    | grep -o 'inet .*' | awk '{print $2}' | sed -E 's#/[0-9]+.*##g; s/"//g'
+                grep -E '^ifconfig_vnet.*inet6' "${jd}root/etc/rc.conf" 2>/dev/null \
+                    | grep -Eow '(::)?[0-9a-fA-F]{1,4}(::?[0-9a-fA-F]{1,4}){1,7}(::)?' | sed 's/"//g'
+            )"
+            if printf '%s\n' "${jail_ips}" | grep -qxF "${want}"; then
+                echo "jail $(basename "${jd}")"
+                return 0
+            fi
+        done
+    fi
+
+    # VMs (address= in each vm.conf).
+    if [ -d "${bastille_vmdir}" ]; then
+        local vc vaddr
+        for vc in "${bastille_vmdir}"/*/vm.conf; do
+            [ -f "${vc}" ] || continue
+            vaddr="$(sysrc -f "${vc}" -n address 2>/dev/null)"
+            vaddr="${vaddr%%/*}"
+            if [ -n "${vaddr}" ] && [ "${vaddr}" = "${want}" ]; then
+                echo "VM $(basename "$(dirname "${vc}")")"
+                return 0
+            fi
+        done
+    fi
+    return 1
+}
+
 validate_netconf() {
     # Add default 'bastille_network_vnet_type' on old config file
     # This is so we don't have to indtroduce a 'breaking change' statement

--- a/usr/local/share/bastille/common.sh
+++ b/usr/local/share/bastille/common.sh
@@ -35,6 +35,16 @@
 # shellcheck disable=SC1090
 . ${BASTILLE_CONFIG}
 
+# Provide defaults for VM (bhyve) settings so configs predating VM support
+# keep working without edits. Real values come from bastille.conf.
+: "${bastille_vmdir:=${bastille_prefix}/vms}"
+: "${bastille_vm_bootrom:=/usr/local/share/uefi-firmware/BHYVE_UEFI.fd}"
+: "${bastille_vm_bridge:=bridge0}"
+: "${bastille_vm_shutdown_timeout:=30}"
+: "${bastille_vm_disk_type:=virtio-blk}"
+: "${bastille_vm_nic_type:=virtio-net}"
+: "${bastille_vm_devfs_ruleset:=100}"
+
 COLOR_RED=
 COLOR_GREEN=
 COLOR_YELLOW=
@@ -144,6 +154,46 @@ check_target_is_stopped() {
         return 1
     else
         return 0
+    fi
+}
+
+check_vm_exists() {
+    local target="${1}"
+    if [ -f "${bastille_vmdir}/${target}/vm.conf" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+check_vm_is_running() {
+    ## A Bastille VM is running when its supervision jail exists. Keying on the
+    ## jail (not /dev/vmm) is what lets 'stop' tear down a persistent jail that
+    ## lingers after bhyve exits -- e.g. when a guest powers itself off.
+    local target="${1}"
+    if jls name 2>/dev/null | grep -Eq "^${target}$"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+check_vm_is_stopped() {
+    local target="${1}"
+    if jls name 2>/dev/null | grep -Eq "^${target}$"; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+check_vm_guest_is_running() {
+    ## The bhyve guest itself is live when its vmm(4) instance exists.
+    local target="${1}"
+    if [ -e "/dev/vmm/${target}" ]; then
+        return 0
+    else
+        return 1
     fi
 }
 

--- a/usr/local/share/bastille/console.sh
+++ b/usr/local/share/bastille/console.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille console [option(s)] TARGET [USER]"
@@ -73,6 +74,30 @@ TARGET="${1}"
 USER="${2}"
 
 bastille_root_check
+
+# Brand dispatch: a VM console is the nmdm serial line, not a jexec login.
+if check_vm_exists "${TARGET}"; then
+    if ! check_vm_is_running "${TARGET}"; then
+        if [ "${AUTO}" -eq 1 ]; then
+            bastille start "${TARGET}" || error_exit "[ERROR]: Failed to start VM: ${TARGET}"
+            # bhyve is daemon-backgrounded, so wait briefly for /dev/vmm/<name>.
+            waited=0
+            while [ "${waited}" -lt 10 ]; do
+                check_vm_is_running "${TARGET}" && break
+                sleep 1
+                waited=$((waited + 1))
+            done
+        else
+            info 1 "\n[${TARGET}]:"
+            error_notify "VM is not running."
+            error_exit "Use [-a|--auto] to auto-start the VM."
+        fi
+    fi
+    info 1 "\n[${TARGET}]:"
+    vm_console "${TARGET}"
+    exit $?
+fi
+
 set_target "${TARGET}"
 
 for jail in ${JAILS}; do

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -940,9 +940,17 @@ if [ "${VM_MODE}" -eq 1 ]; then
     if [ "$#" -ne 2 ]; then
         usage
     fi
+    # [-V|--vnet] selects VNET networking: the VM's supervision jail becomes a
+    # VNET jail with the guest's tap inside its own network stack. Default is
+    # shared (guest tap on a host bridge).
+    if [ "${VNET_JAIL}" -eq 1 ]; then
+        VM_NETWORK_TYPE="vnet"
+    else
+        VM_NETWORK_TYPE="shared"
+    fi
     info 1 "\nCreating VM: ${NAME}..."
     validate_vm_name
-    vm_create "${NAME}" "${TEMPLATE}"
+    vm_create "${NAME}" "${TEMPLATE}" "${VM_NETWORK_TYPE}"
     exit 0
 fi
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -156,15 +156,24 @@ define_ips() {
             if [ "${VNET_JAIL}" -eq 0 ]; then
                 error_exit "[ERROR]: Unsupported IP option for non-VNET jail: ${IP4_ADDR}"
             fi
-        # Warn if IP is in use
-        elif ifconfig | grep -qwF "${IP4_ADDR}"; then
-            warn 1 "[WARNING]: IP address in use: ${IP4_ADDR}"
+        # Refuse a concrete address already held by a host interface, another
+        # jail, or a VM (a duplicate address silently breaks connectivity).
+        else
+            local owner_in_use="$(check_address_in_use "${IP4_ADDR}")"
+            if [ -n "${owner_in_use}" ]; then
+                error_exit "[ERROR]: IP address already in use by ${owner_in_use}: ${IP4_ADDR}"
+            fi
         fi
     fi
 
     if [ -n "${IP6_ADDR}" ]; then
         if [ "${IP6_ADDR}" = "SLAAC" ] && [ "${VNET_JAIL}" -eq 0 ]; then
             error_exit "[ERROR]: Unsupported IP option for standard jail: ${IP6_ADDR}"
+        elif [ "${IP6_ADDR}" != "SLAAC" ] && [ "${IP6_ADDR}" != "inherit" ] && [ "${IP6_ADDR}" != "ip_hostname" ]; then
+            local owner_in_use="$(check_address_in_use "${IP6_ADDR}")"
+            if [ -n "${owner_in_use}" ]; then
+                error_exit "[ERROR]: IP address already in use by ${owner_in_use}: ${IP6_ADDR}"
+            fi
         fi
     fi
 

--- a/usr/local/share/bastille/create.sh
+++ b/usr/local/share/bastille/create.sh
@@ -31,11 +31,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     # Build an independent usage for the create command
     # If no option specified, will create a thin jail by default
     error_notify "Usage: bastille create [option(s)] NAME RELEASE IP [INTERFACE]"
+    error_notify "       bastille create --vm [option(s)] NAME TEMPLATE"
     cat << EOF
 
     Options:
@@ -57,10 +59,29 @@ usage() {
          --tags TAG1,TAG2           Apply specified tag(s) to jail. Comma-separated.
     -V | --vnet                     Enable VNET. INTERFACE must be a physical interface.
     -v | --vlan VLANID              Set VLAN ID (VNET only).
+         --vm                       Create a bhyve VM from a VM template (NAME TEMPLATE).
     -Z | --zfs-opts zfs,options     Custom zfs options. Comma-separated.
 
 EOF
     exit 1
+}
+
+validate_vm_name() {
+
+    local NAME_VERIFY="${NAME}"
+    local NAME_SANITY="$(echo "${NAME_VERIFY}" | tr -c -d 'a-zA-Z0-9-_')"
+
+    if check_vm_exists "${NAME}"; then
+        error_exit "[ERROR]: VM already exists: ${NAME}"
+    elif check_target_exists "${NAME}"; then
+        error_exit "[ERROR]: A jail already exists with that name: ${NAME}"
+    elif [ -n "$(echo "${NAME_SANITY}" | awk "/^[-_].*$/")" ]; then
+        error_exit "[ERROR]: VM names may not begin with (-|_) characters!"
+    elif [ "${NAME_VERIFY}" != "${NAME_SANITY}" ]; then
+        error_exit "[ERROR]: VM names may not contain special characters!"
+    elif echo "${NAME_VERIFY}" | grep -qE '^[0-9]+$'; then
+        error_exit "[ERROR]: VM names may not contain only digits."
+    fi
 }
 
 validate_name() {
@@ -70,6 +91,8 @@ validate_name() {
 
     if check_target_exists "${NAME}"; then
         error_exit "[ERROR]: Jail already exists: ${NAME}"
+    elif check_vm_exists "${NAME}"; then
+        error_exit "[ERROR]: A VM already exists with that name: ${NAME}"
     fi
 
     # Make sure NAME has only allowed characters
@@ -780,6 +803,7 @@ PRIORITY="99"
 OPT_GATEWAY=""
 OPT_NAMESERVER=""
 OPT_TAGS=""
+VM_MODE=0
 while [ $# -gt 0 ]; do
     case "${1}" in
         -h|--help|help)
@@ -878,6 +902,10 @@ while [ $# -gt 0 ]; do
             fi
             shift 2
             ;;
+        --vm)
+            VM_MODE=1
+            shift
+            ;;
         -Z|--zfs-opts)
             bastille_zfs_options="${2}"
             shift 2
@@ -904,6 +932,19 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+# Brand dispatch: a VM is created from a template, bypassing the jail path.
+if [ "${VM_MODE}" -eq 1 ]; then
+    NAME="${1}"
+    TEMPLATE="${2}"
+    if [ "$#" -ne 2 ]; then
+        usage
+    fi
+    info 1 "\nCreating VM: ${NAME}..."
+    validate_vm_name
+    vm_create "${NAME}" "${TEMPLATE}"
+    exit 0
+fi
 
 # Validate options
 # Do not allow EMPTY_JAIL with any other jail type

--- a/usr/local/share/bastille/destroy.sh
+++ b/usr/local/share/bastille/destroy.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille destroy [option(s)] JAIL"
@@ -332,7 +333,19 @@ case "${TARGET}" in
         destroy_release
         ;;
     *)
-        if [ -d "${bastille_releasesdir}/${TARGET}" ]; then
+        if check_vm_exists "${TARGET}"; then
+            # Destroy targeted VM
+            if [ "${AUTO_YES}" -ne 1 ]; then
+                info 1 "\nDeleting VM: ${TARGET}"
+                # shellcheck disable=SC3045
+                read -p "Are you sure you want to continue? [y/N]: " answer
+                case "${answer}" in
+                    [Yy]|[Yy][Ee][Ss]) ;;
+                    *) error_exit "[ERROR]: VM not destroyed." ;;
+                esac
+            fi
+            vm_destroy "${TARGET}" "${FORCE}"
+        elif [ -d "${bastille_releasesdir}/${TARGET}" ]; then
             NAME_VERIFY="${TARGET}"
             destroy_release
         else

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille list [option(s)] [all|backup|export|import|ip|jail|limit]"
@@ -143,9 +144,117 @@ get_max_lengths() {
         #MAX_LENGTH_JAIL_TAGS=$(find ${bastille_jailsdir}/*/tags -maxdepth 1 -type f -print0 2> /dev/null | xargs -r0 -P0 -n1 sh -c 'grep -h . "$1" | paste -sd "," -' sh | awk '{print length}' | sort -nr | head -n 1)
         #MAX_LENGTH_JAIL_TAGS=${MAX_LENGTH_JAIL_TAG:-10}
 
+        # Factor VM instances into shared column widths so VM rows align.
+        widen_max_lengths_for_vms
+
+    elif [ -d "${bastille_vmdir}" ] && ls -v --color=never "${bastille_vmdir}"/*/vm.conf >/dev/null 2>&1; then
+        # No jails directory, but VMs exist: seed defaults so VM rows still list.
+        DEFAULT_VALUE="-"
+        SPACER=2
+        MAX_LENGTH_JAIL_NAME=10
+        MAX_LENGTH_JAIL_TYPE=5
+        MAX_LENGTH_JID=3
+        MAX_LENGTH_JAIL_IP=10
+        MAX_LENGTH_JAIL_PORTS=15
+        MAX_LENGTH_JAIL_RELEASE=10
+        widen_max_lengths_for_vms
     else
         error_exit "[ERROR]: No jails found."
     fi
+}
+
+widen_max_lengths_for_vms() {
+
+    [ -d "${bastille_vmdir}" ] || return 0
+    for vmconf in "${bastille_vmdir}"/*/vm.conf; do
+        [ -f "${vmconf}" ] || continue
+        vm="$(basename "$(dirname "${vmconf}")")"
+        if [ "${#vm}" -gt "${MAX_LENGTH_JAIL_NAME}" ]; then MAX_LENGTH_JAIL_NAME="${#vm}"; fi
+        VM_ADDR="$(vm_get "${vm}" address)"
+        if [ -n "${VM_ADDR}" ] && [ "${#VM_ADDR}" -gt "${MAX_LENGTH_JAIL_IP}" ]; then MAX_LENGTH_JAIL_IP="${#VM_ADDR}"; fi
+        # "uefi-guest" is the widest VM release label.
+        if [ "${MAX_LENGTH_JAIL_RELEASE}" -lt 10 ]; then MAX_LENGTH_JAIL_RELEASE=10; fi
+    done
+}
+
+get_vm_list() {
+
+    if [ -n "${TARGET}" ]; then
+        VM_LIST="${TARGET}"
+    else
+        VM_LIST="$(ls -v --color=never "${bastille_vmdir}" 2>/dev/null | sed "s/\n//g")"
+    fi
+}
+
+get_vm_info() {
+
+    VM_NAME="${1}"
+
+    # A VM's JID exists only while its supervision jail is running.
+    JID="$(jls -j ${VM_NAME} jid 2>/dev/null)"
+    JID="${JID:-${DEFAULT_VALUE}}"
+
+    if check_vm_is_running "${VM_NAME}"; then
+        JAIL_STATE="Up"
+    else
+        JAIL_STATE="Down"
+    fi
+
+    JAIL_TYPE="vm"
+    BOOT="$(sysrc -f ${bastille_vmdir}/${VM_NAME}/settings.conf -n boot 2>/dev/null)"
+    BOOT="${BOOT:-${DEFAULT_VALUE}}"
+    PRIORITY="$(sysrc -f ${bastille_vmdir}/${VM_NAME}/settings.conf -n priority 2>/dev/null)"
+    PRIORITY="${PRIORITY:-${DEFAULT_VALUE}}"
+    JAIL_IP="$(vm_get "${VM_NAME}" address)"
+    JAIL_IP="${JAIL_IP:-${DEFAULT_VALUE}}"
+    JAIL_PORTS="${DEFAULT_VALUE}"
+    # Single-token guest label; a space here would break -j/JSON field parsing.
+    case "$(vm_get "${VM_NAME}" bootrom)" in
+        *CSM*|*csm*) JAIL_RELEASE="uefi-csm" ;;
+        *) JAIL_RELEASE="uefi-guest" ;;
+    esac
+    JAIL_TAGS="${DEFAULT_VALUE}"
+}
+
+# Append VM rows to the default table, matching list_bastille's format.
+print_vm_rows() {
+
+    [ -d "${bastille_vmdir}" ] || return 0
+    get_vm_list
+
+    for vm in ${VM_LIST}; do
+
+        [ -f "${bastille_vmdir}/${vm}/vm.conf" ] || continue
+
+        get_vm_info "${vm}"
+
+        # Honor the -u|-d state filter, like get_jail_info does for jails.
+        if [ "${OPT_STATE:-all}" != "all" ] && [ "${JAIL_STATE}" != "${OPT_STATE}" ]; then
+            continue
+        fi
+
+        printf " ${JID}%*s${vm}%*s${BOOT}%*s${PRIORITY}%*s${JAIL_STATE}%*s${JAIL_TYPE}%*s${JAIL_IP}%*s${JAIL_PORTS}%*s${JAIL_RELEASE}%*s${JAIL_TAGS}\n" "$((${MAX_LENGTH_JID} - ${#JID} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_NAME} - ${#vm} + ${SPACER}))" "" "$((4 - ${#BOOT} + ${SPACER}))" "" "$((4 - ${#PRIORITY} + ${SPACER}))" "" "$((5 - ${#JAIL_STATE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_TYPE} - ${#JAIL_TYPE} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_IP} - ${#JAIL_IP} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_PORTS} - ${#JAIL_PORTS} + ${SPACER}))" "" "$((${MAX_LENGTH_JAIL_RELEASE} - ${#JAIL_RELEASE} + ${SPACER}))" ""
+
+    done
+}
+
+list_vm() {
+
+    printf " %-20s %-8s %s\n" "Name" "State" "Type"
+    for vmconf in "${bastille_vmdir}"/*/vm.conf; do
+        [ -f "${vmconf}" ] || continue
+        vm="$(basename "$(dirname "${vmconf}")")"
+        if check_vm_is_running "${vm}"; then
+            VM_STATE="Up"
+        else
+            VM_STATE="Down"
+        fi
+        # Honor the -u|-d state filter.
+        if [ "${OPT_STATE:-all}" != "all" ] && [ "${VM_STATE}" != "${OPT_STATE}" ]; then
+            continue
+        fi
+        printf " %-20s %-8s %s\n" "${vm}" "${VM_STATE}" "vm"
+    done
 }
 
 get_jail_info() {
@@ -349,6 +458,9 @@ list_bastille(){
     wait
 
     print_info
+
+    # Append bhyve VMs as peers of jails (Type column shows 'vm').
+    print_vm_rows
 }
 
 list_all(){
@@ -793,6 +905,9 @@ if [ "$#" -eq 1 ]; then
         jail|jails|container|containers)
             list_jail
             ;;
+        vm|vms)
+            list_vm
+            ;;
         log|logs)
             list_log
             ;;
@@ -806,6 +921,13 @@ if [ "$#" -eq 1 ]; then
         *)
             # Check if we want to query all info for a specific jail instead.
             TARGET="${1}"
+            # A VM target renders as a single-row VM table.
+            if check_vm_exists "${TARGET}"; then
+                get_max_lengths
+                printf " JID%*sName%*sBoot%*sPrio%*sState%*sType%*sIP Address%*sPublished Ports%*sRelease%*sTags\n" "$((${MAX_LENGTH_JID} + ${SPACER} - 3))" "" "$((${MAX_LENGTH_JAIL_NAME} + ${SPACER} - 4))" "" "$((${SPACER}))" "" "$((${SPACER}))" "" "$((${SPACER}))" "" "$((${MAX_LENGTH_JAIL_TYPE} + ${SPACER} - 4))" "" "$((${MAX_LENGTH_JAIL_IP} + ${SPACER} - 10))" "" "$((${MAX_LENGTH_JAIL_PORTS} + ${SPACER} - 15))" "" "$((${MAX_LENGTH_JAIL_RELEASE} + ${SPACER} - 7))" ""
+                print_vm_rows
+                exit 0
+            fi
       	    set_target "${TARGET}"
             if [ -f "${bastille_jailsdir}/${TARGET}/jail.conf" ]; then
                 if [ "${OPT_JSON}" -eq 1 ]; then

--- a/usr/local/share/bastille/list.sh
+++ b/usr/local/share/bastille/list.sh
@@ -172,8 +172,11 @@ widen_max_lengths_for_vms() {
         if [ "${#vm}" -gt "${MAX_LENGTH_JAIL_NAME}" ]; then MAX_LENGTH_JAIL_NAME="${#vm}"; fi
         VM_ADDR="$(vm_get "${vm}" address)"
         if [ -n "${VM_ADDR}" ] && [ "${#VM_ADDR}" -gt "${MAX_LENGTH_JAIL_IP}" ]; then MAX_LENGTH_JAIL_IP="${#VM_ADDR}"; fi
-        # "uefi-guest" is the widest VM release label.
-        if [ "${MAX_LENGTH_JAIL_RELEASE}" -lt 10 ]; then MAX_LENGTH_JAIL_RELEASE=10; fi
+        # Widen the Release column to the guest OS label (or the "uefi-guest"
+        # fallback, whichever is longer).
+        VM_OS="$(vm_get "${vm}" os)"
+        VM_OS="${VM_OS:-uefi-guest}"
+        if [ "${#VM_OS}" -gt "${MAX_LENGTH_JAIL_RELEASE}" ]; then MAX_LENGTH_JAIL_RELEASE="${#VM_OS}"; fi
     done
 }
 
@@ -208,11 +211,16 @@ get_vm_info() {
     JAIL_IP="$(vm_get "${VM_NAME}" address)"
     JAIL_IP="${JAIL_IP:-${DEFAULT_VALUE}}"
     JAIL_PORTS="${DEFAULT_VALUE}"
-    # Single-token guest label; a space here would break -j/JSON field parsing.
-    case "$(vm_get "${VM_NAME}" bootrom)" in
-        *CSM*|*csm*) JAIL_RELEASE="uefi-csm" ;;
-        *) JAIL_RELEASE="uefi-guest" ;;
-    esac
+    # Guest OS label (e.g. "Ubuntu-24.04"), derived from the install ISO or an
+    # OS verb at create time. Falls back to the firmware type. Always a single
+    # token, so it never breaks the -j/JSON field parsing.
+    JAIL_RELEASE="$(vm_get "${VM_NAME}" os)"
+    if [ -z "${JAIL_RELEASE}" ]; then
+        case "$(vm_get "${VM_NAME}" bootrom)" in
+            *CSM*|*csm*) JAIL_RELEASE="uefi-csm" ;;
+            *) JAIL_RELEASE="uefi-guest" ;;
+        esac
+    fi
     JAIL_TAGS="${DEFAULT_VALUE}"
 }
 

--- a/usr/local/share/bastille/restart.sh
+++ b/usr/local/share/bastille/restart.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille restart [option(s)] TARGET"
@@ -98,6 +99,20 @@ fi
 TARGET="${1}"
 
 bastille_root_check
+
+# Brand dispatch: restart a VM via its own stop/start (which dispatch too).
+if check_vm_exists "${TARGET}"; then
+    if [ "${IGNORE}" -eq 1 ]; then
+        if check_vm_is_stopped "${TARGET}"; then
+            info 1 "\n[${TARGET}]:"
+            error_exit "VM is stopped."
+        fi
+    fi
+    bastille stop ${stop_options} "${TARGET}"
+    bastille start ${start_options} "${TARGET}"
+    exit $?
+fi
+
 set_target "${TARGET}"
 
 for jail in ${JAILS}; do

--- a/usr/local/share/bastille/start.sh
+++ b/usr/local/share/bastille/start.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille start [option(s)] TARGET"
@@ -95,6 +96,25 @@ fi
 TARGET="${1}"
 
 bastille_root_check
+
+# Brand dispatch: route VM targets to the bhyve supervisor.
+if check_vm_exists "${TARGET}"; then
+    # Respect '-b|--boot' + settings.conf boot value, like jails.
+    if [ "${BOOT}" -eq 1 ]; then
+        BOOT_ENABLED="$(sysrc -f ${bastille_vmdir}/${TARGET}/settings.conf -n boot)"
+        if [ "${BOOT_ENABLED}" = "off" ]; then
+            exit 0
+        fi
+    fi
+    info 1 "\n[${TARGET}]:"
+    if vm_start "${TARGET}"; then
+        sleep "${DELAY_TIME}"
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
 set_target "${TARGET}"
 
 for jail in ${JAILS}; do

--- a/usr/local/share/bastille/stop.sh
+++ b/usr/local/share/bastille/stop.sh
@@ -31,6 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 . /usr/local/share/bastille/common.sh
+. /usr/local/share/bastille/bhyve.sh
 
 usage() {
     error_notify "Usage: bastille stop [option(s)] TARGET"
@@ -85,6 +86,17 @@ fi
 TARGET="${1}"
 
 bastille_root_check
+
+# Brand dispatch: route VM targets to the bhyve supervisor.
+if check_vm_exists "${TARGET}"; then
+    info 1 "\n[${TARGET}]:"
+    if vm_stop "${TARGET}" "${FORCE}"; then
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
 set_target "${TARGET}" "reverse"
 
 for jail in ${JAILS}; do

--- a/usr/local/share/man/man8/bastille-create.8
+++ b/usr/local/share/man/man8/bastille-create.8
@@ -15,6 +15,7 @@
 .Op Fl -no-boot
 .Op Fl -no-ip
 .Op Fl -no-validate
+.Op Fl -vm
 .Ar NAME RELEASE IP Op INTERFACE
 .Sh DESCRIPTION
 The
@@ -106,6 +107,20 @@ Set VLAN ID (VNET only).
 This will configure the jail to use the specified
 .Ar VALUE
 as the VLAN ID.
+.It Fl -vm
+Create a bhyve virtual machine from a VM template instead of a jail.
+.Pp
+In this mode the positional arguments are
+.Ar NAME
+and
+.Ar TEMPLATE
+(a template whose Bastillefile opens with the
+.Sy VM
+verb). The VM is defined by the template, backed by zvols, and managed with
+the same lifecycle verbs as jails
+.Po Nm bastille start , Nm stop , Nm console , Nm destroy Pc .
+Requires ZFS and
+.Xr bhyve 8 .
 .It Fl Z Ar VALUE,VALUE , Fl -zfs-opts Ar VALUE,VALUE
 Custom zfs options. Comma-separated.
 .Pp
@@ -120,6 +135,8 @@ This overrides the defaults. See
 .Sy bastille create -B myjail 15.0-RELEASE DHCP mycustombridge
 .It Create a Linux jail:
 .Sy bastille create -L myjail bookworm 10.2.4.5
+.It Create a bhyve VM from a VM template:
+.Sy bastille create --vm builder sasha/forgejo-runner-vm
 .It Create a VNET jail with boot=off and custom gateway:
 .Sy bastille create -V --no-boot -g 10.1.1.1 myjail 15.0-RELEASE 10.1.1.4/24 vtnet0
 .Pp


### PR DESCRIPTION
## RFC / Draft: first-class bhyve VM support

**This is a draft opened as an RFC -- I'm seeking design feedback, not asking for a merge yet.** The manifest format is a long-term commitment, so I'd rather agree on the shape with maintainers before polishing.

### Summary

Adds bhyve virtual machines as a peer instance type to jails. A VM is defined by a git-trackable template, provisioned with the existing template workflow, and driven by the same lifecycle verbs (`create`/`start`/`stop`/`console`/`list`/`destroy`). The goal is a single management plane for every workload on a FreeBSD host -- whether it runs on the host kernel (a jail) or brings its own (a VM). Deliberately inspired by illumos zone brands and SmartOS ("everything is a zone, the brand is a detail").

### What's here

- New `bhyve.sh` library: template parser, authoritative `vm.conf`, zvol-backed disks, tap-on-bridge networking, bhyve(8) argument generation (materialized to `bhyve.args`), a supervision jail with `allow.vmm`, nmdm(4) serial console, and rctl memory capping.
- Brand dispatch across `create`/`start`/`stop`/`console`/`destroy`/`restart`/`list` -- the jail path is untouched when the target isn't a VM.
- New Bastillefile verbs in VM mode: `VM CPU MEM BOOTROM DISK NIC ISO ADDRESS` (jail-only verbs error in VM mode; a template is one brand).
- `bastille create --vm NAME TEMPLATE`; `bastille list` grows `vm` rows via the existing Type column plus a `list vms` subcommand.
- Docs chapter, `bastille-create(8)` update, example template, and rc.d boot/shutdown ordering.

### Validated on bare-metal FreeBSD 15.0-RELEASE amd64

An Alpine guest boots to a serial login over nmdm, appears in `bastille list` as a `Type=vm` peer with a real JID, reboots correctly (bhyve relaunches rather than powering off), stops gracefully (ACPI power button, then forced after a timeout), and destroys cleanly -- with the host `/dev`/`zfs` unaffected throughout. ShellCheck clean at this repo's CI severity and exclusions.

### Scope (deliberately minimal)

Non-goals for v1: suspend/resume, live migration, cloud-init/ignition, VNC/graphical console, Windows guests, PCI passthrough, multi-host orchestration. RDR-to-pf wiring for VMs is recorded but deferred. ZFS is required.

### Open questions for maintainers

1. **In Bastille or beside it?** This is the first conversation to have. The design works either way, but the manifest format deserves maintainer buy-in even if the code starts external.
2. ~~**Supervision-jail devfs confinement.** v1 uses `path=/` and shares the host `/dev`. A restrictive per-VM devfs ruleset (exposing only the VM's vmm/tap/nmdm devices) needs a dedicated jail root with an isolated `/dev`, and is deferred -- because `path=/` + `mount.devfs` + a ruleset stacks a locked-down devfs over the host's own `/dev` and hides host devices like `/dev/zfs`. Left out until it can be done with an isolated root.~~ **Update: done.** The supervision jail now runs in its own root (a read-only nullfs skeleton of only the userland bhyve needs) with a private per-VM devfs that exposes only that VM's own nodes (`vmm`/`vmm.io`/`nmdm`/tap/zvols plus `null`/`zero`/`random`/`pci`) and hides `/dev/mem`, `/dev/kmem`, raw host disks, and every other VM. It also gets its own vnet (empty in shared mode, full in VNET mode), so it sees no host interfaces. On by default via `bastille_vm_isolated_devfs`, validated on bare metal in both networking modes.
3. **Manifest stability** (a `version=` key from day one?), **naming** (`--vm` flag vs a `bastille vm` subcommand), and **rctl defaults** -- all discussed in the design.

I'm happy to open a Discussion or attach the full design document (motivation, prior art -- vm-bhyve / CBSD / illumos zones / kernel zones, risks and mitigations) if that's the preferred venue for the design conversation.

