### PR TITLE
config: Supports multiple comma separated get values

### DIFF
--- a/docs/chapters/subcommands/config.rst
+++ b/docs/chapters/subcommands/config.rst
@@ -15,6 +15,17 @@ Getting a property that *is not* defined in jail.conf
   ishmael ~ # bastille config azkaban get notaproperty
   not set
 
+Getting several properties at once (comma-separated). A single property
+still prints only its value; multiple properties print a table:
+
+.. code-block:: shell
+
+  ishmael ~ # bastille config alcatraz get name,securelevel,osrelease
+  PROPERTY     VALUE
+  name         alcatraz
+  securelevel  2
+  osrelease    15.1-RELEASE
+
 Setting a property:
 
 .. code-block:: shell
@@ -78,8 +89,17 @@ scraping stderr. The process exits 1:
     }
   }
 
+Multiple properties become extra fields on the same jail object
+(``name`` is not duplicated when it is also queried):
+
+.. code-block:: shell
+
+  ishmael ~ # bastille -j config alcatraz get name,securelevel,osrelease
+  {"bastille": {"type":"jail", "jail": [{"jid":1,"name":"alcatraz","securelevel":"2","osrelease":"15.1-RELEASE"}]}}
+
 .. code-block:: shell
 
   ishmael ~ # bastille config help
   Usage: bastille config [option(s)] TARGET set|add PROPERTY [VALUE]
-                                            get|remove PROPERTY
+                                            get PROPERTY[,PROPERTY...]
+                                            remove PROPERTY

--- a/docs/chapters/subcommands/config.rst
+++ b/docs/chapters/subcommands/config.rst
@@ -26,6 +26,32 @@ still prints only its value; multiple properties print a table:
   securelevel  2
   osrelease    15.1-RELEASE
 
+Getting a property from every jail. Multiple jails always print a
+``JID JAIL PROPERTY VALUE`` table (stopped jails show ``-`` in the
+``JID`` column):
+
+.. code-block:: shell
+
+  ishmael ~ # bastille config ALL get securelevel
+  JID  JAIL         PROPERTY     VALUE
+  2    alcatraz     securelevel  2
+  3    bella        securelevel  2
+  1    gorgona      securelevel  2
+
+Several properties across every jail use the same four columns, one
+row per jail and property:
+
+.. code-block:: shell
+
+  ishmael ~ # bastille config ALL get name,securelevel
+  JID  JAIL         PROPERTY     VALUE
+  2    alcatraz     name         alcatraz
+  2    alcatraz     securelevel  2
+  3    bella        name         bella
+  3    bella        securelevel  2
+  1    gorgona      name         gorgona
+  1    gorgona      securelevel  2
+
 Setting a property:
 
 .. code-block:: shell

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION=1.4.4
+BASTILLE_VERSION=-
 export BASTILLE_VERSION # needed to check min_version in plugins
 
 # Validate config file

--- a/usr/local/bin/bastille
+++ b/usr/local/bin/bastille
@@ -32,7 +32,7 @@
 
 PATH=${PATH}:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASTILLE_VERSION=-
+BASTILLE_VERSION=1.4.4
 export BASTILLE_VERSION # needed to check min_version in plugins
 
 # Validate config file

--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -151,6 +151,7 @@ validate_property() {
     esac
 }
 
+# boot/depend/priority live in settings.conf (sysrc), not jail.conf.
 is_bastille_property() {
     case "${1}" in
         boot|depend|depends|prio|priority)
@@ -162,6 +163,7 @@ is_bastille_property() {
     esac
 }
 
+# Canonical names so `get prio` and `get priority` hit the same sysrc key.
 normalize_property() {
     case "${1}" in
         prio)
@@ -176,10 +178,13 @@ normalize_property() {
     esac
 }
 
-# get accepts a comma-separated property list; set/remove stay single-property
+# Comma lists are get-only (like `zfs get atime,compression`). set/remove
+# still take one property so we never partially apply a mutation.
 PROPERTIES=""
 PROP_COUNT=0
 if [ "${ACTION}" = "get" ]; then
+    # `name,` never yields an empty token in the loop below (the comma is
+    # consumed and _rest becomes empty), so catch leading/trailing commas here.
     case "${PROPERTY}" in
         ,*|*,)
             error_exit "[ERROR]: Empty property in list."
@@ -197,6 +202,8 @@ if [ "${ACTION}" = "get" ]; then
                 _rest=""
                 ;;
         esac
+        # Allow `get 'name, boot'` (quoted spaces); unquoted spaces are
+        # extra argv and already rejected by the get argc check.
         _one="$(printf '%s' "${_one}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         if [ -z "${_one}" ]; then
             error_exit "[ERROR]: Empty property in list."
@@ -232,7 +239,8 @@ print_jail_conf() {
 '
 }
 
-# Query one property from a jail(8) -e dump on stdin
+# Exit 120 is the historic "not set" signal so 1x1 get can warn (yellow)
+# without changing the printed text scripts already match.
 query_jail_conf() {
     awk -F= -v property="${1}" '
         $1 == property {
@@ -254,8 +262,7 @@ query_jail_conf() {
         }'
 }
 
-# Print the value of one property for one jail. Returns 120 when a
-# jail.conf property is unset, 2 when jail.conf is missing.
+# Returns 120 when a jail.conf property is unset, 2 when jail.conf is missing.
 config_get_value() {
     local _jail="${1}"
     local _prop="${2}"
@@ -271,6 +278,8 @@ config_get_value() {
             ;;
     esac
 
+    # jail -f is relatively expensive; parse once per jail and reuse the dump
+    # for every requested jail.conf property.
     _file="${bastille_jailsdir}/${_jail}/jail.conf"
     if [ "${JAIL_CONF_LOADED}" -eq 0 ]; then
         if [ ! -f "${_file}" ]; then
@@ -286,6 +295,8 @@ config_get_value() {
     return "${_status}"
 }
 
+# Stopped jails have no jls entry. Human tables use "-" like `bastille list`;
+# JSON still emits null via json_record.
 config_jail_jid() {
     local _jid
     _jid="$(jls -j "${1}" jid 2>/dev/null || :)"
@@ -296,6 +307,10 @@ config_jail_jid() {
     fi
 }
 
+# One jail's worth of get output. JSON: one object, extra properties as extra
+# fields (json_record drops a duplicate `name` so `get name` stays identity).
+# Human: 1x1 stays a bare value so scripts and recursive `config get ip4.addr`
+# still parse one line; tables follow `zfs get`.
 emit_get_for_jail() {
     local jail="${1}"
     local _prop _val _st _needs_conf _jid
@@ -310,6 +325,8 @@ emit_get_for_jail() {
             *) _needs_conf=1 ;;
         esac
     done
+    # Missing jail.conf: skip the jail (historic) rather than error_exit,
+    # so `config ALL get` can still report the other jails.
     if [ "${_needs_conf}" -eq 1 ] && [ ! -f "${bastille_jailsdir}/${jail}/jail.conf" ]; then
         error_notify "jail.conf does not exist for jail: ${jail}"
         return 0
@@ -333,12 +350,14 @@ emit_get_for_jail() {
         _val="$(config_get_value "${jail}" "${_prop}")"
         _st=$?
         if [ "${TABLE_MODE}" -eq 0 ]; then
+            # Yellow "not set" is only useful when it is the entire output.
             if [ "${_st}" -eq 120 ]; then
                 warn 3 "${_val}"
             else
                 info 3 "${_val}"
             fi
         elif [ "${TABLE_MODE}" -eq 1 ]; then
+            # Color on a single cell would shift column padding.
             info 3 "$(printf '%-*s %s' "${MAX_PROP}" "${_prop}" "${_val}")"
         else
             info 3 "$(printf '%-*s %-*s %-*s %s' \
@@ -350,9 +369,9 @@ emit_get_for_jail() {
     done
 }
 
-# 0 = bare value (1 jail × 1 property)
-# 1 = PROPERTY VALUE
-# 2 = JID JAIL PROPERTY VALUE
+# 0 = bare value (scripts depend on one line, no header)
+# 1 = PROPERTY VALUE  (one jail, several properties — identity is already known)
+# 2 = JID JAIL PROPERTY VALUE  (several jails; same shape as `zfs get`)
 JAIL_COUNT=0
 TABLE_MODE=0
 if [ "${ACTION}" = "get" ]; then
@@ -369,6 +388,9 @@ fi
 # Emit JSON only for the 'get' action (a query); other actions are unchanged.
 [ "${ACTION}" = "get" ] && json_open jail
 
+# Header once, before the jail loop. Floor widths at the header labels so a
+# short name like "jid" does not under-align "PROPERTY". VALUE is the last
+# column and unpadded so spaces in ip4.addr / depend stay in one field.
 if [ "${ACTION}" = "get" ] && [ "${BASTILLE_JSON:-0}" -ne 1 ] && [ "${TABLE_MODE}" -gt 0 ]; then
     MAX_PROP=8
     for _p in ${PROPERTIES}; do
@@ -395,6 +417,7 @@ fi
 for jail in ${JAILS}; do
 
     if [ "${ACTION}" = "get" ]; then
+        # get is handled above; skip the set/remove mutation path.
         emit_get_for_jail "${jail}"
         continue
     fi

--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -34,7 +34,9 @@
 
 
 usage() {
-    error_exit "Usage: bastille config [option(s)] TARGET set|add PROPERTY [VALUE]"
+    error_exit "Usage: bastille config [option(s)] TARGET set|add PROPERTY [VALUE]
+                                            get PROPERTY[,PROPERTY...]
+                                            remove PROPERTY"
 }
 
 # Handle options
@@ -149,14 +151,77 @@ validate_property() {
     esac
 }
 
-case "${PROPERTY}" in
-    boot|depend|depends|prio|priority)
-        BASTILLE_PROPERTY=1
-        ;;
-    *)
-        validate_property "${PROPERTY}"
-        ;;
-esac
+is_bastille_property() {
+    case "${1}" in
+        boot|depend|depends|prio|priority)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+normalize_property() {
+    case "${1}" in
+        prio)
+            printf '%s\n' "priority"
+            ;;
+        depends)
+            printf '%s\n' "depend"
+            ;;
+        *)
+            printf '%s\n' "${1}"
+            ;;
+    esac
+}
+
+# get accepts a comma-separated property list; set/remove stay single-property
+PROPERTIES=""
+PROP_COUNT=0
+if [ "${ACTION}" = "get" ]; then
+    case "${PROPERTY}" in
+        ,*|*,)
+            error_exit "[ERROR]: Empty property in list."
+            ;;
+    esac
+    _rest="${PROPERTY}"
+    while [ -n "${_rest}" ]; do
+        case "${_rest}" in
+            *,*)
+                _one="${_rest%%,*}"
+                _rest="${_rest#*,}"
+                ;;
+            *)
+                _one="${_rest}"
+                _rest=""
+                ;;
+        esac
+        _one="$(printf '%s' "${_one}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        if [ -z "${_one}" ]; then
+            error_exit "[ERROR]: Empty property in list."
+        fi
+        if ! is_bastille_property "${_one}"; then
+            validate_property "${_one}"
+        fi
+        _one="$(normalize_property "${_one}")"
+        PROPERTIES="${PROPERTIES} ${_one}"
+        PROP_COUNT=$((PROP_COUNT + 1))
+    done
+    PROPERTIES="${PROPERTIES# }"
+    if [ "${PROP_COUNT}" -eq 0 ]; then
+        error_exit "[ERROR]: Empty property in list."
+    fi
+else
+    case "${PROPERTY}" in
+        boot|depend|depends|prio|priority)
+            BASTILLE_PROPERTY=1
+            ;;
+        *)
+            validate_property "${PROPERTY}"
+            ;;
+    esac
+fi
 
 # we need jail(8) to parse the config file so it can expand variables etc
 print_jail_conf() {
@@ -167,10 +232,122 @@ print_jail_conf() {
 '
 }
 
+# Query one property from a jail(8) -e dump on stdin
+query_jail_conf() {
+    awk -F= -v property="${1}" '
+        $1 == property {
+            found = 1;
+            if (NF == 2) {
+                sub(/^"/, "", $2);
+                sub(/"$/, "", $2);
+                print $2;
+            } else {
+                print "enabled";
+            }
+            exit 0;
+        }
+        END {
+            if (! found) {
+                print("not set");
+                exit(120);
+            }
+        }'
+}
+
+# Print the value of one property for one jail. Returns 120 when a
+# jail.conf property is unset, 2 when jail.conf is missing.
+config_get_value() {
+    local _jail="${1}"
+    local _prop="${2}"
+    local _file
+    local _output
+    local _status
+
+    case "${_prop}" in
+        boot|depend|priority)
+            _file="${bastille_jailsdir}/${_jail}/settings.conf"
+            sysrc -f "${_file}" -n "${_prop}" 2>/dev/null
+            return 0
+            ;;
+    esac
+
+    _file="${bastille_jailsdir}/${_jail}/jail.conf"
+    if [ "${JAIL_CONF_LOADED}" -eq 0 ]; then
+        if [ ! -f "${_file}" ]; then
+            return 2
+        fi
+        JAIL_CONF_TEXT="$(print_jail_conf "${_file}")"
+        JAIL_CONF_LOADED=1
+    fi
+
+    _output="$(printf '%s\n' "${JAIL_CONF_TEXT}" | query_jail_conf "${_prop}")"
+    _status=$?
+    printf '%s\n' "${_output}"
+    return "${_status}"
+}
+
+emit_get_for_jail() {
+    local jail="${1}"
+    local _prop _val _st _needs_conf
+
+    JAIL_CONF_LOADED=0
+    JAIL_CONF_TEXT=""
+
+    _needs_conf=0
+    for _prop in ${PROPERTIES}; do
+        case "${_prop}" in
+            boot|depend|priority) ;;
+            *) _needs_conf=1 ;;
+        esac
+    done
+    if [ "${_needs_conf}" -eq 1 ] && [ ! -f "${bastille_jailsdir}/${jail}/jail.conf" ]; then
+        error_notify "jail.conf does not exist for jail: ${jail}"
+        return 0
+    fi
+
+    if [ "${BASTILLE_JSON:-0}" -eq 1 ]; then
+        set -- name "${jail}"
+        for _prop in ${PROPERTIES}; do
+            _val="$(config_get_value "${jail}" "${_prop}")"
+            set -- "$@" "${_prop}" "${_val}"
+        done
+        json_record "$@"
+        return 0
+    fi
+
+    for _prop in ${PROPERTIES}; do
+        _val="$(config_get_value "${jail}" "${_prop}")"
+        _st=$?
+        if [ "${PROP_COUNT}" -eq 1 ]; then
+            if [ "${_st}" -eq 120 ]; then
+                warn 3 "${_val}"
+            else
+                info 3 "${_val}"
+            fi
+        else
+            info 3 "$(printf '%-*s %s' "${MAX_PROP}" "${_prop}" "${_val}")"
+        fi
+    done
+}
+
 # Emit JSON only for the 'get' action (a query); other actions are unchanged.
 [ "${ACTION}" = "get" ] && json_open jail
 
+if [ "${ACTION}" = "get" ] && [ "${BASTILLE_JSON:-0}" -ne 1 ] && [ "${PROP_COUNT}" -gt 1 ]; then
+    MAX_PROP=8
+    for _p in ${PROPERTIES}; do
+        [ "${#_p}" -gt "${MAX_PROP}" ] && MAX_PROP="${#_p}"
+    done
+    info 3 "$(printf '%-*s %s' "${MAX_PROP}" "PROPERTY" "VALUE")"
+fi
+
 for jail in ${JAILS}; do
+
+    if [ "${ACTION}" = "get" ]; then
+        emit_get_for_jail "${jail}"
+        continue
+    fi
+
 
     # Backwards compatibility for specifying only an IP with ip[4|6].addr
     if [ "${ACTION}" = "set" ] && [ "${PROPERTY}" = "ip4.addr" ]; then
@@ -195,15 +372,7 @@ for jail in ${JAILS}; do
             depends) PROPERTY="depend" ;;
         esac
 
-        if [ "${ACTION}" = "get" ]; then
-          if [ "${BASTILLE_JSON}" -eq 1 ]; then
-              json_record name "${jail}" "${PROPERTY}" "$(sysrc -f "${FILE}" -n "${PROPERTY}" 2>/dev/null)"
-          else
-
-            sysrc -f "${FILE}" -n "${PROPERTY}"
-          fi
-
-        elif [ "${ACTION}" = "remove" ]; then
+        if [ "${ACTION}" = "remove" ]; then
 
             # Only 'depend' supports removing a value; the rest are permanent
             if [ "${PROPERTY}" != "depend" ]; then
@@ -245,46 +414,7 @@ for jail in ${JAILS}; do
             error_notify "jail.conf does not exist for jail: ${jail}"
             continue
         fi
-        if [ "${ACTION}" = 'get' ]; then
-            _output=$(
-                print_jail_conf "${FILE}" | awk -F= -v property="${PROPERTY}" '
-                    $1 == property {
-                        # note that we have found the property
-                        found = 1;
-                        # check if there is a value for this property
-                        if (NF == 2) {
-                            # remove any quotes surrounding the string
-                            #sub(",[^|]*\\|", ",", $2);
-                            sub(/^"/, "", $2);
-                            sub(/"$/, "", $2);
-                            print $2;
-                        } else {
-                            # no value, just the property name
-                            print "enabled";
-                        }
-                        exit 0;
-                    }
-                    END {
-                        # if we have not found anything we need to print a special
-                        # string
-                        if (! found) {
-                            print("not set");
-                            #  let the caller know that this is a warn condition
-                            exit(120);
-                        }
-                    }'
-                )
-            # capture the awk exit status before any other command resets $?
-            _status=$?
-            # check if our output is a warning or regular
-            if [ "${BASTILLE_JSON}" -eq 1 ]; then
-                json_record name "${jail}" "${PROPERTY}" "${_output}"
-            elif [ "${_status}" -eq 120 ]; then
-                warn 3 "${_output}"
-            else
-                info 3 "${_output}"
-            fi
-        elif [ "${ACTION}" = "remove" ]; then
+        if [ "${ACTION}" = "remove" ]; then
             if [ "$(bastille config ${jail} get ${PROPERTY})" != "not set" ]; then
 
                 info 1 "\n[${jail}]:"

--- a/usr/local/share/bastille/config.sh
+++ b/usr/local/share/bastille/config.sh
@@ -286,9 +286,19 @@ config_get_value() {
     return "${_status}"
 }
 
+config_jail_jid() {
+    local _jid
+    _jid="$(jls -j "${1}" jid 2>/dev/null || :)"
+    if [ -n "${_jid}" ]; then
+        printf '%s\n' "${_jid}"
+    else
+        printf '%s\n' "-"
+    fi
+}
+
 emit_get_for_jail() {
     local jail="${1}"
-    local _prop _val _st _needs_conf
+    local _prop _val _st _needs_conf _jid
 
     JAIL_CONF_LOADED=0
     JAIL_CONF_TEXT=""
@@ -315,30 +325,71 @@ emit_get_for_jail() {
         return 0
     fi
 
+    if [ "${TABLE_MODE}" -eq 2 ]; then
+        _jid="$(config_jail_jid "${jail}")"
+    fi
+
     for _prop in ${PROPERTIES}; do
         _val="$(config_get_value "${jail}" "${_prop}")"
         _st=$?
-        if [ "${PROP_COUNT}" -eq 1 ]; then
+        if [ "${TABLE_MODE}" -eq 0 ]; then
             if [ "${_st}" -eq 120 ]; then
                 warn 3 "${_val}"
             else
                 info 3 "${_val}"
             fi
-        else
+        elif [ "${TABLE_MODE}" -eq 1 ]; then
             info 3 "$(printf '%-*s %s' "${MAX_PROP}" "${_prop}" "${_val}")"
+        else
+            info 3 "$(printf '%-*s %-*s %-*s %s' \
+                "${MAX_JID}" "${_jid}" \
+                "${MAX_JAIL}" "${jail}" \
+                "${MAX_PROP}" "${_prop}" \
+                "${_val}")"
         fi
     done
 }
 
+# 0 = bare value (1 jail × 1 property)
+# 1 = PROPERTY VALUE
+# 2 = JID JAIL PROPERTY VALUE
+JAIL_COUNT=0
+TABLE_MODE=0
+if [ "${ACTION}" = "get" ]; then
+    for _j in ${JAILS}; do
+        JAIL_COUNT=$((JAIL_COUNT + 1))
+    done
+    if [ "${JAIL_COUNT}" -gt 1 ]; then
+        TABLE_MODE=2
+    elif [ "${PROP_COUNT}" -gt 1 ]; then
+        TABLE_MODE=1
+    fi
+fi
+
 # Emit JSON only for the 'get' action (a query); other actions are unchanged.
 [ "${ACTION}" = "get" ] && json_open jail
 
-if [ "${ACTION}" = "get" ] && [ "${BASTILLE_JSON:-0}" -ne 1 ] && [ "${PROP_COUNT}" -gt 1 ]; then
+if [ "${ACTION}" = "get" ] && [ "${BASTILLE_JSON:-0}" -ne 1 ] && [ "${TABLE_MODE}" -gt 0 ]; then
     MAX_PROP=8
     for _p in ${PROPERTIES}; do
         [ "${#_p}" -gt "${MAX_PROP}" ] && MAX_PROP="${#_p}"
     done
-    info 3 "$(printf '%-*s %s' "${MAX_PROP}" "PROPERTY" "VALUE")"
+    if [ "${TABLE_MODE}" -eq 1 ]; then
+        info 3 "$(printf '%-*s %s' "${MAX_PROP}" "PROPERTY" "VALUE")"
+    else
+        MAX_JID=3
+        MAX_JAIL=4
+        for _j in ${JAILS}; do
+            [ "${#_j}" -gt "${MAX_JAIL}" ] && MAX_JAIL="${#_j}"
+            _jid="$(config_jail_jid "${_j}")"
+            [ "${#_jid}" -gt "${MAX_JID}" ] && MAX_JID="${#_jid}"
+        done
+        info 3 "$(printf '%-*s %-*s %-*s %s' \
+            "${MAX_JID}" "JID" \
+            "${MAX_JAIL}" "JAIL" \
+            "${MAX_PROP}" "PROPERTY" \
+            "VALUE")"
+    fi
 fi
 
 for jail in ${JAILS}; do

--- a/usr/local/share/man/man8/bastille-config.8
+++ b/usr/local/share/man/man8/bastille-config.8
@@ -46,10 +46,21 @@ Get the value of the specified
 from the jail configuration. Multiple properties may be given as a
 comma-separated list (for example
 .Ql name,securelevel,osrelease ).
-A single property prints only its value. Multiple properties are
-printed as a
+A single property on a single jail prints only its value. Multiple
+properties on a single jail are printed as a
 .Ql PROPERTY VALUE
-table, one row per property. If a property is not present, 'not
+table, one row per property. Multiple jails (for example
+.Ql ALL )
+are printed as a
+.Ql JID JAIL PROPERTY VALUE
+table, one row per jail and property, like
+.Xr zfs 8
+.Ql get .
+A stopped jail shows
+.Ql -
+in the
+.Ql JID
+column. If a property is not present, 'not
 set' will be shown. If the property has no value, but
 is present, 'enabled' will be returned. Otherwise you will be
 shown the value.
@@ -72,6 +83,10 @@ from the jail configuration.
 .Sy bastille config myjail set boot off
 .It Get several properties from one jail:
 .Sy bastille config myjail get name,securelevel,osrelease
+.It Get a property from all jails:
+.Sy bastille config ALL get securelevel
+.It Get several properties from all jails:
+.Sy bastille config ALL get name,securelevel
 .It Get a property from all jails as JSON:
 .Sy bastille -j config ALL get boot
 .It Get several properties as JSON:

--- a/usr/local/share/man/man8/bastille-config.8
+++ b/usr/local/share/man/man8/bastille-config.8
@@ -12,7 +12,11 @@
 .Op VALUE
 .Nm bastille config
 .Ar TARGET
-.Cm get|remove
+.Cm get
+.Ar PROPERTY Ns Op , Ns Ar PROPERTY Ns ...
+.Nm bastille config
+.Ar TARGET
+.Cm remove
 .Ar PROPERTY
 .Sh DESCRIPTION
 The
@@ -34,19 +38,30 @@ It is not always necesary to set a
 for a
 .Ar PROPERTY .
 For example, 'allow.mlock=1' is the same as 'allow.mlock'.
-.It Sy bastille config Ar TARGET Sy get|remove Ar PROPERTY
+.It Sy bastille config Ar TARGET Sy get Ar PROPERTY Ns Op , Ns Ar PROPERTY Ns ...
 .Bl -tag -width Ds
 .It Sy get
 Get the value of the specified
 .Ar PROPERTY
-from the jail configuration. If a property is not present, 'not
-enabled' will be shown. If the property has no value, but
+from the jail configuration. Multiple properties may be given as a
+comma-separated list (for example
+.Ql name,securelevel,osrelease ).
+A single property prints only its value. Multiple properties are
+printed as a
+.Ql PROPERTY VALUE
+table, one row per property. If a property is not present, 'not
+set' will be shown. If the property has no value, but
 is present, 'enabled' will be returned. Otherwise you will be
 shown the value.
+.El
+.It Sy bastille config Ar TARGET Sy remove Ar PROPERTY
+.Bl -tag -width Ds
 .It Sy remove
 Remove the specified
 .Ar PROPERTY
 from the jail configuration.
+.El
+.El
 .Sh EXAMPLES
 .Bl -tag -width Ds
 .It Set allow.mlock inside myjail:
@@ -55,8 +70,12 @@ from the jail configuration.
 .Sy bastille config myjail set priority 10
 .It Set the boot value:
 .Sy bastille config myjail set boot off
+.It Get several properties from one jail:
+.Sy bastille config myjail get name,securelevel,osrelease
 .It Get a property from all jails as JSON:
 .Sy bastille -j config ALL get boot
+.It Get several properties as JSON:
+.Sy bastille -j config myjail get name,securelevel,osrelease
 .Pp
 The
 .Sy get
@@ -74,10 +93,11 @@ array with a
 .Ql jid ,
 a
 .Ql name ,
-and the queried property as a field named after the property itself (for
+and each queried property as a field named after the property itself (for
 example
 .Ql securelevel )
-holding its value. The
+holding its value. Multiple properties become extra fields on the same
+object. The
 .Ql jid
 leads each record as a native number when the jail is running, or
 .Ql null


### PR DESCRIPTION
Currently you can only get one only value from the jail config, like `bastille config alcatraz get securelevel` and that will print the value. But you hit a limitation if you want to get multiple config values. This PR adds that possibilty:


```
ishmael ~ # bastille config alcatraz get name,securelevel,osrelease
  PROPERTY     VALUE
  name         alcatraz
  securelevel  2
  osrelease    15.1-RELEASE
```

Currently if you want to print a property using ALL as target, you just get a list of values, but you have no idea what value is to what jail. 

This PR allows getting a property from every jail. Multiple jails always print a `JID JAIL PROPERTY VALUE` table (stopped jails show `-` in the `JID` column):

```
  ishmael ~ # bastille config ALL get securelevel
  JID  JAIL         PROPERTY     VALUE
  2    alcatraz     securelevel  2
  3    bella        securelevel  2
  1    gorgona      securelevel  2

```

Several properties across every jail use the same four columns, one row per jail and property:

```
  ishmael ~ # bastille config ALL get name,securelevel
  JID  JAIL         PROPERTY     VALUE
  2    alcatraz     name         alcatraz
  2    alcatraz     securelevel  2
  3    bella        name         bella
  3    bella        securelevel  2
  1    gorgona      name         gorgona
  1    gorgona      securelevel  2
```

This PR makes sure JSON support is not broken and supported in every case.