### PR TITLE
bastille-update: Update child jail osrelease on proper conditions

### DIFF
--- a/usr/local/share/bastille/update.sh
+++ b/usr/local/share/bastille/update.sh
@@ -308,7 +308,7 @@ release_update() {
         # Updated osrelase for child jails
         UPDATED_RELEASE="$(${bastille_releasesdir}/${TARGET}/bin/freebsd-version 2>/dev/null)"
         for jail in $(bastille list jails); do
-            if grep -qw "${bastille_jailsdir}/${jail}/root/.bastille" "${bastille_jailsdir}/${jail}/fstab"; then
+            if grep -qw "${release_dir} ${bastille_jailsdir}/${jail}/root/.bastille" "${bastille_jailsdir}/${jail}/fstab"; then
                 bastille config ${jail} set osrelease ${UPDATED_RELEASE} >/dev/null 2>/dev/null
             fi
         done


### PR DESCRIPTION
'bastille update' incorrectly updates the osrelease of any lightweight jail, regardless of which release jail it references in its fstab. Change the match regex to match the release jail dir as the device in the fstab entry to ensure only lightweight jails that explicitly derive from the updated release are given the new osrelease.